### PR TITLE
[Fix] #87 - 회원가입 및 비밀번호 변경 뷰 1차 QA 반영

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -66,6 +66,7 @@ public struct I18N {
         public static let validNickname = "사용 가능한 이름입니다."
         public static let duplicatedNickname = "사용 중인 이름입니다."
         public static let validEmail = "사용 가능한 이메일입니다."
+        public static let duplicatedEmail = "사용 중인 이메일입니다."
         public static let invalidEmailForm = "잘못된 이메일 형식입니다."
         public static let invalidPasswordForm = "영문, 숫자, 특수문자 포함 8-15자로 입력해주세요."
         public static let passwordNotAccord = "비밀번호가 일치하지 않습니다."

--- a/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-Stamp-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -71,6 +71,7 @@ public struct I18N {
         public static let invalidPasswordForm = "영문, 숫자, 특수문자 포함 8-15자로 입력해주세요."
         public static let passwordNotAccord = "비밀번호가 일치하지 않습니다."
         public static let signUpComplete = "가입 완료"
+        public static let signUpFail = "회원가입 실패"
         public static let welcome = "SOPTAMP에 오신 것을 환영합니다"
         public static let start = "시작하기"
     }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/SignUpUseCase.swift
@@ -12,7 +12,9 @@ import Combine
 import Core
 
 public protocol SignUpUseCase {
+    func resetNicknameValidation()
     func checkNickname(nickname: String)
+    func resetEmailValidation()
     func checkEmail(email: String)
     func checkPassword(password: String)
     func checkAccordPassword(firstPassword: String, secondPassword: String)
@@ -47,6 +49,14 @@ public class DefaultSignUpUseCase {
 }
 
 extension DefaultSignUpUseCase: SignUpUseCase {
+    public func resetNicknameValidation() {
+        self.isValidForm.send(false)
+    }
+    
+    public func resetEmailValidation() {
+        self.isValidForm.send(false)
+    }
+    
     public func checkNickname(nickname: String) {
         let nicknameRegEx = "[가-힣ㄱ-ㅣA-Za-z\\s]{1,10}"
         let pred = NSPredicate(format: "SELF MATCHES %@", nicknameRegEx)

--- a/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -49,7 +49,7 @@ extension AuthAPI: BaseAPI {
         case .getNicknameAvailable, .getEmailAvailable:
             return .get
         case .changePassword, .changeNickname:
-            return .put
+            return .patch
         }
     }
     

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SettingScene/PasswordSettingScene/VC/PasswordChangeVC.swift
@@ -30,8 +30,7 @@ public class PasswordChangeVC: UIViewController {
         .setTitle(I18N.Setting.passwordEdit)
         .setTitleTypoStyle(.h1)
     
-    private lazy var passwordTextFieldView = CustomTextFieldView(type: .title)
-        .setTitle(I18N.SignUp.password)
+    private lazy var passwordTextFieldView = CustomTextFieldView(type: .plain)
         .setTextFieldType(.password)
         .setPlaceholder(I18N.SignUp.passwordTextFieldPlaceholder)
         .setAlertDelegate(passwordCheckTextFieldView)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpCompleteVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpCompleteVC.swift
@@ -48,13 +48,25 @@ public class SignUpCompleteVC: UIViewController {
         super.viewDidLoad()
         self.setUI()
         self.setLayout()
+        self.setAddTarget()
     }
 }
 
 // MARK: - Methods
 
 extension SignUpCompleteVC {
-    
+    private func setAddTarget() {
+        startButton.addTarget(self, action: #selector(startButtonDidTap), for: .touchUpInside)
+    }
+}
+
+// MARK: - @objc Function
+
+extension SignUpCompleteVC {
+    @objc private func startButtonDidTap() {
+        let missionListVC = self.factory.makeMissionListVC(sceneType: .default)
+        self.navigationController?.pushViewController(missionListVC, animated: true)
+    }
 }
 
 // MARK: - UI & Layout

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
@@ -250,7 +250,9 @@ extension SignUpVC {
     
     private func presentSignUpCompleteView() {
         let signUpCompleteVC = factory.makeSignUpCompleteVC()
-        signUpCompleteVC.modalPresentationStyle = .fullScreen
-        self.present(signUpCompleteVC, animated: true)
+        let nav = UINavigationController(rootViewController: signUpCompleteVC)
+        nav.modalPresentationStyle = .fullScreen
+        nav.navigationBar.isHidden = true
+        self.present(nav, animated: true)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
@@ -138,7 +138,7 @@ extension SignUpVC {
         output.signUpSuccessed
             .sink { [weak self] isSuccess in
                 guard let self = self else { return }
-                isSuccess ? self.presentSignUpCompleteView() : print("회원가입 실패")
+                isSuccess ? self.presentSignUpCompleteView() : self.showToast(message: I18N.SignUp.signUpFail)
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/VC/SignUpVC.swift
@@ -97,7 +97,9 @@ extension SignUpVC {
             .asDriver()
         
         let input = SignUpViewModel.Input(
+            nicknameTextChanged: nickNameTextFieldView.textChanged,
             nicknameCheckButtonTapped: nickNameTextFieldView.rightButtonTapped,
+            emailTextChanged: emailTextFieldView.textChanged,
             emailCheckButtonTapped: emailTextFieldView.rightButtonTapped,
             passwordTextChanged: passwordTextFieldView.textChanged,
             passwordCheckTextChanged: passwordCheckTextFieldView.textChanged,

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
@@ -100,10 +100,17 @@ extension SignUpViewModel {
         useCase.isEmailFormValid.sink { event in
             print("SignUpViewModel - completion: \(event)")
         } receiveValue: { isEmailValid in
-            output.emailAlert.send(isEmailValid ?
-                .valid(text: I18N.SignUp.validEmail) : .invalid(text: I18N.SignUp.invalidEmailForm))
+            if !isEmailValid {
+                output.emailAlert.send(.invalid(text: I18N.SignUp.invalidEmailForm))
+            }
         }.store(in: cancelBag)
         
+        useCase.isDuplicateEmail.sink { event in
+            print("SignUpViewModel - completion: \(event)")
+        } receiveValue: { isDuplicateEmail in
+            output.emailAlert.send(isDuplicateEmail ? .invalid(text: I18N.SignUp.duplicatedEmail) : .valid(text: I18N.SignUp.validEmail))
+        }.store(in: cancelBag)
+
         useCase.isPasswordFormValid.combineLatest(useCase.isAccordPassword).sink { event in
             print("SignUpViewModel - completion: \(event)")
         } receiveValue: { (isFormValid, isAccordValid) in

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
@@ -26,7 +26,9 @@ public class SignUpViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
+        let nicknameTextChanged: Driver<String?>
         let nicknameCheckButtonTapped: Driver<String?>
+        let emailTextChanged: Driver<String?>
         let emailCheckButtonTapped: Driver<String?>
         let passwordTextChanged: Driver<String?>
         let passwordCheckTextChanged: Driver<String?>
@@ -56,10 +58,22 @@ extension SignUpViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
+        input.nicknameTextChanged
+            .compactMap({ $0 })
+            .sink { _ in
+                self.useCase.resetNicknameValidation()
+            }.store(in: self.cancelBag)
+        
         input.nicknameCheckButtonTapped
             .compactMap({ $0 })
             .sink { nickname in
                 self.useCase.checkNickname(nickname: nickname)
+            }.store(in: self.cancelBag)
+        
+        input.emailTextChanged
+            .compactMap({ $0 })
+            .sink { _ in
+                self.useCase.resetEmailValidation()
             }.store(in: self.cancelBag)
         
         input.emailCheckButtonTapped

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootVC = ModuleFactory.shared.makeSplashVC()
+        let rootVC = ModuleFactory.shared.makeSignUpVC()
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#87

## 🌱 PR Point
- 회원 가입 완료 후 메인페이지로 화면 전환
- 이메일 중복일 때 텍스트 안내
- 닉네임, 이메일 텍스트 필드 변경 시 가입하기 버튼 비활성화
- 비밀번호 변경뷰에서 비밀번호 텍스트 제거

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- qa 43번 사항인 _회원가입의 비밀번호 입력 시 @ 특수문자 입력하면 다음 텍스트 필드로 넘어가는 문제 해결_ 은 슬랙에 질문 올린거 답변 달리면 따로 이슈 파서 해결하겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #87 
