### PR TITLE
[Feat] #34 - KeyPathFindable Protocol 및 withUnretained Operator

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Extension/Combine+/Publisher+withUnretained.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Extension/Combine+/Publisher+withUnretained.swift
@@ -1,0 +1,21 @@
+//
+//  Publisher+withUnretained.swift
+//  Core
+//
+//  Created by Junho Lee on 2022/12/07.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+public extension Publisher {
+    func withUnretained<T: AnyObject>(_ object: T) -> Publishers.CompactMap<Self, (T, Self.Output)> {
+        compactMap { [weak object] output in
+            guard let object = object else {
+                return nil
+            }
+            return (object, output)
+        }
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Protocols/KeyPathFindable.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Protocols/KeyPathFindable.swift
@@ -1,0 +1,37 @@
+//
+//  KeyPathFindable.swift
+//  Core
+//
+//  Created by Junho Lee on 2022/12/07.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+@dynamicMemberLookup
+public struct KeyFinder<Base: AnyObject> {
+
+    private var base: Base
+
+    public init(_ base: Base) {
+        self.base = base
+    }
+
+    public subscript<Value>(dynamicMember keyPath: ReferenceWritableKeyPath<Base, Value>) -> ReferenceWritableKeyPath<Base, Value> {
+        return keyPath
+    }
+}
+
+public protocol KeyPathFindable {
+    associatedtype Base: AnyObject
+    var kf: KeyFinder<Base> { get }
+}
+
+public extension KeyPathFindable where Self: AnyObject {
+    var kf: KeyFinder<Self> {
+        get { KeyFinder(self) }
+        set { }
+    }
+}
+
+extension NSObject: KeyPathFindable { }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#34

## 🌱 PR Point
구현 시 편의를 제공하는 Util 코드들을 추가했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

### KeyPathFindable: keyPath를 자동완성으로 조회 가능
구현 방법 : [링크](https://jazz-the-it.tistory.com/71)에 기술했습니다!

```swift
        output.nicknameAlert
            .assign(to: nickNameTextFieldView.kf.alertText,
                    on: nickNameTextFieldView)
            .store(in: cancelBag)
```

### withUnreatined: retain cycle 방지를 위한 guard self문 생략 가능

```swift
        output.passwordAlert
            .withUnretained(self)
            .sink { event in
            print("event: \(event)")
        } receiveValue: { (weakself, alertText) in
            weakself.passwordCheckTextFieldView.changeAlertLabelText(alertText)
        }.store(in: cancelBag)
```

## 📮 관련 이슈
- Resolved: #34 
