### PR TITLE
[Setting] #9 - provisioning profile 세팅 수정

### DIFF
--- a/SOPT-Stamp-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/SOPT-Stamp-iOS/Plugins/UtilityPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -57,14 +57,14 @@ public extension SettingsDictionary {
     }
     
     func setProvisioningDevelopment() -> SettingsDictionary {
-        merging(["PROVISIONING_PROFILE_SPECIFIER": SettingValue(stringLiteral: "SOPT iOS Debug")])
-            .merging(["PROVISIONING_PROFILE": SettingValue(stringLiteral: "SOPT Stamp iOS Debug")])
+        merging(["PROVISIONING_PROFILE_SPECIFIER": SettingValue(stringLiteral: "SOPTAMP Debug")])
+            .merging(["PROVISIONING_PROFILE": SettingValue(stringLiteral: "SOPTAMP Debug")])
     }
     
     func setProvisioningAppstore() -> SettingsDictionary {
-        merging(["PROVISIONING_PROFILE_SPECIFIER": SettingValue(stringLiteral: "SOPT iOS Release")])
+        merging(["PROVISIONING_PROFILE_SPECIFIER": SettingValue(stringLiteral: "SOPTAMP Release")])
             .merging(["CODE_SIGN_IDENTITY[sdk=iphoneos*]": SettingValue(stringLiteral: "iPhone Distribution")])
-            .merging(["PROVISIONING_PROFILE": SettingValue(stringLiteral: "SOPT Stamp iOS Release")])
+            .merging(["PROVISIONING_PROFILE": SettingValue(stringLiteral: "SOPTAMP Release")])
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- setting/#9-Signing

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
make regenerate하면, 처음에는 Signing(release) 부분에 경고가 뜨는데 
아래처럼 그냥 기존에 들어가있는 Ineligible이라 나오는 SOPTAMP Release를 다시 누르면 정상적으로 Distibution을 사용하는것 같습니다 
![ezgif com-gif-maker (88)](https://user-images.githubusercontent.com/81167570/203351637-90e3e064-e13f-45d8-90b4-70e131ced5ee.gif)

처음에 regenerate하면 release가 갖고 있는 distribution를 인식하고 정상적으로 되어야 되는 것 같은데, 지금 이 친구는 development를 먼저 찾는 것 같아요 
distribution이 들어가는 것이 정상이고, 알맞게 잘 들어가긴 하는 것 같으니까 일단 올려보겠습니다 .. 나중에 릴리즈할때 다시 한번 봐도 좋을 것 같어요 ..!


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #9 
