### PR TITLE
[Fix] #86 - 랭킹에서 다른 사람 스탬프 상세 조회 연결, userId 분기처리

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-Stamp-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -14,7 +14,7 @@ import Network
 
 public class ListDetailRepository {
     
-    private let userId: Int = UserDefaultKeyList.Auth.userId ?? 0
+    private let userId: Int = UserDefaultKeyList.Auth.userId ?? 1
     private let stampService: StampService
     private let cancelBag = CancelBag()
 
@@ -24,8 +24,9 @@ public class ListDetailRepository {
 }
 
 extension ListDetailRepository: ListDetailRepositoryInterface {
-    public func fetchListDetail(missionId: Int) -> Driver<ListDetailModel> {
-        return stampService.fetchStampListDetail(userId: userId, missionId: missionId)
+    public func fetchListDetail(missionId: Int, userId: Int?) -> Driver<ListDetailModel> {
+        let targetUserId = userId ?? (self.userId)
+        return stampService.fetchStampListDetail(userId: targetUserId, missionId: missionId)
             .map { $0.toDomain() }
             .asDriver()
     }

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
@@ -11,7 +11,7 @@ import Core
 import Combine
 
 public protocol ListDetailRepositoryInterface {
-    func fetchListDetail(missionId: Int) -> Driver<ListDetailModel>
+    func fetchListDetail(missionId: Int, userId: Int?) -> Driver<ListDetailModel>
     func postStamp(missionId: Int, stampData: [Any]) -> Driver<ListDetailModel>
     func putStamp(missionId: Int, stampData: [Any]) -> Driver<Int>
     func deleteStamp(stampId: Int) -> Driver<Bool>

--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -12,6 +12,7 @@ import Combine
 
 public protocol ListDetailUseCase {
     func fetchListDetail(missionId: Int)
+    func fetchOtherListDetail(userId: Int, missionId: Int)
     func postStamp(missionId: Int, stampData: ListDetailRequestModel)
     func putStamp(missionId: Int, stampData: ListDetailRequestModel)
     func deleteStamp(stampId: Int)
@@ -36,7 +37,14 @@ public class DefaultListDetailUseCase {
 
 extension DefaultListDetailUseCase: ListDetailUseCase {
     public func fetchListDetail(missionId: Int) {
-        repository.fetchListDetail(missionId: missionId)
+        repository.fetchListDetail(missionId: missionId, userId: nil)
+            .sink { model in
+                self.listDetailModel.send(model)
+            }.store(in: self.cancelBag)
+    }
+    
+    public func fetchOtherListDetail(userId: Int, missionId: Int) {
+        repository.fetchListDetail(missionId: missionId, userId: userId)
             .sink { model in
                 self.listDetailModel.send(model)
             }.store(in: self.cancelBag)

--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomNavigationBar.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomNavigationBar.swift
@@ -77,6 +77,10 @@ extension CustomNavigationBar {
         }
     }
     
+    public func hideRightButton(_ isHidden: Bool = true) {
+        self.rightButton.isHidden = isHidden
+    }
+    
     private func setAddTarget() {
         self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
     }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -421,6 +421,10 @@ extension ListDetailVC {
             self.dateLabel.isHidden = false
             self.missionImageView.isUserInteractionEnabled = false
         }
+        
+        if viewModel.otherUserId != nil {
+            self.naviBar.hideRightButton()
+        }
     }
     
     private func setDefaultUI() {

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -27,6 +27,7 @@ public class ListDetailViewModel: ViewModelType {
     public var missionId: Int!
     public var missionTitle: String!
     public var stampId: Int!
+    public var otherUserId: Int!
   
     // MARK: - Inputs
     
@@ -48,12 +49,13 @@ public class ListDetailViewModel: ViewModelType {
     
     // MARK: - init
   
-    public init(useCase: ListDetailUseCase, sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String) {
+    public init(useCase: ListDetailUseCase, sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String, otherUserId: Int?) {
         self.useCase = useCase
         self.sceneType = sceneType
         self.starLevel = starLevel
         self.missionId = missionId
         self.missionTitle = missionTitle
+        self.otherUserId = otherUserId
     }
 }
 
@@ -67,7 +69,11 @@ extension ListDetailViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 if owner.sceneType == .completed {
-                    owner.useCase.fetchListDetail(missionId: owner.missionId)
+                    if let otherUserId = self.otherUserId {
+                        owner.useCase.fetchOtherListDetail(userId: otherUserId, missionId: owner.missionId)
+                    } else {
+                        owner.useCase.fetchListDetail(missionId: owner.missionId)
+                    }
                 }
             }.store(in: cancelBag)
         

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/VC/MissionListVC.swift
@@ -289,7 +289,7 @@ extension MissionListVC: UICollectionViewDelegate {
             case .default:
                 return true
             case .ranking:
-                return false
+                return true
             }
         default:
             return false
@@ -309,7 +309,8 @@ extension MissionListVC: UICollectionViewDelegate {
             let detailVC = factory.makeListDetailVC(sceneType: sceneType,
                                                     starLevel: starLevel,
                                                     missionId: model.id,
-                                                    missionTitle: model.title)
+                                                    missionTitle: model.title,
+                                                    otherUserId: viewModel.otherUserId)
             self.navigationController?.pushViewController(detailVC, animated: true)
         default:
             return

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -30,6 +30,7 @@ public class MissionListViewModel: ViewModelType {
     private let useCase: MissionListUseCase
     private var cancelBag = CancelBag()
     public var missionListsceneType: MissionListSceneType!
+    public var otherUserId: Int?
     
     // MARK: - Inputs
     
@@ -76,6 +77,7 @@ extension MissionListViewModel {
     private func fetchMissionList() {
         switch self.missionListsceneType {
         case .ranking(_, _, let userId):
+            self.otherUserId = userId
             self.useCase.fetchOtherUserMissionList(type: .complete, userId: userId)
         default:
             self.useCase.fetchMissionList(type: .all)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ModuleFactoryInterface.swift
@@ -23,7 +23,7 @@ public protocol ModuleFactoryInterface {
     // MARK: - Main Flow
     
     func makeMissionListVC(sceneType: MissionListSceneType) -> MissionListVC
-    func makeListDetailVC(sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String) -> ListDetailVC
+    func makeListDetailVC(sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String, otherUserId: Int?) -> ListDetailVC
     func makeMissionCompletedVC(starLevel: StarViewLevel) -> MissionCompletedVC
     func makeRankingVC() -> RankingVC
     

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/Application/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: scene.coordinateSpace.bounds)
         window?.windowScene = scene
-        let rootVC = ModuleFactory.shared.makeSignUpVC()
+        let rootVC = ModuleFactory.shared.makeSplashVC()
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()
     }

--- a/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
+++ b/SOPT-Stamp-iOS/Projects/SOPT-Stamp-iOS/Sources/ModuleFactory/ModuleFactory.swift
@@ -86,10 +86,10 @@ extension ModuleFactory: ModuleFactoryInterface {
         return missionListVC
     }
     
-    public func makeListDetailVC(sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String) -> ListDetailVC {
+    public func makeListDetailVC(sceneType: ListDetailSceneType, starLevel: StarViewLevel, missionId: Int, missionTitle: String, otherUserId: Int?) -> ListDetailVC {
         let repository = ListDetailRepository(service: stampService)
         let useCase = DefaultListDetailUseCase(repository: repository)
-        let viewModel = ListDetailViewModel(useCase: useCase, sceneType: sceneType, starLevel: starLevel, missionId: missionId, missionTitle: missionTitle)
+        let viewModel = ListDetailViewModel(useCase: useCase, sceneType: sceneType, starLevel: starLevel, missionId: missionId, missionTitle: missionTitle, otherUserId: otherUserId)
         let listDetailVC = ListDetailVC()
         listDetailVC.viewModel = viewModel
         listDetailVC.factory = self


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#86

## 🌱 PR Point
- 랭킹뷰에서 다른 사람 스탬프 상세 조회 연결
- MissionList에서 ListDetail로 넘어갈때, 랭킹에서 넘어오는 경우 userId 전달
- UseCase에서 userId 유무에 따라 구분
- CustomNavigationBar에 hideRightButton 메소드 추가

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
MissionList에서 ListDetail로 넘어갈때 userId가 필요한데, 
그래서 MissionListViewModel 안에 otherUserId를 넣어서 내가 아닌 다른 유저 조회인 경우 사용할 수 있도록 해뒀습니다

<img width="500" alt="스크린샷 2023-01-08 오후 3 01 48" src="https://user-images.githubusercontent.com/81167570/211182790-0e4995dc-68c5-4437-8209-5c488fa96c93.png">
이 부분은 엄 MissionListViewModel 안에 되도록 바로 데이터를 저장하지 않으려구 작업하신 것 같은데, 
일단 이슈 먼저 해결하려구 public으로 otherUserId를 추가해둔거라 추후에 수정이 필요하다 느껴지면 수정해주셔두 될 것 같습니다. 🙇‍♀️


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 랭킹에서 글 상세 메인에서 글 상세  | ![ezgif com-gif-maker (97)](https://user-images.githubusercontent.com/81167570/211182821-27b276e2-8a1e-4b4b-a33d-517903108a9b.gif)|

## 📮 관련 이슈
- Resolved: #86 
