### PR TITLE
[Feat] #74 - 뷰윌어피어에서 미션 리스트 fetch하기

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -28,6 +28,7 @@ public class MissionListVC: UIViewController {
     private var cancelBag = CancelBag()
     
     private var missionTypeMenuSelected = CurrentValueSubject<MissionListFetchType, Error>(.all)
+    private var viewWillAppear = PassthroughSubject<Void, Error>()
     
     lazy var dataSource: UICollectionViewDiffableDataSource<MissionListSection, MissionListModel>! = nil
     
@@ -113,6 +114,7 @@ public class MissionListVC: UIViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.viewWillAppear.send(())
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 }
@@ -198,7 +200,7 @@ extension MissionListVC {
     private func bindViewModels() {
         
         let input = MissionListViewModel.Input(viewDidLoad: Driver.just(()),
-                                               viewWillAppear: Driver.just(()),
+                                               viewWillAppear: viewWillAppear.asDriver(),
                                                missionTypeSelected: missionTypeMenuSelected.asDriver())
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -54,26 +54,32 @@ extension MissionListViewModel {
         input.viewDidLoad
             .withUnretained(self)
             .sink { owner, _ in
-                switch owner.missionListsceneType {
-                case .ranking(_, _, let userId):
-                    owner.useCase.fetchOtherUserMissionList(type: .all, userId: userId)
-                default:
-                    owner.useCase.fetchMissionList(type: .all)
-                }
+                owner.fetchMissionList()
+            }.store(in: cancelBag)
+        
+        input.viewWillAppear
+            .dropFirst()
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.fetchMissionList()
             }.store(in: cancelBag)
         
         input.missionTypeSelected
             .withUnretained(self)
             .sink { owner, fetchType in
-                switch owner.missionListsceneType {
-                case .ranking(_, _, let userId):
-                    owner.useCase.fetchOtherUserMissionList(type: fetchType, userId: userId)
-                default:
-                    owner.useCase.fetchMissionList(type: fetchType)
-                }
+                owner.useCase.fetchMissionList(type: fetchType)
             }.store(in: cancelBag)
         
         return output
+    }
+    
+    private func fetchMissionList() {
+        switch self.missionListsceneType {
+        case .ranking(_, _, let userId):
+            self.useCase.fetchOtherUserMissionList(type: .all, userId: userId)
+        default:
+            self.useCase.fetchMissionList(type: .all)
+        }
     }
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#74

## 🌱 PR Point
뷰윌어피어에서 미션 리스트 fetch 기능 구현

RxSwift처럼 뷰 라이프 사이클에 편하게 접근할 수 있는 방법이 없더라구요...!
그래서 combine으로 구현할 수 있는 방법에 대해 생각해봤는데 베이스뷰컨을 만들거나, RxSwift 내부 구현을 따와서 하는 방법밖에 안떠오르네요...! 베이스뷰컨은 효용이 클 것 같지 않고 Rx를 모방하는 것은 로드가 좀 클 것 같아서 일단 쉬운 방법으로 구현했습니다!

## 📮 관련 이슈
- Resolved: #74
