### PR TITLE
[Fix] #66 - PHPickerViewController MainThread에서 돌아가도록 수정

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -230,10 +230,12 @@ extension ListDetailVC {
         configuration.selectionLimit = 1
         configuration.filter = .any(of: [.images, .livePhotos])
         
-        let pickerVC = PHPickerViewController(configuration: configuration)
-        pickerVC.delegate = self
-        
-        self.present(pickerVC, animated: true)
+        DispatchQueue.main.async {
+            let pickerVC = PHPickerViewController(configuration: configuration)
+            pickerVC.delegate = self
+            
+            self.present(pickerVC, animated: true)
+        }
     }
     
     private func moveToSetting() {

--- a/SOPT-Stamp-iOS/Tuist/ProjectDescriptionHelpers/BaseInfoPlist.swift
+++ b/SOPT-Stamp-iOS/Tuist/ProjectDescriptionHelpers/BaseInfoPlist.swift
@@ -34,6 +34,6 @@ public extension Project {
         "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
         "ITSAppUsesNonExemptEncryption": false,
         "UIUserInterfaceStyle": "Light",
-        "NSPhotoLibraryUsageDescription": "권한 !!!!!!!1"
+        "NSPhotoLibraryUsageDescription": "미션과 관련된 사진을 업로드하기 위해 갤러리 권한이 필요합니다."
     ]
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#66

## 🌱 PR Point
최초 사진 접근 권한 얻고 왔을때 앱 터짐
-> PHPickerViewController(UI) MainThread에서 돌아가도록 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #66 
