### PR TITLE
[Feat] #54 - 랭킹 리스트 뷰 비즈니스 로직 구현

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
@@ -23,5 +23,9 @@ public class RankingRepository {
 }
 
 extension RankingRepository: RankingRepositoryInterface {
-    
+    public func fetchRankingListModel() -> AnyPublisher<[Domain.RankingModel], Error> {
+        return Future<[RankingModel], Error> { promise in
+            promise(.success([RankingModel.init(username: "1등이다", usreId: 1, score: 94, sentence: "제가 1등입니다"), RankingModel.init(username: "헬로", usreId: 2, score: 92, sentence: "2등"), RankingModel.init(username: "이름이 긴 사람", usreId: 3, score: 91, sentence: "제가 3등입니다 말이 길어지면 어케"), RankingModel.init(username: "더미데이름", usreId: 4, score: 86, sentence: "4444"), RankingModel.init(username: "레포지토리", usreId: 5, score: 65, sentence: "5"), RankingModel.init(username: "인터페이스", usreId: 6, score: 53, sentence: "ㅎㄴ마ㄷ한마디"), RankingModel.init(username: "솝트", usreId: 7, score: 53, sentence: "하남ㄴㅁㅇㄹㅁㅋㅌㅊㅍ"), RankingModel.init(username: "노가다", usreId: 8, score: 52, sentence: "한마디 띄우기"), RankingModel.init(username: "9등이다", usreId: 9, score: 40, sentence: "한마디 최고글자길이는몇일까여?"), RankingModel.init(username: "10등이다", usreId: 10, score: 35, sentence: "5166"), RankingModel.init(username: "11등이다", usreId: 11, score: 32, sentence: "더메대충이데머"), RankingModel.init(username: "12등이다", usreId: 12, score: 12, sentence: "대충 더미데잍"), RankingModel.init(username: "안녕하세요", usreId: 13, score: 7, sentence: "531542642"), RankingModel.init(username: "14등이다", usreId: 14, score: 5, sentence: "한마디 귀찮아"), RankingModel.init(username: "15등이다", usreId: 15, score: 3, sentence: "")]))
+        }.eraseToAnyPublisher()
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
@@ -13,7 +13,7 @@ import Network
 
 extension RankingEntity {
     
-    public func toDomain() -> RankingModel {
-        return RankingModel.init()
-    }
+//    public func toDomain() -> RankingModel {
+//        return RankingModel.init()
+//    }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/RankingModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/RankingModel.swift
@@ -8,9 +8,24 @@
 
 import Foundation
 
-public struct RankingModel {
+public struct RankingModel: Hashable {
+    public let username: String
+    public let usreId: Int
+    public let score: Int
+    public let sentence: String
+    
+    public init(username: String, usreId: Int, score: Int, sentence: String) {
+        self.username = username
+        self.usreId = usreId
+        self.score = score
+        self.sentence = sentence
+    }
+}
 
-    public init() {
-        
+public struct RankingChartModel: Hashable {
+    public let ranking: [RankingModel]
+    
+    public init(ranking: [RankingModel]) {
+        self.ranking = ranking
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/RankingModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/RankingModel.swift
@@ -10,13 +10,13 @@ import Foundation
 
 public struct RankingModel: Hashable {
     public let username: String
-    public let usreId: Int
+    public let userId: Int
     public let score: Int
     public let sentence: String
     
     public init(username: String, usreId: Int, score: Int, sentence: String) {
         self.username = username
-        self.usreId = usreId
+        self.userId = usreId
         self.score = score
         self.sentence = sentence
     }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/RankingRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/RankingRepositoryInterface.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol RankingRepositoryInterface {
-  
+    func fetchRankingListModel() -> AnyPublisher<[RankingModel], Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/ChartRectangleView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/ChartRectangleView.swift
@@ -174,7 +174,16 @@ extension ChartRectangleView {
 }
 
 extension ChartRectangleView {
-    static func ==(left: ChartRectangleView, right: ChartRectangleView) -> Bool {
+    public func setData(score: Int, username: String) {
+        self.usernameLabel.text = username
+        self.scoreLabel.text = "\(score)점"
+        self.scoreLabel.partFontChange(targetString: "점",
+                                       font: DSKitFontFamily.Pretendard.medium.font(size: 12))
+    }
+}
+
+extension ChartRectangleView {
+    static func == (left: ChartRectangleView, right: ChartRectangleView) -> Bool {
         return left.viewLevel == right.viewLevel
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/SpeechBalloonView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/SpeechBalloonView.swift
@@ -83,10 +83,15 @@ extension SpeechBalloonView {
             make.top.equalToSuperview()
             
             let standardSize = calculateLabelSize(sentence: sentence)
-            if standardSize < 108.adjusted {
-                make.width.equalTo(108.adjusted + 20)
+            let smallBalloonMinimumWidth: CGFloat = 108
+            let smallBalloonCompensates: CGFloat = 10
+            let smallBalloonWidth = smallBalloonMinimumWidth - smallBalloonCompensates
+            let largeBalloonCompensates: CGFloat = 30 * standardSize / 266.adjusted
+            
+            if standardSize < smallBalloonWidth.adjusted {
+                make.width.equalTo(smallBalloonWidth.adjusted + smallBalloonCompensates)
             } else if standardSize < 266.adjusted {
-                make.width.equalTo(standardSize + 40)
+                make.width.equalTo(standardSize + largeBalloonCompensates)
             } else {
                 make.width.lessThanOrEqualToSuperview()
                 sentenceLabel.lineBreakMode = .byTruncatingTail
@@ -121,9 +126,9 @@ extension SpeechBalloonView {
     private func calculateLabelSize(sentence: String) -> CGFloat {
         let tempLabel = BalloonPaddingLabel()
         tempLabel.text = sentence
-        tempLabel.sizeToFit()
         tempLabel.setTypoStyle(.subtitle3)
-        return tempLabel.frame.width
+        tempLabel.sizeToFit()
+        return tempLabel.intrinsicContentSize.width
     }
 }
 

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
@@ -147,3 +147,9 @@ extension RankingChartCVC {
         }
     }
 }
+
+extension RankingChartCVC: RankingListTappble {
+    func getModelItem() -> RankingListTapItem? {
+        return RankingListTapItem.init(username: "유저", sentence: "한마디", userId: 1)
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
@@ -102,8 +102,17 @@ extension RankingChartCVC {
     
     public func setData(model: RankingChartModel) {
         
-        let sentences = model.ranking.map { $0.sentence }
+        // 데이터 바인딩을 위한 모델 순서 재정렬
+        let arrangedModel = [model.ranking[1], model.ranking[0], model.ranking[2]]
+        let sentences = arrangedModel.map { $0.sentence }
         
+        self.setSpeechBalloonViews(sentences: sentences)
+        self.setChartData(chartRectangleModel: arrangedModel)
+    }
+    
+    private func setSpeechBalloonViews(sentences: [String]) {
+        
+        // 말풍선 text 설정
         for (index, sentence) in sentences.enumerated() {
             var baloonView: SpeechBalloonView
             if index == 0 {
@@ -127,6 +136,14 @@ extension RankingChartCVC {
                 make.width.equalToSuperview()
                 make.centerX.equalToSuperview()
             }
+        }
+    }
+    
+    private func setChartData(chartRectangleModel: [RankingModel]) {
+        for (index, rectangle) in chartStackView.subviews.enumerated() {
+            guard let chartRectangle = rectangle as? ChartRectangleView else { return }
+            chartRectangle.setData(score: chartRectangleModel[index].score,
+                                   username: chartRectangleModel[index].username)
         }
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingChartCVC.swift
@@ -100,9 +100,11 @@ extension RankingChartCVC {
         baloonViews.removeAll()
     }
     
-    public func setData(model: String) {
+    public func setData(model: RankingChartModel) {
         
-        for (index, sentence) in ["안녕하세요", "제가 일등일 수도 있습니다 하하", "그래"].enumerated() {
+        let sentences = model.ranking.map { $0.sentence }
+        
+        for (index, sentence) in sentences.enumerated() {
             var baloonView: SpeechBalloonView
             if index == 0 {
                 baloonView = SpeechBalloonView.init(level: .rankTwo, sentence: sentence)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
@@ -116,7 +116,12 @@ extension RankingListCVC {
 
 extension RankingListCVC {
     
-    public func setData(model: String) {
-        
+    public func setData(model: RankingModel, rank: Int) {
+        rankLabel.text = String(rank)
+        usernameLabel.text = model.username
+        sentenceLabel.text = model.sentence
+        scoreLabel.text = "\(model.score)점"
+        scoreLabel.partFontChange(targetString: "점",
+                                  font: DSKitFontFamily.Pretendard.medium.font(size: 12))
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
@@ -21,6 +21,8 @@ final class RankingListCVC: UICollectionViewCell, UICollectionViewRegisterable {
     
     static var isFromNib: Bool = false
     
+    private var model: RankingModel?
+    
     // MARK: - UI Components
     
     private let rankLabel: UILabel = {
@@ -117,11 +119,21 @@ extension RankingListCVC {
 extension RankingListCVC {
     
     public func setData(model: RankingModel, rank: Int) {
+        self.model = model
         rankLabel.text = String(rank)
         usernameLabel.text = model.username
         sentenceLabel.text = model.sentence
         scoreLabel.text = "\(model.score)점"
         scoreLabel.partFontChange(targetString: "점",
                                   font: DSKitFontFamily.Pretendard.medium.font(size: 12))
+    }
+}
+
+extension RankingListCVC: RankingListTappble {
+    func getModelItem() -> RankingListTapItem? {
+        guard let model = model else { return nil }
+        return RankingListTapItem.init(username: model.username,
+                                       sentence: model.sentence,
+                                       userId: model.userId)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListTappable.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListTappable.swift
@@ -1,0 +1,19 @@
+//
+//  RankingListTappable.swift
+//  Presentation
+//
+//  Created by Junho Lee on 2022/12/22.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+protocol RankingListTappble {
+    func getModelItem() -> RankingListTapItem?
+}
+
+public struct RankingListTapItem {
+    public let username: String
+    public let sentence: String
+    public let userId: Int
+}

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -152,14 +152,15 @@ extension RankingVC {
 
 extension RankingVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-//        guard let tappedCell = collectionView.cellForItem(at: indexPath) as? MissionListCVC,
-//              let model = tappedCell.model,
-//              let starLevel = StarViewLevel.init(rawValue: model.level)else { return }
-//        let sceneType = model.toListDetailSceneType()
-        
-        let otherUserMissionListVC = factory.makeMissionListVC(sceneType: .ranking(userName: "유저",
-                                                                                   sentence: "한마디입니다",
-                                                                                   userId: 2))
+        guard let tappedCell = collectionView.cellForItem(at: indexPath) as? RankingListTappble,
+              let item = tappedCell.getModelItem() else { return }
+        self.pushToOtherUserMissionListVC(item: item)
+    }
+    
+    private func pushToOtherUserMissionListVC(item: RankingListTapItem) {
+        let otherUserMissionListVC = factory.makeMissionListVC(sceneType: .ranking(userName: item.username,
+                                                                                   sentence: item.sentence,
+                                                                                   userId: item.userId))
         self.navigationController?.pushViewController(otherUserMissionListVC, animated: true)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -89,8 +89,16 @@ extension RankingVC {
 extension RankingVC {
     
     private func bindViewModels() {
-        let input = RankingViewModel.Input()
+        let input = RankingViewModel.Input(viewDidLoad: Driver.just(()))
+        
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.$rankingListModel
+            .dropFirst()
+            .withUnretained(self)
+            .sink { owner, model in
+                owner.applySnapshot(model: model)
+            }.store(in: self.cancelBag)
     }
     
     private func setDelegate() {
@@ -115,7 +123,7 @@ extension RankingVC {
             case .list:
                 guard let rankingListCell = collectionView.dequeueReusableCell(withReuseIdentifier: RankingListCVC.className, for: indexPath) as? RankingListCVC,
                       let rankingListCellModel = itemIdentifier as? RankingModel else { return UICollectionViewCell() }
-                rankingListCell.setData(model: rankingListCellModel, rank: indexPath.row + 1)
+                rankingListCell.setData(model: rankingListCellModel, rank: indexPath.row + 1 + 3)
                 
                 return rankingListCell
             }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/ViewModel/RankingViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/ViewModel/RankingViewModel.swift
@@ -20,6 +20,7 @@ public class RankingViewModel: ViewModelType {
     
     public struct Input {
         let viewDidLoad: Driver<Void>
+        let refreshStarted: Driver<Void>
     }
     
     // MARK: - Outputs
@@ -40,7 +41,7 @@ extension RankingViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
-        input.viewDidLoad
+        input.viewDidLoad.merge(with: input.refreshStarted)
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.fetchRankingList()

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/ViewModel/RankingViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/ViewModel/RankingViewModel.swift
@@ -12,24 +12,24 @@ import Core
 import Domain
 
 public class RankingViewModel: ViewModelType {
-
+    
     private let useCase: RankingUseCase
     private var cancelBag = CancelBag()
-  
+    
     // MARK: - Inputs
     
     public struct Input {
-    
+        let viewDidLoad: Driver<Void>
     }
     
     // MARK: - Outputs
     
-    public struct Output {
-    
+    public class Output {
+        @Published var rankingListModel = [RankingModel]()
     }
     
     // MARK: - init
-  
+    
     public init(useCase: RankingUseCase) {
         self.useCase = useCase
     }
@@ -39,12 +39,23 @@ extension RankingViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
-        // input,output 상관관계 작성
-    
+        
+        input.viewDidLoad
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.useCase.fetchRankingList()
+            }.store(in: self.cancelBag)
+        
         return output
     }
-  
-    private func bindOutput(output: Output, cancelBag: CancelBag) {
     
+    private func bindOutput(output: Output, cancelBag: CancelBag) {
+        let fetchedRankingList = self.useCase.rankingListModelFetched
+        
+        fetchedRankingList.asDriver()
+            .sink(receiveValue: { model in
+                output.rankingListModel = model
+            })
+            .store(in: self.cancelBag)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#54

## 🌱 PR Point

랭킹 리스트 뷰의 비즈니스 로직 구현했습니다. Service는 아직 서버가 구현되지 않아 더미데이터를 보내고 있습니다.

랭킹 미션 리스트 뷰로의 화면전환 로직을 구현했습니다.

추후 말풍선 디자인 변경되면 1, 2, 3위의 화면전환 로직도 구현하겠습니다.

## 📮 관련 이슈
- Resolved: #54 
