### PR TITLE
[Feat] #61 - 스탬프 삭제, 초기화 Domain, Data 및 Network 구현

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -11,7 +11,8 @@ import Foundation
 public struct I18N {
     public struct Default {
         public static let error = "에러"
-        public static let networkError = "네트워크 오류가 발생했습니다."
+        public static let networkError = "네트워크가 원활하지 않습니다."
+        public static let networkErrorDescription = "인터넷 연결을 확인하고 다시 시도해 주세요."
         public static let delete = "삭제"
         public static let cancel = "취소"
         public static let ok = "확인"
@@ -92,6 +93,9 @@ public struct I18N {
         public static let suggestion = "서비스 의견 제안"
         public static let mission = "미션"
         public static let resetMission = "미션 초기화"
+        public static let resetMissionTitle = "스탬프를 초기화 하시겠습니까?"
+        public static let resetMissionDescription = "사진, 메모가 삭제되고\n 전체 미션이 미완료상태로 초기화됩니다."
+        public static let reset = "초기화"
         public static let logout = "로그아웃"
         public static let withdraw = "탈퇴하기"
     }

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -96,6 +96,7 @@ public struct I18N {
         public static let resetMissionTitle = "스탬프를 초기화 하시겠습니까?"
         public static let resetMissionDescription = "사진, 메모가 삭제되고\n 전체 미션이 미완료상태로 초기화됩니다."
         public static let reset = "초기화"
+        public static let resetSuccess = "초기화 되었습니다"
         public static let logout = "로그아웃"
         public static let withdraw = "탈퇴하기"
         public static let passwordEditSuccess = "비밀번호가 변경되었습니다."

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -44,9 +44,8 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
     }
     
     public func deleteStamp(stampId: Int) -> Driver<Bool> {
-        // TODO: - networkService
-        return Just(Bool.random())
-            .setFailureType(to: Error.self)
+        return stampService.deleteStamp(stampId: stampId)
+            .map { $0 == 200 }
             .asDriver()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -20,7 +20,6 @@ public class ListDetailRepository {
 
     public init(service: StampService) {
         self.stampService = service
-        print("listdetailrepository", userId)
     }
 }
 
@@ -46,23 +45,6 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
     public func deleteStamp(stampId: Int) -> Driver<Bool> {
         return stampService.deleteStamp(stampId: stampId)
             .map { $0 == 200 }
-            .asDriver()
-    }
-}
-
-extension ListDetailRepository {
-    private func makeMockListDetailEntity() -> Driver<ListDetailModel> {
-        let mockData = ListDetailEntity.init(
-            createdAt: "2022-01-22",
-            updatedAt: "2022-02-01",
-            id: 1,
-            contents: "안녕하세요",
-            images: ["https://avatars.githubusercontent.com/u/81167570?v=4"],
-            userID: 3,
-            missionID: 2)
-        let date = mockData.toDomain()
-        return Just(date)
-            .setFailureType(to: Error.self)
             .asDriver()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/SettingRepository.swift
@@ -14,21 +14,28 @@ import Network
 
 public class SettingRepository {
     
-    private let networkService: AuthService
+    private let userId: Int = UserDefaultKeyList.Auth.userId ?? 0
+    private let authService: AuthService
+    private let stampService: StampService
     private let cancelBag = CancelBag()
     
-    public init(service: AuthService) {
-        self.networkService = service
+    public init(authService: AuthService, stampService: StampService) {
+        self.authService = authService
+        self.stampService = stampService
     }
 }
 
 extension SettingRepository: SettingRepositoryInterface {
-    
+    public func resetStamp() -> Driver<Bool> {
+        stampService.resetStamp(userId: userId)
+            .map { $0 == 200 }
+            .asDriver()
+    }
 }
 
 extension SettingRepository: PasswordChangeRepositoryInterface {
     public func changePassword(password: String) -> AnyPublisher<Bool, Error> {
-        networkService.changePassword(password: password, userId: 12).map { statusCode in statusCode == 200 }
+        authService.changePassword(password: password, userId: 12).map { statusCode in statusCode == 200 }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
@@ -16,7 +16,8 @@ extension ListDetailEntity {
         
         return ListDetailModel.init(image: self.images.first ?? "",
                                     content: self.contents,
-                                    date: changeDateformat(self.updatedAt ?? self.createdAt))
+                                    date: changeDateformat(self.updatedAt ?? self.createdAt),
+                                    stampId: self.id)
     }
     
     private func changeDateformat(_ date: String) -> String {

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
@@ -11,10 +11,12 @@ import Foundation
 public struct ListDetailModel {
 
     public let image, content, date: String
+    public let stampId: Int
 
-    public init(image: String, content: String, date: String) {
+    public init(image: String, content: String, date: String, stampId: Int) {
         self.image = image
         self.content = content
         self.date = date
+        self.stampId = stampId
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SettingRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/SettingRepositoryInterface.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2022 SOPT-Stamp-iOS. All rights reserved.
 //
 
+import Core
+
 import Combine
 
 public protocol SettingRepositoryInterface {
-  
+    func resetStamp() -> Driver<Bool>
 }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SettingUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SettingUseCase.swift
@@ -8,14 +8,19 @@
 
 import Combine
 
-public protocol SettingUseCase {
+import Core
 
+public protocol SettingUseCase {
+    func resetStamp()
+    var resetSuccess: PassthroughSubject<Bool, Error> { get set }
 }
 
 public class DefaultSettingUseCase {
   
     private let repository: SettingRepositoryInterface
-    private var cancelBag = Set<AnyCancellable>()
+    private var cancelBag = CancelBag()
+    
+    public var resetSuccess = PassthroughSubject<Bool, Error>()
   
     public init(repository: SettingRepositoryInterface) {
         self.repository = repository
@@ -23,5 +28,10 @@ public class DefaultSettingUseCase {
 }
 
 extension DefaultSettingUseCase: SettingUseCase {
-  
+    public func resetStamp() {
+        repository.resetStamp()
+            .sink { success in
+                self.resetSuccess.send(success)
+            }.store(in: self.cancelBag)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/StampAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/StampAPI.swift
@@ -17,6 +17,7 @@ public enum StampAPI {
     case fetchStampListDetail(userId: Int, missionId: Int)
     case postStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel)
     case putStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel)
+    case deleteStamp(stampId: Int)
 }
 
 extension StampAPI: BaseAPI {
@@ -31,6 +32,8 @@ extension StampAPI: BaseAPI {
         case .postStamp(let userId, _, _),
                 .putStamp(let userId, _, _):
             return HeaderType.multipart(userId: userId).value
+        case .deleteStamp:
+            return HeaderType.json.value
         }
     }
     
@@ -41,6 +44,8 @@ extension StampAPI: BaseAPI {
                 .postStamp(_ , let missionId, _),
                 .putStamp(_ , let missionId, _):
             return "/\(missionId)"
+        case .deleteStamp(let stampId):
+            return "/\(stampId)"
         }
     }
     
@@ -51,6 +56,8 @@ extension StampAPI: BaseAPI {
             return .post
         case .putStamp:
             return .put
+        case .deleteStamp:
+            return .delete
         default: return .get
         }
     }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/StampAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/StampAPI.swift
@@ -18,6 +18,7 @@ public enum StampAPI {
     case postStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel)
     case putStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel)
     case deleteStamp(stampId: Int)
+    case resetStamp(userId: Int)
 }
 
 extension StampAPI: BaseAPI {
@@ -27,7 +28,8 @@ extension StampAPI: BaseAPI {
     // MARK: - Header
     public var headers: [String : String]? {
         switch self {
-        case .fetchStampListDetail(let userId, _):
+        case .fetchStampListDetail(let userId, _),
+                .resetStamp(let userId):
             return HeaderType.userId(userId: userId).value
         case .postStamp(let userId, _, _),
                 .putStamp(let userId, _, _):
@@ -46,6 +48,8 @@ extension StampAPI: BaseAPI {
             return "/\(missionId)"
         case .deleteStamp(let stampId):
             return "/\(stampId)"
+        case .resetStamp:
+            return "/all"
         }
     }
     
@@ -56,7 +60,7 @@ extension StampAPI: BaseAPI {
             return .post
         case .putStamp:
             return .put
-        case .deleteStamp:
+        case .deleteStamp, .resetStamp:
             return .delete
         default: return .get
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
@@ -38,14 +38,7 @@ extension DefaultStampService: StampService {
     }
     
     public func deleteStamp(stampId: Int) -> AnyPublisher<Int, Error> {
-        let subject = PassthroughSubject<Int, Error>()
-        requestObjectWithNoResult(StampAPI.deleteStamp(stampId: stampId)) { result in
-            result.success { statusCode in
-                subject.send(statusCode ?? 0)
-            }
-        }
-        return subject.eraseToAnyPublisher()
-//        return requestObjectInCombineNoResult(StampAPI.deleteStamp(stampId: stampId))
+        return requestObjectInCombineNoResult(StampAPI.deleteStamp(stampId: stampId))
     }
     
     public func resetStamp(userId: Int) -> AnyPublisher<Int, Error> {

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
@@ -20,6 +20,7 @@ public protocol StampService {
     func fetchStampListDetail(userId: Int, missionId: Int) -> AnyPublisher<ListDetailEntity, Error>
     func postStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel) -> AnyPublisher<ListDetailEntity, Error>
     func putStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel) -> AnyPublisher<StampEntity, Error>
+    func deleteStamp(stampId: Int) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultStampService: StampService {
@@ -33,5 +34,15 @@ extension DefaultStampService: StampService {
     
     public func putStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel) -> AnyPublisher<StampEntity, Error> {
         requestObjectInCombine(StampAPI.putStamp(userId: userId, missionId: missionId, requestModel: requestModel))
+    }
+    
+    public func deleteStamp(stampId: Int) -> AnyPublisher<Int, Error> {
+        let subject = PassthroughSubject<Int, Error>()
+        requestObjectWithNoResult(StampAPI.deleteStamp(stampId: stampId)) { result in
+            result.success { statusCode in
+                subject.send(statusCode ?? 0)
+            }
+        }
+        return subject.eraseToAnyPublisher()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/StampService.swift
@@ -21,6 +21,7 @@ public protocol StampService {
     func postStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel) -> AnyPublisher<ListDetailEntity, Error>
     func putStamp(userId: Int, missionId: Int, requestModel: ListDetailRequestModel) -> AnyPublisher<StampEntity, Error>
     func deleteStamp(stampId: Int) -> AnyPublisher<Int, Error>
+    func resetStamp(userId: Int) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultStampService: StampService {
@@ -44,5 +45,10 @@ extension DefaultStampService: StampService {
             }
         }
         return subject.eraseToAnyPublisher()
+//        return requestObjectInCombineNoResult(StampAPI.deleteStamp(stampId: stampId))
+    }
+    
+    public func resetStamp(userId: Int) -> AnyPublisher<Int, Error> {
+        return requestObjectInCombineNoResult(StampAPI.resetStamp(userId: userId))
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/AlertScene/VC/AlertVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/AlertScene/VC/AlertVC.swift
@@ -15,7 +15,7 @@ import DSKit
 
 public enum AlertType {
     case title
-    case titleWithDesciption
+    case titleDescription
     case networkErr
 }
 
@@ -162,7 +162,7 @@ extension AlertVC {
         alertView.addSubviews(cancelButton)
         
         switch type {
-        case .title, .titleWithDesciption:
+        case .title, .titleDescription:
             alertView.addSubviews(customButton)
             
             cancelButton.snp.makeConstraints { make in

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/AlertScene/VC/AlertVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/AlertScene/VC/AlertVC.swift
@@ -13,6 +13,12 @@ import SnapKit
 import Core
 import DSKit
 
+public enum AlertType {
+    case title
+    case titleWithDesciption
+    case networkErr
+}
+
 public class AlertVC: UIViewController {
     
     // MARK: - Properties
@@ -24,23 +30,37 @@ public class AlertVC: UIViewController {
     private lazy var backgroundDimmerView = CustomDimmerView(self)
     private let alertView = UIView()
     private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
     private let cancelButton = UIButton()
     private let customButton = UIButton()
+    private var alertType: AlertType!
+    
+    // MARK: - Init
+    
+    public init(alertType: AlertType) {
+        self.alertType = alertType
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - View Life Cycles
-
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        setLayout()
+        setLayout(alertType)
         setAddTarget()
     }
     
     // MARK: - Custom Method
     
     @discardableResult
-    public func setTitle(_ title: String) -> Self {
+    public func setTitle(_ title: String, _ description: String = "") -> Self {
         self.titleLabel.text = title
+        self.descriptionLabel.text = description
         return self
     }
     
@@ -77,26 +97,35 @@ public class AlertVC: UIViewController {
 
 extension AlertVC {
     private func setUI() {
-        self.view.backgroundColor = .clear//.black.withAlphaComponent(0.6)
+        self.view.backgroundColor = .clear
         self.alertView.backgroundColor = .white
-        self.cancelButton.backgroundColor = DSKitAsset.Colors.gray300.color
+        self.cancelButton.backgroundColor = (self.alertType == .networkErr) ? DSKitAsset.Colors.error200.color : DSKitAsset.Colors.gray300.color
         self.customButton.backgroundColor = DSKitAsset.Colors.error200.color
         
         self.titleLabel.setTypoStyle(.subtitle1)
+        self.descriptionLabel.setTypoStyle(.caption3)
         self.cancelButton.titleLabel?.setTypoStyle(.subtitle1)
         self.customButton.titleLabel?.setTypoStyle(.subtitle1)
         
         self.titleLabel.textColor = DSKitAsset.Colors.gray900.color
+        self.descriptionLabel.textColor = DSKitAsset.Colors.gray500.color
         self.cancelButton.titleLabel?.textColor = DSKitAsset.Colors.gray700.color
         self.customButton.titleLabel?.textColor = DSKitAsset.Colors.white.color
         
-        self.cancelButton.setTitle(I18N.Default.cancel, for: .normal)
+        self.descriptionLabel.textAlignment = .center
+        self.descriptionLabel.numberOfLines = 2
+        
+        let cancelTitle = (self.alertType == .networkErr) ? I18N.Default.ok : I18N.Default.cancel
+        self.cancelButton.setTitle(cancelTitle, for: .normal)
         
         self.alertView.layer.cornerRadius = 10
         self.alertView.layer.masksToBounds = true
     }
     
-    private func setLayout() {
+    private func setLayout(_ type: AlertType) {
+        let heightRatio = (type == .title) ? 0.49 : 0.55
+        let titleOffset = (type == .title) ? -22 : -35
+        
         self.view.addSubviews(backgroundDimmerView, alertView)
         
         backgroundDimmerView.snp.makeConstraints { make in
@@ -106,26 +135,53 @@ extension AlertVC {
         alertView.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.leading.trailing.equalToSuperview().inset(50)
-            make.height.equalTo(alertView.snp.width).multipliedBy(0.49)
+            make.height.equalTo(alertView.snp.width).multipliedBy(heightRatio)
         }
         
-        alertView.addSubviews(titleLabel, cancelButton, customButton)
+        self.setButtonLayout(type)
         
-        cancelButton.snp.makeConstraints { make in
-            make.leading.bottom.equalToSuperview()
-            make.width.equalTo(alertView.snp.width).multipliedBy(0.5)
-            make.height.equalTo(cancelButton.snp.width).multipliedBy(0.347)
-        }
-        
-        customButton.snp.makeConstraints { make in
-            make.trailing.bottom.equalToSuperview()
-            make.leading.equalTo(cancelButton.snp.trailing)
-            make.top.equalTo(cancelButton.snp.top)
-        }
+        alertView.addSubview(titleLabel)
         
         titleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.centerY.equalToSuperview().offset(-22)
+            make.centerY.equalToSuperview().offset(titleOffset)
+        }
+        
+        if type != .title {
+            alertView.addSubview(descriptionLabel)
+            
+            descriptionLabel.snp.makeConstraints { make in
+                make.centerX.equalToSuperview()
+                make.centerY.equalToSuperview().offset(-6)
+                make.leading.trailing.equalToSuperview().inset(30)
+            }
+        }
+    }
+    
+    private func setButtonLayout(_ type: AlertType) {
+        alertView.addSubviews(cancelButton)
+        
+        switch type {
+        case .title, .titleWithDesciption:
+            alertView.addSubviews(customButton)
+            
+            cancelButton.snp.makeConstraints { make in
+                make.leading.bottom.equalToSuperview()
+                make.width.equalTo(alertView.snp.width).multipliedBy(0.5)
+                make.height.equalTo(cancelButton.snp.width).multipliedBy(0.347)
+            }
+            
+            customButton.snp.makeConstraints { make in
+                make.trailing.bottom.equalToSuperview()
+                make.leading.equalTo(cancelButton.snp.trailing)
+                make.top.equalTo(cancelButton.snp.top)
+            }
+        case .networkErr:
+            cancelButton.snp.makeConstraints { make in
+                make.leading.trailing.bottom.equalToSuperview()
+                make.width.equalTo(alertView.snp.width)
+                make.height.equalTo(cancelButton.snp.width).multipliedBy(0.17)
+            }
         }
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -259,7 +259,7 @@ extension ListDetailVC {
     
     private func presentDeleteAlertVC() {
         let alertVC = self.factory.makeAlertVC(
-            type: .titleWithDesciption,
+            type: .title,
             title: I18N.ListDetail.deleteTitle,
             description: "",
             customButtonTitle: I18N.Default.delete)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -257,7 +257,11 @@ extension ListDetailVC {
     }
     
     private func presentDeleteAlertVC() {
-        let alertVC = self.factory.makeAlertVC(title: I18N.ListDetail.deleteTitle, customButtonTitle: I18N.Default.delete)
+        let alertVC = self.factory.makeAlertVC(
+            type: .titleWithDesciption,
+            title: I18N.ListDetail.deleteTitle,
+            description: "",
+            customButtonTitle: I18N.Default.delete)
         alertVC.customAction = {
             self.deleteButtonTapped.send(true)
         }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -26,6 +26,7 @@ public class ListDetailViewModel: ViewModelType {
     public var starLevel: StarViewLevel!
     public var missionId: Int!
     public var missionTitle: String!
+    public var stampId: Int!
   
     // MARK: - Inputs
     
@@ -93,8 +94,7 @@ extension ListDetailViewModel {
         
         input.deleteButtonTapped
             .sink { _ in
-                // TODO: - useCase 삭제 연결
-                self.useCase.deleteStamp(stampId: self.missionId)
+                self.useCase.deleteStamp(stampId: self.stampId)
             }.store(in: self.cancelBag)
     
         return output
@@ -106,7 +106,10 @@ extension ListDetailViewModel {
         let deleteSuccess = useCase.deleteSuccess
         
         listDetailModel.asDriver()
-            .compactMap { $0 }
+            .compactMap {
+                self.stampId = $0.stampId
+                return $0
+            }
             .assign(to: \.self.listDetailModel, on: output)
             .store(in: self.cancelBag)
         

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
@@ -19,7 +19,8 @@ public protocol ModuleFactoryInterface {
     func makeMissionListVC(sceneType: MissionListSceneType) -> MissionListVC
     func makeListDetailVC(sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String) -> ListDetailVC
     func makeMissionCompletedVC(starLevel: StarViewLevel) -> MissionCompletedVC
-    func makeAlertVC(title: String, customButtonTitle: String) -> AlertVC
+    func makeAlertVC(type: AlertType, title: String, description: String, customButtonTitle: String) -> AlertVC
+    func makeNetworkAlertVC() -> AlertVC
     func makeRankingVC() -> RankingVC
     func makeSettingVC() -> SettingVC
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -22,6 +22,7 @@ public class SettingVC: UIViewController {
     public var viewModel: SettingViewModel!
     private var cancelBag = CancelBag()
     public var factory: ModuleFactoryInterface!
+    private let resetButtonTapped = PassthroughSubject<Bool, Never>()
   
     // MARK: - UI Components
     
@@ -61,6 +62,20 @@ extension SettingVC {
     private func setDelegate() {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
+    }
+    
+    private func presentResetAlertVC() {
+        let alertVC = self.factory.makeAlertVC(
+            type: .titleWithDesciption,
+            title: I18N.Setting.resetMissionTitle,
+            description: I18N.Setting.resetMissionDescription,
+            customButtonTitle: I18N.Setting.reset)
+        alertVC.customAction = {
+            self.resetButtonTapped.send(true)
+            print("resetButtonTapped")
+        }
+        
+        self.present(alertVC, animated: true)
     }
 }
 
@@ -120,7 +135,7 @@ extension SettingVC: UICollectionViewDelegate {
                 print("서비스 의견 제안")
             }
         case 2:
-            print("미션 초기화")
+            self.presentResetAlertVC()
         default:
             print("로그아웃")
         }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -53,10 +53,9 @@ extension SettingVC {
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
         output.resetSuccessed
-            .sink { success in
-                if success {
-                    self.showToast(message: I18N.Setting.resetSuccess)
-                }
+            .filter({ $0 })
+            .sink { _ in
+                self.showToast(message: I18N.Setting.resetSuccess)
             }.store(in: self.cancelBag)
     }
     

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -48,8 +48,16 @@ public class SettingVC: UIViewController {
 extension SettingVC {
   
     private func bindViewModels() {
-        let input = SettingViewModel.Input()
+        let input = SettingViewModel.Input(
+            resetButtonTapped: resetButtonTapped.asDriver())
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.resetSuccessed
+            .sink { success in
+                if success {
+                    self.showToast(message: I18N.Setting.resetSuccess)
+                }
+            }.store(in: self.cancelBag)
     }
     
     private func setRegister() {
@@ -64,14 +72,12 @@ extension SettingVC {
     }
     
     private func presentResetAlertVC() {
-        let alertVC = self.factory.makeAlertVC(
-            type: .titleWithDesciption,
-            title: I18N.Setting.resetMissionTitle,
-            description: I18N.Setting.resetMissionDescription,
-            customButtonTitle: I18N.Setting.reset)
+        let alertVC = self.factory.makeAlertVC(type: .titleWithDesciption,
+                                               title: I18N.Setting.resetMissionTitle,
+                                               description: I18N.Setting.resetMissionDescription,
+                                               customButtonTitle: I18N.Setting.reset)
         alertVC.customAction = {
             self.resetButtonTapped.send(true)
-            print("resetButtonTapped")
         }
         
         self.present(alertVC, animated: true)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/VC/SettingVC.swift
@@ -72,7 +72,7 @@ extension SettingVC {
     }
     
     private func presentResetAlertVC() {
-        let alertVC = self.factory.makeAlertVC(type: .titleWithDesciption,
+        let alertVC = self.factory.makeAlertVC(type: .titleDescription,
                                                title: I18N.Setting.resetMissionTitle,
                                                description: I18N.Setting.resetMissionDescription,
                                                customButtonTitle: I18N.Setting.reset)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/ViewModel/SettingViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/ViewModel/SettingViewModel.swift
@@ -32,13 +32,13 @@ public class SettingViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-    
+        let resetButtonTapped: Driver<Bool>
     }
     
     // MARK: - Outputs
     
     public struct Output {
-    
+        var resetSuccessed = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - init
@@ -52,12 +52,22 @@ extension SettingViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
-        // input,output 상관관계 작성
+        
+        input.resetButtonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.useCase.resetStamp()
+            }.store(in: cancelBag)
     
         return output
     }
   
     private func bindOutput(output: Output, cancelBag: CancelBag) {
-    
+        let resetSuccess = useCase.resetSuccess
+        
+        resetSuccess.asDriver()
+            .sink { success in
+                output.resetSuccessed.send(success)
+            }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -90,10 +90,18 @@ extension ModuleFactory: ModuleFactoryInterface {
         return missionCompletedVC
     }
     
-    public func makeAlertVC(title: String, customButtonTitle: String) -> AlertVC {
-        let alertVC = AlertVC()
-            .setTitle(title)
+    public func makeAlertVC(type: AlertType, title: String, description: String = "", customButtonTitle: String) -> AlertVC {
+        let alertVC = AlertVC(alertType: type)
+            .setTitle(title, description)
             .setCustomButtonTitle(customButtonTitle)
+        alertVC.modalPresentationStyle = .overFullScreen
+        alertVC.modalTransitionStyle = .crossDissolve
+        return alertVC
+    }
+    
+    public func makeNetworkAlertVC() -> AlertVC {
+        let alertVC = AlertVC(alertType: .networkErr)
+            .setTitle(I18N.Default.networkError, I18N.Default.networkErrorDescription)
         alertVC.modalPresentationStyle = .overFullScreen
         alertVC.modalTransitionStyle = .crossDissolve
         return alertVC

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -118,7 +118,7 @@ extension ModuleFactory: ModuleFactoryInterface {
     }
     
     public func makeSettingVC() -> SettingVC {
-        let repository = SettingRepository(service: authService)
+        let repository = SettingRepository(authService: authService, stampService: stampService)
         let useCase = DefaultSettingUseCase(repository: repository)
         let viewModel = SettingViewModel(useCase: useCase)
         let settingVC = SettingVC()
@@ -128,7 +128,7 @@ extension ModuleFactory: ModuleFactoryInterface {
     }
     
     public func makePasswordChangeVC() -> PasswordChangeVC {
-        let repository = SettingRepository(service: authService)
+        let repository = SettingRepository(authService: authService, stampService: stampService)
         let useCase = DefaultPasswordChangeUseCase(repository: repository)
         let viewModel = PasswordChangeViewModel(useCase: useCase)
         let passwordChangeVC = PasswordChangeVC()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#61

## 🌱 PR Point
- ListDetail(fetchStamp, putStamp, postStamp, deleteStamp) 네트워크 연결
- resetStamp 연결
- AlertVC 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

#### 🚨앞의 풀리퀘 #62 머지한 다음에 봐주세여 ! 커밋이 포함되어 있어서 조금 정신 없을 수 있습니다 ..

AlertVC에 type별로 분리했습니다
```
public enum AlertType {
    case title // 타이틀 + 취소 버튼 + 커스텀 버튼
    case titleDescription // 타이틀 + 설명 + 취소 버튼 + 커스텀 버튼
    case networkErr // 타이틀 + 설명 + 확인 버튼(다른 케이스의 취소 버튼과 동일)
}
```

네트워크 오류 alert의 경우 
아래처럼 바로 factory에서 불러서 사용하시면 됩니다
```
let alertVC = factory.makeNetworkAlertVC()
```

그 외의 alert를 사용하는 경우
```
let alertVC = self.factory.makeAlertVC(
            type: .title,
            title: I18N.ListDetail.deleteTitle,
            description: "", // 설명을 사용하지 않는 경우 빈 스트링을 넣어주세요
            customButtonTitle: I18N.Default.delete)

let alertVC = self.factory.makeAlertVC(
            type: .titleDescription,
            title: I18N.ListDetail.deleteTitle,
            description: "안녕하세요",
            customButtonTitle: I18N.Default.delete)
```


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #61 
