### PR TITLE
[Feat] #72 - 랭킹 리스트 API 구현 및 1, 2, 3위 탭 액션 구현

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Extension/Combine+/Publisher+Driver.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Extension/Combine+/Publisher+Driver.swift
@@ -25,4 +25,9 @@ public extension Publisher {
     static func empty() -> Driver<Output> {
         return Empty().eraseToAnyPublisher()
     }
+    
+    func mapVoid() -> AnyPublisher<Void, Failure> {
+        return self.map { _ in () }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -74,6 +74,10 @@ public struct I18N {
         public static let start = "시작하기"
     }
     
+    public struct RankingList {
+        public static let noSentenceText = "설정된 한 마디가 없습니다."
+    }
+    
     public struct ListDetail {
         public static let imagePlaceHolder = "달성 사진을 올려주세요"
         public static let memoPlaceHolder = "메모를 작성해주세요"

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
@@ -24,9 +24,7 @@ public class MissionListRepository {
 
 extension MissionListRepository: MissionListRepositoryInterface {
     public func fetchMissionList(type: MissionListFetchType, userId: Int?) -> AnyPublisher<[MissionListModel], Error> {
-        let userId: Int = (userId != nil)
-        ? userId!
-        : 1
+        let userId = userId ?? 1
         switch type {
         case .all:
             return missionService.fetchAllMissionList(userId: userId)

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
@@ -14,18 +14,21 @@ import Network
 
 public class RankingRepository {
     
-    private let networkService: RankService
+    private let rankService: RankService
     private let cancelBag = CancelBag()
     
     public init(service: RankService) {
-        self.networkService = service
+        self.rankService = service
     }
 }
 
 extension RankingRepository: RankingRepositoryInterface {
     public func fetchRankingListModel() -> AnyPublisher<[Domain.RankingModel], Error> {
-        return Future<[RankingModel], Error> { promise in
-            promise(.success([RankingModel.init(username: "1등이다", usreId: 1, score: 94, sentence: "제가 1등입니다"), RankingModel.init(username: "헬로", usreId: 2, score: 92, sentence: "2등"), RankingModel.init(username: "이름이 긴 사람", usreId: 3, score: 91, sentence: "제가 3등입니다 말이 길어지면 어케"), RankingModel.init(username: "더미데이름", usreId: 4, score: 86, sentence: "4444"), RankingModel.init(username: "레포지토리", usreId: 5, score: 65, sentence: "5"), RankingModel.init(username: "인터페이스", usreId: 6, score: 53, sentence: "ㅎㄴ마ㄷ한마디"), RankingModel.init(username: "솝트", usreId: 7, score: 53, sentence: "하남ㄴㅁㅇㄹㅁㅋㅌㅊㅍ"), RankingModel.init(username: "노가다", usreId: 8, score: 52, sentence: "한마디 띄우기"), RankingModel.init(username: "9등이다", usreId: 9, score: 40, sentence: "한마디 최고글자길이는몇일까여?"), RankingModel.init(username: "10등이다", usreId: 10, score: 35, sentence: "5166"), RankingModel.init(username: "11등이다", usreId: 11, score: 32, sentence: "더메대충이데머"), RankingModel.init(username: "12등이다", usreId: 12, score: 12, sentence: "대충 더미데잍"), RankingModel.init(username: "안녕하세요", usreId: 13, score: 7, sentence: "531542642"), RankingModel.init(username: "14등이다", usreId: 14, score: 5, sentence: "한마디 귀찮아"), RankingModel.init(username: "15등이다", usreId: 15, score: 3, sentence: "")]))
-        }.eraseToAnyPublisher()
+        return self.rankService
+            .fetchRankingList(userId: UserDefaultKeyList.Auth.userId ?? 1)
+            .map({ entity in
+                entity.map { $0.toDomain() }
+            })
+            .eraseToAnyPublisher()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
@@ -8,12 +8,16 @@
 
 import Foundation
 
+import Core
 import Domain
 import Network
 
 extension RankingEntity {
     
-//    public func toDomain() -> RankingModel {
-//        return RankingModel.init()
-//    }
+    public func toDomain() -> RankingModel {
+        return .init(username: self.nickname,
+                     usreId: self.userID,
+                     score: self.point,
+                     sentence: self.profileMessage ?? I18N.RankingList.noSentenceText)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/SpeechBalloonView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/SpeechBalloonView.swift
@@ -20,7 +20,7 @@ public class SpeechBalloonView: UIView {
     
     // MARK: - UI Components
     
-    private let baloonTailImageView: UIImageView = {
+    private let balloonTailImageView: UIImageView = {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFit
         iv.image = DSKitAsset.Assets.balloonTail.image.withRenderingMode(.alwaysTemplate)
@@ -36,6 +36,13 @@ public class SpeechBalloonView: UIView {
         label.clipsToBounds = true
         label.sizeToFit()
         return label
+    }()
+    
+    private let leftArrowImage: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFit
+        iv.image = DSKitAsset.Assets.icLeftArrow.image.withRenderingMode(.alwaysTemplate)
+        return iv
     }()
     
     // MARK: View Life Cycle
@@ -66,18 +73,24 @@ extension SpeechBalloonView {
         switch viewLevel {
         case .rankOne:
             sentenceLabel.backgroundColor = DSKitAsset.Colors.purple300.color
-            baloonTailImageView.tintColor = DSKitAsset.Colors.purple300.color
+            sentenceLabel.textColor = DSKitAsset.Colors.white.color
+            leftArrowImage.tintColor = .white
+            balloonTailImageView.tintColor = DSKitAsset.Colors.purple300.color
         case .rankTwo:
             sentenceLabel.backgroundColor = DSKitAsset.Colors.pink300.color
-            baloonTailImageView.tintColor = DSKitAsset.Colors.pink300.color
+            sentenceLabel.textColor = DSKitAsset.Colors.white.color
+            leftArrowImage.tintColor = .white
+            balloonTailImageView.tintColor = DSKitAsset.Colors.pink300.color
         case .rankThree:
             sentenceLabel.backgroundColor = DSKitAsset.Colors.mint300.color
-            baloonTailImageView.tintColor = DSKitAsset.Colors.mint300.color
+            sentenceLabel.textColor = DSKitAsset.Colors.black.color
+            leftArrowImage.tintColor = .black
+            balloonTailImageView.tintColor = DSKitAsset.Colors.mint300.color
         }
     }
     
     private func setLayout(sentence: String) {
-        self.addSubviews(sentenceLabel, baloonTailImageView)
+        self.addSubviews(sentenceLabel, balloonTailImageView)
         
         sentenceLabel.snp.makeConstraints { make in
             make.top.equalToSuperview()
@@ -107,7 +120,7 @@ extension SpeechBalloonView {
             }
         }
         
-        baloonTailImageView.snp.makeConstraints { make in
+        balloonTailImageView.snp.makeConstraints { make in
             make.top.equalTo(sentenceLabel.snp.bottom).offset(-3).priority(.high)
             make.height.equalTo(11.5)
             make.width.equalTo(10)
@@ -120,6 +133,14 @@ extension SpeechBalloonView {
                 make.centerX.equalTo(sentenceLabel.snp.trailing).offset(-45.adjusted)
             }
             make.bottom.equalToSuperview()
+        }
+        
+        sentenceLabel.addSubview(leftArrowImage)
+        
+        leftArrowImage.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.size.equalTo(32)
+            make.trailing.equalToSuperview()
         }
     }
     

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/RankAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/RankAPI.swift
@@ -12,26 +12,34 @@ import Alamofire
 import Moya
 
 public enum RankAPI {
-    case sample(provider: String)
+    case rank(userId: Int)
 }
 
 extension RankAPI: BaseAPI {
     
-    public static var apiType: APIType = .auth
+    public static var apiType: APIType = .rank
+    
+    // MARK: - Header
+    public var headers: [String: String]? {
+        switch self {
+        case .rank(let userId):
+            return HeaderType.userId(userId: userId).value
+        default: return HeaderType.json.value
+        }
+    }
     
     // MARK: - Path
     public var path: String {
         switch self {
-        case .sample:
-            return ""
+        case .rank:
+            return "/rank"
         }
     }
     
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .sample:
-            return .post
+        default: return .get
         }
     }
     
@@ -39,16 +47,13 @@ extension RankAPI: BaseAPI {
     private var bodyParameters: Parameters? {
         var params: Parameters = [:]
         switch self {
-        case .sample(let provider):
-            params["platform"] = provider
+        default: break
         }
         return params
     }
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
-        case .sample:
-            return URLEncoding.init(destination: .queryString, arrayEncoding: .noBrackets, boolEncoding: .literal)
         default:
             return JSONEncoding.default
         }
@@ -56,8 +61,6 @@ extension RankAPI: BaseAPI {
     
     public var task: Task {
         switch self {
-        case .sample:
-            return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain
         }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/RankingEntity.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/RankingEntity.swift
@@ -8,9 +8,15 @@
 
 import Foundation
 
-public struct RankingEntity {
-    
-    public init() {
-        
+public struct RankingEntity: Codable {
+    public let rank, userID: Int
+    public let nickname: String
+    public let point: Int
+    public let profileMessage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case rank
+        case userID = "userId"
+        case nickname, point, profileMessage
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/RankService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/RankService.swift
@@ -15,9 +15,11 @@ import Moya
 public typealias DefaultRankService = BaseService<RankAPI>
 
 public protocol RankService {
-    
+    func fetchRankingList(userId: Int) -> AnyPublisher<[RankingEntity], Error>
 }
 
 extension DefaultRankService: RankService {
-    
+    public func fetchRankingList(userId: Int) -> AnyPublisher<[RankingEntity], Error> {
+        requestObjectInCombine(RankAPI.rank(userId: userId))
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListCVC.swift
@@ -129,7 +129,7 @@ extension RankingListCVC {
     }
 }
 
-extension RankingListCVC: RankingListTappble {
+extension RankingListCVC: RankingListTappable {
     func getModelItem() -> RankingListTapItem? {
         guard let model = model else { return nil }
         return RankingListTapItem.init(username: model.username,

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListTappable.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/Cells/RankingListTappable.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-protocol RankingListTappble {
+import Domain
+
+protocol RankingListTappable {
     func getModelItem() -> RankingListTapItem?
 }
 
@@ -16,4 +18,12 @@ public struct RankingListTapItem {
     public let username: String
     public let sentence: String
     public let userId: Int
+}
+
+extension RankingModel {
+    func toRankingListTapItem() -> RankingListTapItem {
+        .init(username: self.username,
+              sentence: self.sentence,
+              userId: self.userId)
+    }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -123,7 +123,11 @@ extension RankingVC {
                 guard let chartCell = collectionView.dequeueReusableCell(withReuseIdentifier: RankingChartCVC.className, for: indexPath) as? RankingChartCVC,
                       let chartCellModel = itemIdentifier as? RankingChartModel else { return UICollectionViewCell() }
                 chartCell.setData(model: chartCellModel)
-                
+                chartCell.balloonTapped = { [weak self] balloonModel in
+                    guard let self = self else { return }
+                    let item = balloonModel.toRankingListTapItem()
+                    self.pushToOtherUserMissionListVC(item: item)
+                }
                 return chartCell
                 
             case .list:
@@ -155,7 +159,9 @@ extension RankingVC {
 
 extension RankingVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let tappedCell = collectionView.cellForItem(at: indexPath) as? RankingListTappble,
+        guard indexPath.section >= 1 else { return }
+        
+        guard let tappedCell = collectionView.cellForItem(at: indexPath) as? RankingListTappable,
               let item = tappedCell.getModelItem() else { return }
         self.pushToOtherUserMissionListVC(item: item)
     }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -113,6 +113,7 @@ extension RankingVC {
         
         let showRankingButtonTapped = self.showMyRankingFloatingButton
             .publisher(for: .touchUpInside)
+            .filter { _ in self.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
             .mapVoid()
             .asDriver()
         
@@ -175,6 +176,7 @@ extension RankingVC {
     func applySnapshot(model: [RankingModel]) {
         var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
         snapshot.appendSections([.chart, .list])
+        guard model.count >= 4 else { return }
         guard let chartCellModels = Array(model[0...2]) as? [RankingModel],
               let rankingListModel = Array(model[3...model.count-1]) as? [RankingModel] else { return }
         let chartCellModel = RankingChartModel.init(ranking: chartCellModels)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#72

## 🌱 PR Point

- 랭킹 리스트 API 구현 및 1, 2, 3위 탭 액션을 구현했습니다.
- 현재 leftArrowImage가 figma와는 다른 위치에 있기는 한데... 이미지를 정확한 위치에 놓기 위해서는 아예 컴포넌트를 재설계해야 할 것 같아서.. 요건 디자인과 이야기 해보겠습니다.
- 랭킹 리스트 API가 아까까지만 해도 되다가 갑자기 500에러가 뜨고 있어서 일단 더미로 영상 찍었습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|탭 액션|![Simulator Screen Recording - iPhone 14 Pro - 2023-01-02 at 05 19 59](https://user-images.githubusercontent.com/77208067/210183669-589bd46c-b1cf-4003-86a5-ee0df5d25724.gif)|
|내 랭킹 보기|![Simulator Screen Recording - iPhone 14 Pro - 2023-01-02 at 05 19 36](https://user-images.githubusercontent.com/77208067/210183672-faeabcbc-449c-45fa-a3c7-d19ff243f9f0.gif)|

## 📮 관련 이슈
- Resolved: #72 
