### PR TITLE
[Feat] #57 - 비밀번호 변경 뷰 구현

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -94,5 +94,7 @@ public struct I18N {
         public static let resetMission = "미션 초기화"
         public static let logout = "로그아웃"
         public static let withdraw = "탈퇴하기"
+        public static let passwordEditSuccess = "비밀번호가 변경되었습니다."
+        public static let passwordEditFail = "비밀번호 변경 실패"
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -84,7 +84,7 @@ public struct I18N {
         public static let setting = "설정"
         public static let myinfo = "내 정보"
         public static let bioEdit = "한 마디 편집"
-        public static let passwordEdit = "비밀번호 편집"
+        public static let passwordEdit = "비밀번호 변경"
         public static let nicknameEdit = "닉네임 변경"
         public static let serviceUsagePolicy = "서비스 이용방침"
         public static let personalInfoPolicy = "개인정보처리방침"

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
@@ -27,5 +27,8 @@ extension SettingRepository: SettingRepositoryInterface {
 }
 
 extension SettingRepository: PasswordChangeRepositoryInterface {
-    
+    public func changePassword(password: String) -> AnyPublisher<Bool, Error> {
+        networkService.changePassword(password: password, userId: 12).map { statusCode in statusCode == 200 }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
@@ -14,10 +14,10 @@ import Network
 
 public class SettingRepository {
     
-    private let networkService: UserService
+    private let networkService: AuthService
     private let cancelBag = CancelBag()
     
-    public init(service: UserService) {
+    public init(service: AuthService) {
         self.networkService = service
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
@@ -25,3 +25,7 @@ public class SettingRepository {
 extension SettingRepository: SettingRepositoryInterface {
     
 }
+
+extension SettingRepository: PasswordChangeRepositoryInterface {
+    
+}

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/PasswordSettingTransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/PasswordSettingTransform.swift
@@ -1,0 +1,19 @@
+//
+//  PasswordSettingTransform.swift
+//  Data
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Network
+
+extension PasswordChangeEntity {
+
+    public func toDomain() -> PasswordChangeModel {
+        return PasswordChangeModel.init()
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/PasswordChangeModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/PasswordChangeModel.swift
@@ -1,0 +1,16 @@
+//
+//  PasswordChangeModel.swift
+//  Domain
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct PasswordChangeModel {
+
+    public init() {
+        
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/PasswordChangeRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/PasswordChangeRepositoryInterface.swift
@@ -1,0 +1,13 @@
+//
+//  PasswordChangeRepositoryInterface.swift
+//  Domain
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Combine
+
+public protocol PasswordChangeRepositoryInterface {
+  
+}

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/PasswordChangeRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/PasswordChangeRepositoryInterface.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol PasswordChangeRepositoryInterface {
-  
+    func changePassword(password: String) -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
@@ -6,22 +6,76 @@
 //  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
 //
 
+import Foundation
 import Combine
 
-public protocol PasswordChangeUseCase {
+import Core
 
+public protocol PasswordChangeUseCase {
+    func checkPassword(password: String)
+    func checkAccordPassword(firstPassword: String, secondPassword: String)
+    func changePassword(password: String)
+    
+    var isPasswordFormValid: CurrentValueSubject<Bool, Error> { get set }
+    var isAccordPassword: CurrentValueSubject<Bool, Error> { get set }
+    var isValidForm: CurrentValueSubject<Bool, Error> { get set }
+    var passwordChangeSuccess: CurrentValueSubject<Bool, Error> { get set }
 }
 
 public class DefaultPasswordChangeUseCase {
-  
+    
     private let repository: PasswordChangeRepositoryInterface
-    private var cancelBag = Set<AnyCancellable>()
-  
+    private var cancelBag = CancelBag()
+    
+    public var isPasswordFormValid = CurrentValueSubject<Bool, Error>(false)
+    public var isAccordPassword = CurrentValueSubject<Bool, Error>(false)
+    public var isValidForm = CurrentValueSubject<Bool, Error>(false)
+    public var passwordChangeSuccess = CurrentValueSubject<Bool, Error>(false)
+
     public init(repository: PasswordChangeRepositoryInterface) {
         self.repository = repository
+        self.bindFormValid()
     }
 }
 
 extension DefaultPasswordChangeUseCase: PasswordChangeUseCase {
-  
+    public func checkPassword(password: String) {
+        checkPasswordForm(password: password)
+    }
+    
+    public func checkAccordPassword(firstPassword: String, secondPassword: String) {
+        checkAccordPasswordForm(firstPassword: firstPassword, secondPassword: secondPassword)
+    }
+    
+    public func changePassword(password: String) {
+        // repository 연결
+    }
+}
+
+// MARK: - Methods
+
+extension DefaultPasswordChangeUseCase {
+    func bindFormValid() {
+        isPasswordFormValid.combineLatest(isAccordPassword)
+        .map { (isPasswordValid, isAccordPassword) in
+            (isPasswordValid && isAccordPassword)
+        }
+        .sink { event in
+            print("PasswordChangeUseCase - completion: \(event)")
+        } receiveValue: { isValid in
+            self.isValidForm.send(isValid)
+        }.store(in: cancelBag)
+    }
+    
+    func checkPasswordForm(password: String) {
+        let passwordRegEx = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*()_+=-]).{8,15}" // 8자리 ~ 15자리 영어+숫자+특수문자
+        let passwordTest = NSPredicate(format: "SELF MATCHES %@", passwordRegEx)
+        let isValid = passwordTest.evaluate(with: password)
+        isPasswordFormValid.send(isValid)
+    }
+    
+    func checkAccordPasswordForm(firstPassword: String, secondPassword: String) {
+        let isValid = (firstPassword == secondPassword)
+        isAccordPassword.send(isValid)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  PasswordChangeUseCase.swift
+//  Domain
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Combine
+
+public protocol PasswordChangeUseCase {
+
+}
+
+public class DefaultPasswordChangeUseCase {
+  
+    private let repository: PasswordChangeRepositoryInterface
+    private var cancelBag = Set<AnyCancellable>()
+  
+    public init(repository: PasswordChangeRepositoryInterface) {
+        self.repository = repository
+    }
+}
+
+extension DefaultPasswordChangeUseCase: PasswordChangeUseCase {
+  
+}

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/PasswordChangeUseCase.swift
@@ -48,7 +48,12 @@ extension DefaultPasswordChangeUseCase: PasswordChangeUseCase {
     }
     
     public func changePassword(password: String) {
-        // repository 연결
+        repository.changePassword(password: password)
+            .sink { event in
+                print("PasswordChangeUseCase: \(event)")
+            } receiveValue: { isSuccess in
+                self.passwordChangeSuccess.send(isSuccess)
+            }.store(in: cancelBag)
     }
 }
 

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
@@ -5,7 +5,6 @@
 //  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
 //
 
-
 import UIKit
 
 import SnapKit
@@ -17,7 +16,7 @@ public extension UIViewController {
 }
 
 public class Toast {
-    static func show(message: String, controller: UIViewController) {
+    public static func show(message: String, controller: UIViewController) {
         
         let toastContainer = UIView()
         let toastLabel = UILabel()
@@ -42,6 +41,50 @@ public class Toast {
         toastContainer.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(controller.safeAreaBottomInset()).inset(40)
+            $0.width.equalTo(213)
+            $0.height.equalTo(44)
+        }
+        
+        toastLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        UIView.animate(withDuration: 0.4, delay: 0.0, options: .curveEaseIn, animations: {
+            toastContainer.alpha = 1.0
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.4, delay: 1.0, options: .curveEaseOut, animations: {
+                toastContainer.alpha = 0.0
+            }, completion: {_ in
+                toastContainer.removeFromSuperview()
+            })
+        })
+    }
+    
+    public static func showInView(message: String, view: UIView) {
+        
+        let toastContainer = UIView()
+        let toastLabel = UILabel()
+        
+        toastContainer.backgroundColor = DSKitAsset.Colors.gray600.color
+        toastContainer.alpha = 1
+        toastContainer.layer.cornerRadius = 9
+        toastContainer.clipsToBounds = true
+        toastContainer.isUserInteractionEnabled = false
+        
+        toastLabel.textColor = .white
+        toastLabel.textAlignment = .center
+        toastLabel.setTypoStyle(.caption1)
+        toastLabel.text = message
+        toastLabel.clipsToBounds = true
+        toastLabel.numberOfLines = 0
+        toastLabel.sizeToFit()
+        
+        toastContainer.addSubview(toastLabel)
+        view.addSubview(toastContainer)
+        
+        toastContainer.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(40)
             $0.width.equalTo(213)
             $0.height.equalTo(44)
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
@@ -11,56 +11,12 @@ import SnapKit
 
 public extension UIViewController {
     func showToast(message: String) {
-        Toast.show(message: message, controller: self)
+        Toast.show(message: message, view: self.view, safeAreaBottomInset: self.safeAreaBottomInset())
     }
 }
 
 public class Toast {
-    public static func show(message: String, controller: UIViewController) {
-        
-        let toastContainer = UIView()
-        let toastLabel = UILabel()
-        
-        toastContainer.backgroundColor = DSKitAsset.Colors.gray600.color
-        toastContainer.alpha = 1
-        toastContainer.layer.cornerRadius = 9
-        toastContainer.clipsToBounds = true
-        toastContainer.isUserInteractionEnabled = false
-        
-        toastLabel.textColor = .white
-        toastLabel.textAlignment = .center
-        toastLabel.setTypoStyle(.caption1)
-        toastLabel.text = message
-        toastLabel.clipsToBounds = true
-        toastLabel.numberOfLines = 0
-        toastLabel.sizeToFit()
-        
-        toastContainer.addSubview(toastLabel)
-        controller.view.addSubview(toastContainer)
-        
-        toastContainer.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(controller.safeAreaBottomInset()).inset(40)
-            $0.width.equalTo(213)
-            $0.height.equalTo(44)
-        }
-        
-        toastLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-        
-        UIView.animate(withDuration: 0.4, delay: 0.0, options: .curveEaseIn, animations: {
-            toastContainer.alpha = 1.0
-        }, completion: { _ in
-            UIView.animate(withDuration: 0.4, delay: 1.0, options: .curveEaseOut, animations: {
-                toastContainer.alpha = 0.0
-            }, completion: {_ in
-                toastContainer.removeFromSuperview()
-            })
-        })
-    }
-    
-    public static func showInView(message: String, view: UIView) {
+    public static func show(message: String, view: UIView, safeAreaBottomInset: CGFloat = 0) {
         
         let toastContainer = UIView()
         let toastLabel = UILabel()
@@ -84,7 +40,7 @@ public class Toast {
         
         toastContainer.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(40)
+            $0.bottom.equalToSuperview().inset(safeAreaBottomInset+40)
             $0.width.equalTo(213)
             $0.height.equalTo(44)
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -14,17 +14,29 @@ import Moya
 public enum AuthAPI {
     case getNicknameAvailable(nickname: String)
     case getEmailAvailable(email: String)
+    case changePassword(password: String, userId: Int)
 }
 
 extension AuthAPI: BaseAPI {
     
     public static var apiType: APIType = .auth
     
+    // MARK: - Header
+    public var headers: [String: String]? {
+        switch self {
+        case .changePassword(_, let userId):
+            return HeaderType.userId(userId: userId).value
+        default: return HeaderType.json.value
+        }
+    }
+    
     // MARK: - Path
     public var path: String {
         switch self {
         case .getNicknameAvailable, .getEmailAvailable:
             return ""
+        case .changePassword:
+            return "password"
         }
     }
     
@@ -33,6 +45,8 @@ extension AuthAPI: BaseAPI {
         switch self {
         case .getNicknameAvailable, .getEmailAvailable:
             return .get
+        case .changePassword:
+            return .put
         }
     }
     
@@ -42,6 +56,8 @@ extension AuthAPI: BaseAPI {
         switch self {
         case .getNicknameAvailable, .getEmailAvailable:
             break
+        case .changePassword(let password, _):
+            params["password"] = password
         }
         return params
     }
@@ -59,6 +75,8 @@ extension AuthAPI: BaseAPI {
             return .requestParameters(parameters: ["nickname": nickname], encoding: URLEncoding.queryString)
         case .getEmailAvailable(let email):
             return .requestParameters(parameters: ["email": email], encoding: URLEncoding.queryString)
+        case .changePassword:
+            return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/PasswordChangeEntity.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/PasswordChangeEntity.swift
@@ -1,0 +1,13 @@
+//
+//  PasswordChangeEntity.swift
+//  Network
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct PasswordChangeEntity {
+    
+}

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/AuthService.swift
@@ -17,6 +17,7 @@ public typealias DefaultAuthService = BaseService<AuthAPI>
 public protocol AuthService {
     func getNicknameAvailable(nickname: String) -> AnyPublisher<Int, Error>
     func getEmailAvailable(email: String) -> AnyPublisher<Int, Error>
+    func changePassword(password: String, userId: Int) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultAuthService: AuthService {
@@ -26,5 +27,9 @@ extension DefaultAuthService: AuthService {
     
     public func getEmailAvailable(email: String) -> AnyPublisher<Int, Error> {
         return requestObjectInCombineNoResult(.getEmailAvailable(email: email))
+    }
+    
+    public func changePassword(password: String, userId: Int) -> AnyPublisher<Int, Error> {
+        return requestObjectInCombineNoResult(.changePassword(password: password, userId: userId))
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
@@ -22,4 +22,5 @@ public protocol ModuleFactoryInterface {
     func makeAlertVC(title: String, customButtonTitle: String) -> AlertVC
     func makeRankingVC() -> RankingVC
     func makeSettingVC() -> SettingVC
+    func makePasswordChangeVC() -> PasswordChangeVC
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/PasswordChangeVC.swift
@@ -1,0 +1,43 @@
+//
+//  PasswordChangeVC.swift
+//  Presentation
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Combine
+
+import Core
+import SnapKit
+import Then
+
+public class PasswordChangeVC: UIViewController {
+    
+    // MARK: - Properties
+    
+    public var viewModel: PasswordChangeViewModel!
+    private var cancelBag = CancelBag()
+  
+    // MARK: - UI Components
+  
+    // MARK: - View Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        self.bindViewModels()
+    }
+}
+
+// MARK: - Methods
+
+extension PasswordChangeVC {
+  
+    private func bindViewModels() {
+        let input = PasswordChangeViewModel.Input()
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+    }
+
+}

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/PasswordChangeVC.swift
@@ -9,25 +9,48 @@
 import UIKit
 
 import Combine
-
-import Core
 import SnapKit
 import Then
+
+import Core
+import Domain
+import DSKit
 
 public class PasswordChangeVC: UIViewController {
     
     // MARK: - Properties
     
+    public var factory: ModuleFactoryInterface!
     public var viewModel: PasswordChangeViewModel!
     private var cancelBag = CancelBag()
   
     // MARK: - UI Components
+    
+    private lazy var naviBar = CustomNavigationBar(self, type: .titleWithLeftButton)
+        .setTitle(I18N.Setting.passwordEdit)
+        .setTitleTypoStyle(.h1)
+    
+    private lazy var passwordTextFieldView = CustomTextFieldView(type: .title)
+        .setTitle(I18N.SignUp.password)
+        .setTextFieldType(.password)
+        .setPlaceholder(I18N.SignUp.passwordTextFieldPlaceholder)
+        .setAlertDelegate(passwordCheckTextFieldView)
+    
+    private lazy var passwordCheckTextFieldView = CustomTextFieldView(type: .plain)
+        .setPlaceholder(I18N.SignUp.passwordCheckTextFieldPlaceholder)
+        .setTextFieldType(.password)
+        .setAlertLabelEnabled(I18N.SignUp.invalidPasswordForm)
+    
+    private let passwordChangeButton = CustomButton(title: I18N.Setting.passwordEdit)
+        .setEnabled(false)
   
     // MARK: - View Life Cycle
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.bindViewModels()
+        self.setUI()
+        self.setLayout()
     }
 }
 
@@ -40,4 +63,37 @@ extension PasswordChangeVC {
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
     }
 
+}
+
+// MARK: - UI & Layout
+
+extension PasswordChangeVC {
+    private func setUI() {
+        self.view.backgroundColor = .white
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
+    private func setLayout() {
+        self.view.addSubviews(naviBar, passwordTextFieldView, passwordCheckTextFieldView, passwordChangeButton)
+        
+        naviBar.snp.makeConstraints { make in
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        passwordTextFieldView.snp.makeConstraints { make in
+            make.top.equalTo(naviBar.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        passwordCheckTextFieldView.snp.makeConstraints { make in
+            make.top.equalTo(passwordTextFieldView.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        passwordChangeButton.snp.makeConstraints { make in
+            make.top.equalTo(passwordCheckTextFieldView.snp.bottom).offset(26)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(56)
+        }
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
@@ -23,9 +23,7 @@ public class PasswordChangeVC: UIViewController {
     public var factory: ModuleFactoryInterface!
     public var viewModel: PasswordChangeViewModel!
     private var cancelBag = CancelBag()
-    
-    @Published public var passwordChangeSuccessed = false
-  
+      
     // MARK: - UI Components
     
     private lazy var naviBar = CustomNavigationBar(self, type: .titleWithLeftButton)
@@ -91,9 +89,10 @@ extension PasswordChangeVC {
         
         output.passwordChangeSuccessed.sink { [weak self] isSuccess in
             guard let self = self else { return }
-            self.passwordChangeSuccessed = isSuccess
             if isSuccess {
                 self.navigationController?.popViewController(animated: true)
+                let window = self.view.window!
+                Toast.showInView(message: I18N.Setting.passwordEditSuccess, view: window)
             } else {
                 self.showToast(message: I18N.Setting.passwordEditFail)
             }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
@@ -23,6 +23,8 @@ public class PasswordChangeVC: UIViewController {
     public var factory: ModuleFactoryInterface!
     public var viewModel: PasswordChangeViewModel!
     private var cancelBag = CancelBag()
+    
+    @Published public var passwordChangeSuccessed = false
   
     // MARK: - UI Components
     
@@ -89,7 +91,12 @@ extension PasswordChangeVC {
         
         output.passwordChangeSuccessed.sink { [weak self] isSuccess in
             guard let self = self else { return }
-            print(isSuccess)
+            self.passwordChangeSuccessed = isSuccess
+            if isSuccess {
+                self.navigationController?.popViewController(animated: true)
+            } else {
+                self.showToast(message: I18N.Setting.passwordEditFail)
+            }
         }.store(in: cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
@@ -92,7 +92,6 @@ extension PasswordChangeVC {
             print(isSuccess)
         }.store(in: cancelBag)
     }
-
 }
 
 // MARK: - UI & Layout

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
@@ -92,7 +92,7 @@ extension PasswordChangeVC {
             if isSuccess {
                 self.navigationController?.popViewController(animated: true)
                 let window = self.view.window!
-                Toast.showInView(message: I18N.Setting.passwordEditSuccess, view: window)
+                Toast.show(message: I18N.Setting.passwordEditSuccess, view: window, safeAreaBottomInset: self.safeAreaBottomInset())
             } else {
                 self.showToast(message: I18N.Setting.passwordEditFail)
             }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
@@ -21,13 +21,18 @@ public class PasswordChangeViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-    
+        let passwordTextChanged: Driver<String?>
+        let passwordCheckTextChanged: Driver<String?>
+        let passwordChangeButtonTapped: Driver<String>
     }
     
     // MARK: - Outputs
     
     public struct Output {
-    
+        var passwordAlert = PassthroughSubject<SignUpFormValidateResult, Never>()
+        var passwordAccordAlert = PassthroughSubject<SignUpFormValidateResult, Never>()
+        var isValidForm = PassthroughSubject<Bool, Never>()
+        var passwordChangeSuccessed = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - init
@@ -41,12 +46,47 @@ extension PasswordChangeViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
-        // input,output 상관관계 작성
+        
+        input.passwordTextChanged
+            .compactMap({ $0 })
+            .sink { password in
+                self.useCase.checkPassword(password: password)
+            }.store(in: self.cancelBag)
+        
+        input.passwordTextChanged
+            .compactMap({ $0 })
+            .combineLatest(input.passwordCheckTextChanged.compactMap({ $0 }))
+            .sink { (firstPassword, secondPassword) in
+                self.useCase.checkAccordPassword(firstPassword: firstPassword, secondPassword: secondPassword)
+            }.store(in: self.cancelBag)
+        
+        input.passwordChangeButtonTapped
+            .sink { signUpRequest in
+                // 버튼 클릭 액션
+            }.store(in: self.cancelBag)
     
         return output
     }
   
     private func bindOutput(output: Output, cancelBag: CancelBag) {
-    
+        useCase.isPasswordFormValid.combineLatest(useCase.isAccordPassword).sink { event in
+            print("PasswordChangeViewModel - completion: \(event)")
+        } receiveValue: { (isFormValid, isAccordValid) in
+            if !isFormValid {
+                output.passwordAlert.send(.invalid(text: I18N.SignUp.invalidPasswordForm))
+            } else if isFormValid && !isAccordValid {
+                output.passwordAlert.send(.valid(text: ""))
+                output.passwordAccordAlert.send(.invalid(text: (I18N.SignUp.passwordNotAccord)))
+            } else {
+                output.passwordAlert.send(.valid(text: ""))
+                output.passwordAccordAlert.send(.valid(text: ""))
+            }
+        }.store(in: cancelBag)
+        
+        useCase.isValidForm.sink { event in
+            print("PasswordChangeViewModel - completion: \(event)")
+        } receiveValue: { isValidForm in
+            output.isValidForm.send(isValidForm)
+        }.store(in: cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
@@ -61,8 +61,8 @@ extension PasswordChangeViewModel {
             }.store(in: self.cancelBag)
         
         input.passwordChangeButtonTapped
-            .sink { signUpRequest in
-                // 버튼 클릭 액션
+            .sink { password in
+                self.useCase.changePassword(password: password)
             }.store(in: self.cancelBag)
     
         return output
@@ -87,6 +87,12 @@ extension PasswordChangeViewModel {
             print("PasswordChangeViewModel - completion: \(event)")
         } receiveValue: { isValidForm in
             output.isValidForm.send(isValidForm)
+        }.store(in: cancelBag)
+        
+        useCase.passwordChangeSuccess.sink { event in
+            print("PasswordChangeViewModel - completion: \(event)")
+        } receiveValue: { isSuccess in
+            output.passwordChangeSuccessed.send(isSuccess)
         }.store(in: cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/ViewModel/PasswordChangeViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  PasswordChangeViewModel.swift
+//  Presentation
+//
+//  Created by sejin on 2022/12/26.
+//  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Combine
+
+import Core
+import Domain
+
+public class PasswordChangeViewModel: ViewModelType {
+
+    private let useCase: PasswordChangeUseCase
+    private var cancelBag = CancelBag()
+  
+    // MARK: - Inputs
+    
+    public struct Input {
+    
+    }
+    
+    // MARK: - Outputs
+    
+    public struct Output {
+    
+    }
+    
+    // MARK: - init
+  
+    public init(useCase: PasswordChangeUseCase) {
+        self.useCase = useCase
+    }
+}
+
+extension PasswordChangeViewModel {
+    public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        self.bindOutput(output: output, cancelBag: cancelBag)
+        // input,output 상관관계 작성
+    
+        return output
+    }
+  
+    private func bindOutput(output: Output, cancelBag: CancelBag) {
+    
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -29,8 +29,7 @@ public class SettingVC: UIViewController {
         .setTitle(I18N.Setting.setting)
     private let collectionViewFlowlayout = UICollectionViewFlowLayout()
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowlayout)
-    
-  
+     
     // MARK: - View Life Cycle
     
     public override func viewDidLoad() {
@@ -61,6 +60,19 @@ extension SettingVC {
     private func setDelegate() {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
+    }
+    
+    private func showPasswordChangeView() {
+        let passwordChangeVC = self.factory.makePasswordChangeVC()
+        passwordChangeVC.$passwordChangeSuccessed
+            .sink { [weak self] isSuccess in
+                guard let self = self else { return }
+                if isSuccess {
+                    self.showToast(message: I18N.Setting.passwordEditSuccess)
+                }
+            }.store(in: cancelBag)
+        
+        navigationController?.pushViewController(passwordChangeVC, animated: true)
     }
 }
 
@@ -106,7 +118,7 @@ extension SettingVC: UICollectionViewDelegate {
             case 0:
                 print("한마디 편집")
             case 1:
-                print("비밀번호 변경")
+               showPasswordChangeView()
             default:
                 print("닉네임 변경")
             }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -64,14 +64,6 @@ extension SettingVC {
     
     private func showPasswordChangeView() {
         let passwordChangeVC = self.factory.makePasswordChangeVC()
-        passwordChangeVC.$passwordChangeSuccessed
-            .sink { [weak self] isSuccess in
-                guard let self = self else { return }
-                if isSuccess {
-                    self.showToast(message: I18N.Setting.passwordEditSuccess)
-                }
-            }.store(in: cancelBag)
-        
         navigationController?.pushViewController(passwordChangeVC, animated: true)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootVC = ModuleFactory.shared.makePasswordChangeVC()
+        let rootVC = ModuleFactory.shared.makeSettingVC()
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()
     }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootVC = ModuleFactory.shared.makeSignUpVC()
+        let rootVC = ModuleFactory.shared.makePasswordChangeVC()
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()
     }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -110,7 +110,7 @@ extension ModuleFactory: ModuleFactoryInterface {
     }
     
     public func makeSettingVC() -> SettingVC {
-        let repository = SettingRepository(service: userService)
+        let repository = SettingRepository(service: authService)
         let useCase = DefaultSettingUseCase(repository: repository)
         let viewModel = SettingViewModel(useCase: useCase)
         let settingVC = SettingVC()

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -118,4 +118,14 @@ extension ModuleFactory: ModuleFactoryInterface {
         settingVC.viewModel = viewModel
         return settingVC
     }
+    
+    public func makePasswordChangeVC() -> PasswordChangeVC {
+        let repository = SettingRepository(service: authService)
+        let useCase = DefaultPasswordChangeUseCase(repository: repository)
+        let viewModel = PasswordChangeViewModel(useCase: useCase)
+        let passwordChangeVC = PasswordChangeVC()
+        passwordChangeVC.factory = self
+        passwordChangeVC.viewModel = viewModel
+        return passwordChangeVC
+    }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#57

## 🌱 PR Point
- 설정 뷰의 비밀번호 변경 뷰 UI 및 서버 연결까지 구현했습니다.
- 준호 선배의 의견대로 SettingRepository는 공유해서 사용하는 방식으로 구현했습니다!
- SettingScene 안에 해당되는 뷰라 폴더링을 어떻게 해야 할지 몰라서 일단은 SettingScene 내부에 새롭게 PasswordSettingScene 폴더를 생성하여 작업했습니다. 논의 후 위치 변경하겠습니다..!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 현재 로그인 API 연결이 되어 있지 않아 비밀번호 변경 API 헤더에 필요한 userId는 임의로 12로 넣어두었습니다.
- 기획 문서에 따라 비번 변경이 성공하면 메인 설정 뷰로 화면 전환 + 토스트가 보여지도록 했습니다.
- 피드백 언제나 환영합니다~!!

## 📸 스크린샷
|기능|스크린샷|
|비밀번호 변경 뷰| ![Simulator Screen Recording - iPhone 13 mini - 2022-12-26 at 17 05 45](https://user-images.githubusercontent.com/77267404/209522943-1d6674c8-738a-44ad-ba8c-9d269796ca24.gif)|


## 📮 관련 이슈
- Resolved: #57 
