### PR TITLE
[Feat] #43 - 회원가입 뷰 Domain, Data 구현

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -52,7 +52,7 @@ public struct I18N {
     public struct SignUp {
         public static let signUp = "회원가입"
         public static let nickname = "닉네임"
-        public static let nicknameTextFieldPlaceholder = "한글/영문 10자로 입력해주세요."
+        public static let nicknameTextFieldPlaceholder = "한글/영문 10자 이하로 입력해주세요."
         public static let email = "이메일"
         public static let emailTextFieldPlaceholder = "이메일을 입력해주세요."
         public static let password = "비밀번호"

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -52,7 +52,7 @@ public struct I18N {
     public struct SignUp {
         public static let signUp = "회원가입"
         public static let nickname = "닉네임"
-        public static let nicknameTextFieldPlaceholder = "한글/영문 NN자로 입력해주세요."
+        public static let nicknameTextFieldPlaceholder = "한글/영문 10자로 입력해주세요."
         public static let email = "이메일"
         public static let emailTextFieldPlaceholder = "이메일을 입력해주세요."
         public static let password = "비밀번호"

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
@@ -26,4 +26,8 @@ extension SignUpRepository: SignUpRepositoryInterface {
     public func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error> {
         return networkService.getNicknameAvailable(nickname: nickname)
     }
+    
+    public func getEmailAvailable(email: String) -> AnyPublisher<Int, Error> {
+        return networkService.getEmailAvailable(email: email)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
@@ -15,10 +15,12 @@ import Network
 public class SignUpRepository {
     
     private let networkService: AuthService
+    private let userService: UserService
     private let cancelBag = CancelBag()
     
-    public init(service: AuthService) {
+    public init(service: AuthService, userService: UserService) {
         self.networkService = service
+        self.userService = userService
     }
 }
 
@@ -29,5 +31,11 @@ extension SignUpRepository: SignUpRepositoryInterface {
     
     public func getEmailAvailable(email: String) -> AnyPublisher<Int, Error> {
         return networkService.getEmailAvailable(email: email)
+    }
+    
+    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error> {
+        return userService.postSignUp(signUpEntity: SignUpEntity(nickname: signUpModel.nickname,
+                                                          email: signUpModel.email,
+                                                          password: signUpModel.password))
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
@@ -8,13 +8,14 @@
 
 import Combine
 
+import Core
 import Domain
 import Network
 
 public class SignUpRepository {
     
     private let networkService: AuthService
-    private let cancelBag = Set<AnyCancellable>()
+    private let cancelBag = CancelBag()
     
     public init(service: AuthService) {
         self.networkService = service
@@ -22,5 +23,7 @@ public class SignUpRepository {
 }
 
 extension SignUpRepository: SignUpRepositoryInterface {
-    
+    public func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error> {
+        return networkService.getNicknameAvailable(nickname: nickname)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
@@ -37,8 +37,8 @@ extension SignUpRepository: SignUpRepositoryInterface {
         }.eraseToAnyPublisher()
     }
     
-    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Bool, Error> {
-        return userService.postSignUp(signUpModel: signUpModel).map { statusCode in
+    public func postSignUp(signUpRequest: SignUpModel) -> AnyPublisher<Bool, Error> {
+        return userService.postSignUp(nickname: signUpRequest.nickname, email: signUpRequest.email, password: signUpRequest.password).map { statusCode in
             statusCode == 200
         }.eraseToAnyPublisher()
     }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SignUpRepository.swift
@@ -25,17 +25,21 @@ public class SignUpRepository {
 }
 
 extension SignUpRepository: SignUpRepositoryInterface {
-    public func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error> {
-        return networkService.getNicknameAvailable(nickname: nickname)
+    public func getNicknameAvailable(nickname: String) -> AnyPublisher<Bool, Error> {
+        return networkService.getNicknameAvailable(nickname: nickname).map { statusCode in
+            statusCode == 200
+        }.eraseToAnyPublisher()
     }
     
-    public func getEmailAvailable(email: String) -> AnyPublisher<Int, Error> {
-        return networkService.getEmailAvailable(email: email)
+    public func getEmailAvailable(email: String) -> AnyPublisher<Bool, Error> {
+        return networkService.getEmailAvailable(email: email).map { statusCode in
+            statusCode == 200
+        }.eraseToAnyPublisher()
     }
     
-    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error> {
-        return userService.postSignUp(signUpEntity: SignUpEntity(nickname: signUpModel.nickname,
-                                                          email: signUpModel.email,
-                                                          password: signUpModel.password))
+    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Bool, Error> {
+        return userService.postSignUp(signUpModel: signUpModel).map { statusCode in
+            statusCode == 200
+        }.eraseToAnyPublisher()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/SignUpTransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/SignUpTransform.swift
@@ -14,6 +14,6 @@ import Network
 extension SignUpEntity {
 
     public func toDomain() -> SignUpModel {
-        return SignUpModel.init()
+        return SignUpModel.init(nickname: nickname, email: email, password: password)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/SignUpModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/SignUpModel.swift
@@ -10,7 +10,13 @@ import Foundation
 
 public struct SignUpModel {
 
-    public init() {
-        
+    public let nickname, email, password: String
+    public let osType = "iOS"
+    public let clientToken: String? = nil
+
+    public init(nickname: String, email: String, password: String) {
+        self.nickname = nickname
+        self.email = email
+        self.password = password
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -10,4 +10,5 @@ import Combine
 
 public protocol SignUpRepositoryInterface {
     func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
+    func getEmailAvailable(email: String) -> AnyPublisher<Int, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol SignUpRepositoryInterface {
-  
+    func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -9,7 +9,7 @@
 import Combine
 
 public protocol SignUpRepositoryInterface {
-    func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
-    func getEmailAvailable(email: String) -> AnyPublisher<Int, Error>
-    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error>
+    func getNicknameAvailable(nickname: String) -> AnyPublisher<Bool, Error>
+    func getEmailAvailable(email: String) -> AnyPublisher<Bool, Error>
+    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -11,5 +11,5 @@ import Combine
 public protocol SignUpRepositoryInterface {
     func getNicknameAvailable(nickname: String) -> AnyPublisher<Bool, Error>
     func getEmailAvailable(email: String) -> AnyPublisher<Bool, Error>
-    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Bool, Error>
+    func postSignUp(signUpRequest: SignUpModel) -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -11,4 +11,5 @@ import Combine
 public protocol SignUpRepositoryInterface {
     func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
     func getEmailAvailable(email: String) -> AnyPublisher<Int, Error>
+    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -46,17 +46,26 @@ extension DefaultSignUpUseCase: SignUpUseCase {
         repository.getNicknameAvailable(nickname: nickname)
             .map { statusCode in statusCode == 200 }
             .sink { event in
-                print("SignUpUseCase: \(event)")
+                print("SignUpUseCase nickname: \(event)")
             } receiveValue: { isValid in
-                print(isValid)
                 self.isNicknameValid.send(isValid)
             }.store(in: cancelBag)
     }
     
     public func checkEmail(email: String) {
         let isValid = checkEmailForm(email: email)
-        guard isValid else { return }
-        // 서버 통신
+        guard isValid else {
+            self.isEmailFormValid.send(isValid)
+            return
+        }
+        
+        repository.getEmailAvailable(email: email)
+            .map { statusCode in statusCode == 200 }
+            .sink { event in
+                print("SignUpUseCase email: \(event)")
+            } receiveValue: { isValid in
+                self.isEmailFormValid.send(isValid)
+            }.store(in: cancelBag)
     }
     
     public func checkPassword(password: String) {
@@ -90,7 +99,6 @@ extension DefaultSignUpUseCase {
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
         let isValid = emailTest.evaluate(with: email)
-        isEmailFormValid.send(isValid)
         return isValid
     }
     

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -16,7 +16,7 @@ public protocol SignUpUseCase {
     func checkEmail(email: String)
     func checkPassword(password: String)
     func checkAccordPassword(firstPassword: String, secondPassword: String)
-    func signUp(signUpModel: SignUpModel)
+    func signUp(signUpRequest: SignUpModel)
     
     var isNicknameValid: CurrentValueSubject<Bool, Error> { get set }
     var isEmailFormValid: CurrentValueSubject<Bool, Error> { get set }
@@ -77,8 +77,8 @@ extension DefaultSignUpUseCase: SignUpUseCase {
         checkAccordPasswordForm(firstPassword: firstPassword, secondPassword: secondPassword)
     }
     
-    public func signUp(signUpModel: SignUpModel) {
-        repository.postSignUp(signUpModel: signUpModel)
+    public func signUp(signUpRequest: SignUpModel) {
+        repository.postSignUp(signUpRequest: signUpRequest)
             .sink { event in
                 print("SignUpUseCase signUp: \(event)")
             } receiveValue: { isValid in

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -43,10 +43,14 @@ public class DefaultSignUpUseCase {
 
 extension DefaultSignUpUseCase: SignUpUseCase {
     public func checkNickname(nickname: String) {
-        // 닉네임 글자 수 정해지면 로직 추가
-        let isValid = checkNicknameForm(nickname: nickname)
-        guard isValid else { return }
-        // 서버 통신
+        repository.getNicknameAvailable(nickname: nickname)
+            .map { statusCode in statusCode == 200 }
+            .sink { event in
+                print("SignUpUseCase: \(event)")
+            } receiveValue: { isValid in
+                print(isValid)
+                self.isNicknameValid.send(isValid)
+            }.store(in: cancelBag)
     }
     
     public func checkEmail(email: String) {
@@ -80,11 +84,6 @@ extension DefaultSignUpUseCase {
         } receiveValue: { isValid in
             self.isValidForm.send(isValid)
         }.store(in: cancelBag)
-    }
-    
-    func checkNicknameForm(nickname: String) -> Bool {
-        isNicknameValid.send(true)
-        return true
     }
     
     func checkEmailForm(email: String) -> Bool {

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -47,7 +47,6 @@ public class DefaultSignUpUseCase {
 extension DefaultSignUpUseCase: SignUpUseCase {
     public func checkNickname(nickname: String) {
         repository.getNicknameAvailable(nickname: nickname)
-            .map { statusCode in statusCode == 200 }
             .sink { event in
                 print("SignUpUseCase nickname: \(event)")
             } receiveValue: { isValid in
@@ -63,7 +62,6 @@ extension DefaultSignUpUseCase: SignUpUseCase {
         }
         
         repository.getEmailAvailable(email: email)
-            .map { statusCode in statusCode == 200 }
             .sink { event in
                 print("SignUpUseCase email: \(event)")
             } receiveValue: { isValid in
@@ -81,7 +79,6 @@ extension DefaultSignUpUseCase: SignUpUseCase {
     
     public func signUp(signUpModel: SignUpModel) {
         repository.postSignUp(signUpModel: signUpModel)
-            .map { statusCode in statusCode == 200 }
             .sink { event in
                 print("SignUpUseCase signUp: \(event)")
             } receiveValue: { isValid in

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -16,12 +16,14 @@ public protocol SignUpUseCase {
     func checkEmail(email: String)
     func checkPassword(password: String)
     func checkAccordPassword(firstPassword: String, secondPassword: String)
+    func signUp(signUpModel: SignUpModel)
     
     var isNicknameValid: CurrentValueSubject<Bool, Error> { get set }
     var isEmailFormValid: CurrentValueSubject<Bool, Error> { get set }
     var isPasswordFormValid: CurrentValueSubject<Bool, Error> { get set }
     var isAccordPassword: CurrentValueSubject<Bool, Error> { get set }
     var isValidForm: CurrentValueSubject<Bool, Error> { get set }
+    var signUpSuccess: CurrentValueSubject<Bool, Error> { get set }
 }
 
 public class DefaultSignUpUseCase {
@@ -34,6 +36,7 @@ public class DefaultSignUpUseCase {
     public var isPasswordFormValid = CurrentValueSubject<Bool, Error>(false)
     public var isAccordPassword = CurrentValueSubject<Bool, Error>(false)
     public var isValidForm = CurrentValueSubject<Bool, Error>(false)
+    public var signUpSuccess = CurrentValueSubject<Bool, Error>(false)
     
     public init(repository: SignUpRepositoryInterface) {
         self.repository = repository
@@ -74,6 +77,16 @@ extension DefaultSignUpUseCase: SignUpUseCase {
     
     public func checkAccordPassword(firstPassword: String, secondPassword: String) {
         checkAccordPasswordForm(firstPassword: firstPassword, secondPassword: secondPassword)
+    }
+    
+    public func signUp(signUpModel: SignUpModel) {
+        repository.postSignUp(signUpModel: signUpModel)
+            .map { statusCode in statusCode == 200 }
+            .sink { event in
+                print("SignUpUseCase signUp: \(event)")
+            } receiveValue: { isValid in
+                self.signUpSuccess.send(isValid)
+            }.store(in: cancelBag)
     }
 }
 

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
@@ -142,6 +142,8 @@ public class CustomTextFieldView: UIView {
         }
     }
     
+    public var maxLength: Int?
+    
     /// alert Label을 다른 CustomTextField에 보여주기 위한 delegate
     weak var alertDelegate: CustomTextFieldViewAlertDelegate?
     
@@ -241,6 +243,12 @@ extension CustomTextFieldView {
         return self
     }
     
+    @discardableResult
+    public func setMaxLength(_ length: Int) -> Self {
+        self.maxLength = length
+        return self
+    }
+    
     /// alertText를 다른 TextField에 보여주기 위한 delegate 설정
     public func setAlertDelegate(_ textView: CustomTextFieldViewAlertDelegate) -> Self {
         self.alertDelegate = textView
@@ -281,6 +289,12 @@ extension CustomTextFieldView {
         textChanged
             .replaceNil(with: "")
             .sink { text in
+                if let maxLength = self.maxLength, text.count > maxLength {
+                    let index = text.index(text.startIndex, offsetBy: maxLength)
+                    let newString = text[text.startIndex..<index]
+                    self.textField.text = String(newString)
+                }
+                
                 self.rightButton.isEnabled = !text.isEmpty
                 if text.isEmpty {
                     self.changeAlertLabelText("")
@@ -464,6 +478,7 @@ extension CustomTextFieldView {
 // MARK: - UITextFieldDelegate
 
 extension CustomTextFieldView: UITextFieldDelegate {
+    
     public func textFieldDidBeginEditing(_ textField: UITextField) {
         self.setTextFieldViewState(.editing)
     }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
@@ -144,6 +144,10 @@ public class CustomTextFieldView: UIView {
     
     public var maxLength: Int?
     
+    public var text: String {
+        self.textField.text ?? ""
+    }
+    
     /// alert Label을 다른 CustomTextField에 보여주기 위한 delegate
     weak var alertDelegate: CustomTextFieldViewAlertDelegate?
     

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -12,7 +12,7 @@ import Alamofire
 import Moya
 
 public enum AuthAPI {
-    case sample(provider: String)
+    case getNicknameAvailable(nickname: String)
 }
 
 extension AuthAPI: BaseAPI {
@@ -22,7 +22,7 @@ extension AuthAPI: BaseAPI {
     // MARK: - Path
     public var path: String {
         switch self {
-        case .sample:
+        case .getNicknameAvailable:
             return ""
         }
     }
@@ -30,8 +30,8 @@ extension AuthAPI: BaseAPI {
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .sample:
-            return .post
+        case .getNicknameAvailable:
+            return .get
         }
     }
     
@@ -39,16 +39,16 @@ extension AuthAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .sample(let provider):
-            params["platform"] = provider
+        case .getNicknameAvailable(_):
+            break
         }
         return params
     }
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .sample:
-            return URLEncoding.init(destination: .queryString, arrayEncoding: .noBrackets, boolEncoding: .literal)
+        case .getNicknameAvailable:
+            return JSONEncoding.default
         default:
             return JSONEncoding.default
         }
@@ -56,8 +56,8 @@ extension AuthAPI: BaseAPI {
     
     public var task: Task {
         switch self {
-        case .sample:
-            return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
+        case .getNicknameAvailable(let nickname):
+            return .requestParameters(parameters: ["nickname": nickname], encoding: URLEncoding.queryString)
         default:
             return .requestPlain
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -13,6 +13,7 @@ import Moya
 
 public enum AuthAPI {
     case getNicknameAvailable(nickname: String)
+    case getEmailAvailable(email: String)
 }
 
 extension AuthAPI: BaseAPI {
@@ -24,6 +25,8 @@ extension AuthAPI: BaseAPI {
         switch self {
         case .getNicknameAvailable:
             return ""
+        case .getEmailAvailable:
+            return ""
         }
     }
     
@@ -32,6 +35,8 @@ extension AuthAPI: BaseAPI {
         switch self {
         case .getNicknameAvailable:
             return .get
+        case .getEmailAvailable:
+            return .get
         }
     }
     
@@ -39,7 +44,7 @@ extension AuthAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .getNicknameAvailable(_):
+        case .getNicknameAvailable, .getEmailAvailable:
             break
         }
         return params
@@ -47,8 +52,6 @@ extension AuthAPI: BaseAPI {
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .getNicknameAvailable:
-            return JSONEncoding.default
         default:
             return JSONEncoding.default
         }
@@ -58,6 +61,8 @@ extension AuthAPI: BaseAPI {
         switch self {
         case .getNicknameAvailable(let nickname):
             return .requestParameters(parameters: ["nickname": nickname], encoding: URLEncoding.queryString)
+        case .getEmailAvailable(let email):
+            return .requestParameters(parameters: ["email": email], encoding: URLEncoding.queryString)
         default:
             return .requestPlain
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -23,9 +23,7 @@ extension AuthAPI: BaseAPI {
     // MARK: - Path
     public var path: String {
         switch self {
-        case .getNicknameAvailable:
-            return ""
-        case .getEmailAvailable:
+        case .getNicknameAvailable, .getEmailAvailable:
             return ""
         }
     }
@@ -33,9 +31,7 @@ extension AuthAPI: BaseAPI {
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .getNicknameAvailable:
-            return .get
-        case .getEmailAvailable:
+        case .getNicknameAvailable, .getEmailAvailable:
             return .get
         }
     }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
@@ -12,25 +12,25 @@ import Alamofire
 import Moya
 
 public enum UserAPI {
-    case sample(provider: String)
+    case signUp(nickname: String, email: String, password: String)
 }
 
 extension UserAPI: BaseAPI {
     
-    public static var apiType: APIType = .auth
+    public static var apiType: APIType = .user
     
     // MARK: - Path
     public var path: String {
         switch self {
-        case .sample:
-            return ""
+        case .signUp:
+            return "signup"
         }
     }
     
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .sample:
+        case .signUp:
             return .post
         }
     }
@@ -39,16 +39,16 @@ extension UserAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .sample(let provider):
-            params["platform"] = provider
+        case .signUp(let nickname, let email, let password):
+            params["nickname"] = nickname
+            params["email"] = email
+            params["password"] = password
         }
         return params
     }
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .sample:
-            return URLEncoding.init(destination: .queryString, arrayEncoding: .noBrackets, boolEncoding: .literal)
         default:
             return JSONEncoding.default
         }
@@ -56,7 +56,7 @@ extension UserAPI: BaseAPI {
     
     public var task: Task {
         switch self {
-        case .sample:
+        case .signUp:
             return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/SignUpEntity.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/SignUpEntity.swift
@@ -9,5 +9,13 @@
 import Foundation
 
 public struct SignUpEntity {
+    public let nickname: String
+    public let email: String
+    public let password: String
     
+    public init(nickname: String, email: String, password: String) {
+        self.nickname = nickname
+        self.email = email
+        self.password = password
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Foundation/BaseAPI.swift
@@ -14,6 +14,7 @@ public enum APIType {
     case notice
     case auth
     case alert
+    case user
 }
 
 public protocol BaseAPI: TargetType {
@@ -26,11 +27,13 @@ extension BaseAPI {
         
         switch Self.apiType {
         case .alert:
-            base += "alert"
+            base += "/alert"
         case .notice:
-            base += "notice"
+            base += "/notice"
         case .auth:
-            base += "auth"
+            base += "/auth"
+        case .user:
+            base += "/user"
         }
         
         guard let url = URL(string: base) else {

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
@@ -15,9 +15,11 @@ import Moya
 public typealias DefaultAuthService = BaseService<AuthAPI>
 
 public protocol AuthService {
-    
+    func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultAuthService: AuthService {
-    
+    public func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error> {
+        return requestObjectInCombineNoResult(.getNicknameAvailable(nickname: nickname))
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
@@ -16,10 +16,15 @@ public typealias DefaultAuthService = BaseService<AuthAPI>
 
 public protocol AuthService {
     func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
+    func getEmailAvailable(email: String) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultAuthService: AuthService {
     public func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error> {
         return requestObjectInCombineNoResult(.getNicknameAvailable(nickname: nickname))
+    }
+    
+    public func getEmailAvailable(email: String) -> AnyPublisher<Int, Error> {
+        return requestObjectInCombineNoResult(.getEmailAvailable(email: email))
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
@@ -16,14 +16,14 @@ import Moya
 public typealias DefaultUserService = BaseService<UserAPI>
 
 public protocol UserService {
-    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error>
+    func postSignUp(nickname: String, email: String, password: String) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultUserService: UserService {
-    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error> {
-        requestObjectInCombineNoResult(.signUp(nickname: signUpModel.nickname,
-                                               email: signUpModel.email,
-                                               password: signUpModel.password)
+    public func postSignUp(nickname: String, email: String, password: String) -> AnyPublisher<Int, Error> {
+        requestObjectInCombineNoResult(.signUp(nickname: nickname,
+                                               email: email,
+                                               password: password)
         )
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
@@ -15,9 +15,14 @@ import Moya
 public typealias DefaultUserService = BaseService<UserAPI>
 
 public protocol UserService {
-    
+    func postSignUp(signUpEntity: SignUpEntity) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultUserService: UserService {
-    
+    public func postSignUp(signUpEntity: SignUpEntity) -> AnyPublisher<Int, Error> {
+        requestObjectInCombineNoResult(.signUp(nickname: signUpEntity.nickname,
+                                               email: signUpEntity.email,
+                                               password: signUpEntity.password)
+        )
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
@@ -10,19 +10,20 @@ import Foundation
 import Combine
 
 import Alamofire
+import Domain
 import Moya
 
 public typealias DefaultUserService = BaseService<UserAPI>
 
 public protocol UserService {
-    func postSignUp(signUpEntity: SignUpEntity) -> AnyPublisher<Int, Error>
+    func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultUserService: UserService {
-    public func postSignUp(signUpEntity: SignUpEntity) -> AnyPublisher<Int, Error> {
-        requestObjectInCombineNoResult(.signUp(nickname: signUpEntity.nickname,
-                                               email: signUpEntity.email,
-                                               password: signUpEntity.password)
+    public func postSignUp(signUpModel: SignUpModel) -> AnyPublisher<Int, Error> {
+        requestObjectInCombineNoResult(.signUp(nickname: signUpModel.nickname,
+                                               email: signUpModel.email,
+                                               password: signUpModel.password)
         )
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
@@ -45,6 +45,7 @@ public class SignUpVC: UIViewController {
     
     private let nickNameTextFieldView = CustomTextFieldView(type: .titleWithRightButton)
         .setTitle(I18N.SignUp.nickname)
+        .setMaxLength(10)
         .setPlaceholder(I18N.SignUp.nicknameTextFieldPlaceholder)
         .setAlertLabelEnabled(I18N.SignUp.duplicatedNickname)
     

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
@@ -13,6 +13,7 @@ import SnapKit
 import Then
 
 import Core
+import Domain
 import DSKit
 
 extension SignUpFormValidateResult {
@@ -88,7 +89,11 @@ extension SignUpVC {
     private func bindViewModels() {
         let registerButtonTapped = registerButton
             .publisher(for: .touchUpInside)
-            .map { _ in () }
+            .map { _ in
+                SignUpModel(nickname: self.nickNameTextFieldView.text,
+                            email: self.emailTextFieldView.text,
+                            password: self.passwordTextFieldView.text)
+            }
             .asDriver()
         
         let input = SignUpViewModel.Input(
@@ -127,6 +132,12 @@ extension SignUpVC {
         output.isValidForm
             .assign(to: \.isEnabled, on: registerButton)
             .store(in: cancelBag)
+        
+        output.signUpSuccessed
+            .sink { [weak self] isSuccess in
+                guard let self = self else { return }
+                isSuccess ? self.presentSignUpCompleteView() : print("회원가입 실패")
+            }.store(in: cancelBag)
     }
 }
 
@@ -235,5 +246,11 @@ extension SignUpVC {
         let contentInset = UIEdgeInsets.zero
         scrollView.contentInset = contentInset
         scrollView.scrollIndicatorInsets = contentInset
+    }
+    
+    private func presentSignUpCompleteView() {
+        let signUpCompleteVC = factory.makeSignUpCompleteVC()
+        signUpCompleteVC.modalPresentationStyle = .fullScreen
+        self.present(signUpCompleteVC, animated: true)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
@@ -82,8 +82,8 @@ extension SignUpViewModel {
             }.store(in: self.cancelBag)
         
         input.registerButtonTapped
-            .sink { signUpModel in
-                self.useCase.signUp(signUpModel: signUpModel)
+            .sink { signUpRequest in
+                self.useCase.signUp(signUpRequest: signUpRequest)
             }.store(in: self.cancelBag)
             
         return output

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
@@ -30,7 +30,7 @@ public class SignUpViewModel: ViewModelType {
         let emailCheckButtonTapped: Driver<String?>
         let passwordTextChanged: Driver<String?>
         let passwordCheckTextChanged: Driver<String?>
-        let registerButtonTapped: Driver<Void>
+        let registerButtonTapped: Driver<SignUpModel>
     }
     
     // MARK: - Outputs
@@ -41,6 +41,7 @@ public class SignUpViewModel: ViewModelType {
         var passwordAlert = PassthroughSubject<SignUpFormValidateResult, Never>()
         var passwordAccordAlert = PassthroughSubject<SignUpFormValidateResult, Never>()
         var isValidForm = PassthroughSubject<Bool, Never>()
+        var signUpSuccessed = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - init
@@ -79,6 +80,11 @@ extension SignUpViewModel {
             .sink { (firstPassword, secondPassword) in
                 self.useCase.checkAccordPassword(firstPassword: firstPassword, secondPassword: secondPassword)
             }.store(in: self.cancelBag)
+        
+        input.registerButtonTapped
+            .sink { signUpModel in
+                self.useCase.signUp(signUpModel: signUpModel)
+            }.store(in: self.cancelBag)
             
         return output
     }
@@ -116,6 +122,12 @@ extension SignUpViewModel {
             print("SignUpViewModel - completion: \(event)")
         } receiveValue: { isValidForm in
             output.isValidForm.send(isValidForm)
+        }.store(in: cancelBag)
+        
+        useCase.signUpSuccess.sink { event in
+            print("SignUpViewModel - completion: \(event)")
+        } receiveValue: { isSuccess in
+            output.signUpSuccessed.send(isSuccess)
         }.store(in: cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootVC = ModuleFactory.shared.makeMissionListVC(sceneType: .default)
+        let rootVC = ModuleFactory.shared.makeSignUpVC()
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()
     }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -49,7 +49,7 @@ extension ModuleFactory: ModuleFactoryInterface {
     }
     
     public func makeSignUpVC() -> Presentation.SignUpVC {
-        let repository = SignUpRepository(service: authService)
+        let repository = SignUpRepository(service: authService, userService: userService)
         let useCase = DefaultSignUpUseCase(repository: repository)
         let viewModel = SignUpViewModel(useCase: useCase)
         let signUpVC = SignUpVC()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#43

## 🌱 PR Point
- 회원가입 뷰 Domain, Data 레이어 구현했습니다.
- network 부분 연결하여 정상적으로 작동하는 것을 확인했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- SignUpRepository에서 2 종류의 service가 필요해서 추가로 생성하고 모듈팰토리에서 주입했습니다.
- 통신 후 받아오는 response가 없어서 requestObjectInCombineNoResult 사용했습니다.
- 모델과 엔티티는 request를 위해 만들었습니다.
- 현재 아키택쳐로 목데이터가 아니라 실제 서버 연결까지 해본 것은 처음이라 이 방식이 맞는지 확인 부탁드립니다..!
- 서버 통신할 때 로딩 뷰 같은 게 없어서 조금 어색한 느낌이 있습니다... 에러 처리도 없어서 나중에 다듬는 과정이 필요할 것 같아요!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|회원가입 뷰 서버 통신|![Simulator Screen Recording - iPhone 13 mini - 2022-12-20 at 18 47 00](https://user-images.githubusercontent.com/77267404/208636203-9e48441e-e5c7-454c-aba7-56bef954c47f.gif)|

## 📮 관련 이슈
- Resolved: #43 
