### PR TITLE
[Fix] #80 - 1차 QA - 미션 리스트 및 랭킹 레이아웃 이슈, API 라우팅 수정, 스와이프 제스쳐 추가

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
@@ -16,6 +16,7 @@ import UIKit
           
 */
 public enum ViewControllerUtils {
+    public
     static func setRootViewController(window: UIWindow, viewController: UIViewController, withAnimation: Bool) {
         if !withAnimation {
             window.rootViewController = viewController

--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/MissionListTransform.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Transform/MissionListTransform.swift
@@ -13,9 +13,18 @@ import Network
 
 public extension MissionListEntity {
     func toDomain() -> [MissionListModel] {
-        return self.map { .init(id: $0.id,
-                                title: $0.title,
-                                level: $0.level,
-                                isCompleted: $0.isCompleted) }
+        self.map {
+            if let isComplete = $0.isCompleted {
+                return .init(id: $0.id,
+                             title: $0.title,
+                             level: $0.level,
+                             isCompleted: isComplete)
+            } else {
+                return .init(id: $0.id,
+                             title: $0.title,
+                             level: $0.level,
+                             isCompleted: $0.fetchTypeHandler!)
+            }
+        }
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/PaddingLabel.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/PaddingLabel.swift
@@ -1,0 +1,38 @@
+//
+//  PaddingLabel.swift
+//  DSKit
+//
+//  Created by Junho Lee on 2023/01/07.
+//  Copyright © 2023 SOPT-Stamp-iOS. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+public class SentencePaddingLabel: UILabel {
+
+    @IBInspectable var topInset: CGFloat = 7.0
+    @IBInspectable var bottomInset: CGFloat = 7.0
+    @IBInspectable var leftInset: CGFloat = 16.0
+    @IBInspectable var rightInset: CGFloat = 16.0
+
+    public
+    override func drawText(in rect: CGRect) {
+        let insets = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    public
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + leftInset + rightInset,
+                      height: size.height + topInset + bottomInset)
+    }
+
+    public
+    override var bounds: CGRect {
+        didSet {
+            preferredMaxLayoutWidth = bounds.width - (leftInset + rightInset)
+        }
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/MissionListEntity.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Entity/MissionListEntity.swift
@@ -13,7 +13,24 @@ public struct MissionListEntityElement: Codable {
     public let title: String
     public let level: Int
     public let profileImage: [String]?
-    public let isCompleted: Bool
+    public let isCompleted: Bool?
+    public let display: Bool?
+    
+    public var fetchTypeHandler: Bool? = false
+    
+    mutating func assignCompleteFetchType(_ type: Bool) -> Self {
+        self.fetchTypeHandler = type
+        return self
+    }
 }
 
 public typealias MissionListEntity = [MissionListEntityElement]
+
+extension MissionListEntity {
+    public mutating func assignCompleteFetchType(_ type: Bool) -> Self {
+        return self.map {
+            var element = $0
+            return element.assignCompleteFetchType(type)
+        }
+    }
+}

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/MissionService.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/Service/MissionService.swift
@@ -26,10 +26,18 @@ extension DefaultMissionService: MissionService {
     }
     
     public func fetchCompleteMissionList(userId: Int) -> AnyPublisher<MissionListEntity, Error> {
-        requestObjectInCombine(MissionAPI.fetchMissionList(type: .complete, userId: userId))
+        let response: AnyPublisher<MissionListEntity, Error> = requestObjectInCombine(MissionAPI.fetchMissionList(type: .complete, userId: userId))
+        return response.map { entity in
+            var newEntity = entity
+            return newEntity.assignCompleteFetchType(true)
+        }.eraseToAnyPublisher()
     }
     
     public func fetchIncompleteMissionList(userId: Int) -> AnyPublisher<MissionListEntity, Error> {
-        requestObjectInCombine(MissionAPI.fetchMissionList(type: .incomplete, userId: userId))
+        let response: AnyPublisher<MissionListEntity, Error> = requestObjectInCombine(MissionAPI.fetchMissionList(type: .incomplete, userId: userId))
+        return response.map { entity in
+            var newEntity = entity
+            return newEntity.assignCompleteFetchType(false)
+        }.eraseToAnyPublisher()
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/Cells/MissionListCVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/Cells/MissionListCVC.swift
@@ -123,6 +123,7 @@ final class MissionListCVC: UICollectionViewCell, UICollectionViewRegisterable {
         get { return self.cellType }
         set {
             DispatchQueue.main.async {
+                self.prepareForReuse()
                 self.cellType = newValue
                 self.setUI(newValue)
                 self.setLayout()
@@ -250,10 +251,12 @@ extension MissionListCVC {
     private func prepareCell() {
         self.backgroundImageView.subviews.forEach {
             $0.removeFromSuperview()
+            $0.snp.removeConstraints()
         }
         
         self.subviews.forEach {
             $0.removeFromSuperview()
+            $0.snp.removeConstraints()
         }
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -104,8 +104,8 @@ public class MissionListVC: UIViewController {
         super.viewDidLoad()
         self.setUI()
         self.setLayout()
-        self.changeRootViewController()
         self.setDelegate()
+        self.setGesture()
         self.registerCells()
         self.setDataSource()
         self.bindViews()
@@ -224,15 +224,25 @@ extension MissionListVC {
 
 extension MissionListVC {
     
-    private func changeRootViewController() {
-        guard let uWindow = self.view.window else { return }
-        uWindow.rootViewController = self
-        uWindow.makeKey()
-        UIView.transition(with: uWindow, duration: 0.5, options: [.transitionCrossDissolve], animations: {}, completion: nil)
-    }
-    
     private func setDelegate() {
         missionListCollectionView.delegate = self
+    }
+
+    private func setGesture() {
+        let swipeGesture = UIPanGestureRecognizer(target: self, action: #selector(swipeBack(_:)))
+        swipeGesture.delegate = self
+        self.missionListCollectionView.addGestureRecognizer(swipeGesture)
+    }
+    
+    @objc
+    private func swipeBack(_ sender: UIPanGestureRecognizer) {
+        let velocity = sender.velocity(in: missionListCollectionView)
+        let velocityMinimum: CGFloat = 1000
+        guard let navigation = self.navigationController else { return }
+        if velocity.x >= velocityMinimum && navigation.viewControllers.count >= 2 {
+            self.missionListCollectionView.isScrollEnabled = false
+            self.navigationController?.popViewController(animated: true)
+        }
     }
     
     private func registerCells() {
@@ -308,7 +318,7 @@ extension MissionListVC: UICollectionViewDelegate {
 }
 
 extension MissionListVC: UIGestureRecognizerDelegate {
-    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return false
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -136,7 +136,7 @@ extension MissionListVC {
         }
         
         missionListCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom).offset(30)
+            make.top.equalTo(naviBar.snp.bottom).offset(20.adjustedH)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
         }
@@ -155,7 +155,7 @@ extension MissionListVC {
             self.view.addSubview(sentenceLabel)
             
             sentenceLabel.snp.makeConstraints { make in
-                make.top.equalTo(naviBar.snp.bottom).offset(16.adjustedH)
+                make.top.equalTo(naviBar.snp.bottom).offset(10.adjustedH)
                 make.leading.trailing.equalToSuperview().inset(20.adjusted)
                 make.height.equalTo(64.adjustedH)
             }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -63,8 +63,8 @@ public class MissionListVC: UIViewController {
         return menuItems
     }()
     
-    private lazy var sentenceLabel: UILabel = {
-        let lb = UILabel()
+    private lazy var sentenceLabel: SentencePaddingLabel = {
+        let lb = SentencePaddingLabel()
         if case let .ranking(_, sentence, _) = sceneType {
             lb.text = sentence
         }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -199,8 +199,7 @@ extension MissionListVC {
     
     private func bindViewModels() {
         
-        let input = MissionListViewModel.Input(viewDidLoad: Driver.just(()),
-                                               viewWillAppear: viewWillAppear.asDriver(),
+        let input = MissionListViewModel.Input(viewWillAppear: viewWillAppear.asDriver(),
                                                missionTypeSelected: missionTypeMenuSelected.asDriver())
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -76,7 +76,7 @@ extension MissionListViewModel {
     private func fetchMissionList() {
         switch self.missionListsceneType {
         case .ranking(_, _, let userId):
-            self.useCase.fetchOtherUserMissionList(type: .all, userId: userId)
+            self.useCase.fetchOtherUserMissionList(type: .complete, userId: userId)
         default:
             self.useCase.fetchMissionList(type: .all)
         }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -16,6 +16,13 @@ import Domain
 public enum MissionListSceneType {
     case `default`
     case ranking(userName: String, sentence: String, userId: Int)
+    
+    var isRankingView: Bool {
+        switch self {
+        case .default: return false
+        case .ranking: return true
+        }
+    }
 }
 
 public class MissionListViewModel: ViewModelType {
@@ -27,7 +34,6 @@ public class MissionListViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-        let viewDidLoad: Driver<Void>
         let viewWillAppear: Driver<Void>
         let missionTypeSelected: Driver<MissionListFetchType>
     }
@@ -51,20 +57,14 @@ extension MissionListViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
-        input.viewDidLoad
-            .withUnretained(self)
-            .sink { owner, _ in
-                owner.fetchMissionList()
-            }.store(in: cancelBag)
-        
         input.viewWillAppear
-            .dropFirst()
             .withUnretained(self)
             .sink { owner, _ in
                 owner.fetchMissionList()
             }.store(in: cancelBag)
         
         input.missionTypeSelected
+            .dropFirst()
             .withUnretained(self)
             .sink { owner, fetchType in
                 owner.useCase.fetchMissionList(type: fetchType)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -51,8 +51,6 @@ public class RankingVC: UIViewController {
         bt.layer.cornerRadius = 27.adjustedH
         bt.backgroundColor = DSKitAsset.Colors.purple300.color
         bt.setTitle("내 랭킹 보기", for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
         bt.tintColor = .white
         bt.titleLabel?.setTypoStyle(.h2)
         return bt

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/RankingScene/VC/RankingVC.swift
@@ -63,6 +63,7 @@ public class RankingVC: UIViewController {
         self.setUI()
         self.setLayout()
         self.setDelegate()
+        self.setGesture()
         self.registerCells()
         self.bindViewModels()
         self.setDataSource()
@@ -142,6 +143,22 @@ extension RankingVC {
         rankingCollectionView.delegate = self
     }
     
+    private func setGesture() {
+        let swipeGesture = UIPanGestureRecognizer(target: self, action: #selector(swipeBack(_:)))
+        swipeGesture.delegate = self
+        self.rankingCollectionView.addGestureRecognizer(swipeGesture)
+    }
+    
+    @objc
+    private func swipeBack(_ sender: UIPanGestureRecognizer) {
+        let velocity = sender.velocity(in: rankingCollectionView)
+        let velocityMinimum: CGFloat = 1000
+        if velocity.x >= velocityMinimum {
+            self.rankingCollectionView.isScrollEnabled = false
+            self.navigationController?.popViewController(animated: true)
+        }
+    }
+    
     private func registerCells() {
         RankingChartCVC.register(target: rankingCollectionView)
         RankingListCVC.register(target: rankingCollectionView)
@@ -203,5 +220,11 @@ extension RankingVC: UICollectionViewDelegate {
                                                                                    sentence: item.sentence,
                                                                                    userId: item.userId))
         self.navigationController?.pushViewController(otherUserMissionListVC, animated: true)
+    }
+}
+
+extension RankingVC: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SplashScene/VC/SplashVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SplashScene/VC/SplashVC.swift
@@ -67,14 +67,14 @@ extension SplashVC {
     
     private func setDelay() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            
-            var nextVC = UIViewController()
-            if UserDefaultKeyList.Auth.userId != nil {
-                nextVC = self.factory.makeMissionListVC(sceneType: .default)
+            let needAuth = UserDefaultKeyList.Auth.userId == nil
+            if !needAuth {
+                let navigation = UINavigationController(rootViewController: self.factory.makeMissionListVC(sceneType: .default))
+                ViewControllerUtils.setRootViewController(window: self.view.window!, viewController: navigation, withAnimation: true)
             } else {
-                nextVC = self.factory.makeOnboardingVC()
+                let nextVC = self.factory.makeOnboardingVC()
+                self.navigationController?.pushViewController(nextVC, animated: true)
             }
-            self.navigationController?.pushViewController(nextVC, animated: true)
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#80

## 🌱 PR Point

1. 미션 리스트 API 수정 -> 잘못된 API 콜을 하던 부분 수정했습니다.
2. 내 랭킹 보기 버튼 이미지 삭제
3. 미션리스트 한마디 라벨에 padding 추가
4. 다른 사람 완료 미션 조회 가능하도록 수정
5. 미션 리스트 스탬프 크기 고정
6. 미션, 랭킹 뷰 스와이프 백 제스쳐 추가
7. 스플래시에서 루트뷰컨 변경 -> 미션리스트에서 pop되고 있는 현상 방지
8. 미션 리스트 탑 오프셋 수정

## 📮 관련 이슈
- Resolved: #80 
