### PR TITLE
[Fix] #96 - 회원가입뷰 비밀번호 경고 로직 수정

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
+++ b/SOPT-Stamp-iOS/Projects/Modules/DSKit/Sources/Components/CustomTextFieldView.swift
@@ -110,6 +110,7 @@ public enum TextFieldAlertType {
 
 public protocol CustomTextFieldViewAlertDelegate: AnyObject {
     func changeAlertLabelText(_ alertText: String)
+    func changeAlertLabelTextColor(state: TextFieldViewState)
 }
 
 public class CustomTextFieldView: UIView {
@@ -263,6 +264,7 @@ extension CustomTextFieldView {
     public func changeAlertLabelText(_ alertText: String) {
         if let alertDelegate = alertDelegate {
             alertDelegate.changeAlertLabelText(alertText)
+            
             return
         }
         self.alertlabel.text = alertText
@@ -281,6 +283,7 @@ extension CustomTextFieldView {
         }
         
         if state == .confirmAlert || state == .warningAlert {
+            alertDelegate?.changeAlertLabelTextColor(state: state)
             alertlabel.textColor = state.alertTextColor
         }
     }
@@ -508,7 +511,7 @@ extension CustomTextFieldView: UITextFieldDelegate {
 
 extension CustomTextFieldView: CustomTextFieldViewAlertDelegate {
     /// 경고 문구 라벨의 컬러 설정
-    public func changeAlertLabelTextColor(toWarning: Bool) {
-        alertlabel.textColor = toWarning ? SoptampColor.error300.color : SoptampColor.access300.color
+    public func changeAlertLabelTextColor(state: TextFieldViewState) {
+        alertlabel.textColor = state.alertTextColor
     }
 }

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SignUpScene/ViewModel/SignUpViewModel.swift
@@ -22,6 +22,9 @@ public class SignUpViewModel: ViewModelType {
     
     private let useCase: SignUpUseCase
     private var cancelBag = CancelBag()
+    
+    private var passwordText: String = ""
+    private var passwordCheckText: String = ""
   
     // MARK: - Inputs
     
@@ -85,6 +88,7 @@ extension SignUpViewModel {
         input.passwordTextChanged
             .compactMap({ $0 })
             .sink { password in
+                self.passwordText = password
                 self.useCase.checkPassword(password: password)
             }.store(in: self.cancelBag)
         
@@ -92,6 +96,7 @@ extension SignUpViewModel {
             .compactMap({ $0 })
             .combineLatest(input.passwordCheckTextChanged.compactMap({ $0 }))
             .sink { (firstPassword, secondPassword) in
+                self.passwordCheckText = secondPassword
                 self.useCase.checkAccordPassword(firstPassword: firstPassword, secondPassword: secondPassword)
             }.store(in: self.cancelBag)
         
@@ -132,7 +137,9 @@ extension SignUpViewModel {
                 output.passwordAlert.send(.invalid(text: I18N.SignUp.invalidPasswordForm))
             } else if isFormValid && !isAccordValid {
                 output.passwordAlert.send(.valid(text: ""))
-                output.passwordAccordAlert.send(.invalid(text: (I18N.SignUp.passwordNotAccord)))
+                if !self.passwordCheckText.isEmpty {
+                    output.passwordAccordAlert.send(.invalid(text: (I18N.SignUp.passwordNotAccord)))
+                }
             } else {
                 output.passwordAlert.send(.valid(text: ""))
                 output.passwordAccordAlert.send(.valid(text: ""))


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#96

## 🌱 PR Point
- QA 43번 사항을 고쳤습니다.
- 회원가입 뷰에서 첫 번째 비밀번호 텍스트 필드를 올바르게 입력하면 동시에 비밀번호 확인 텍스트 필드에 경고 문구와 배경색이 바뀌는 현상을 수정했습니다..!

## 📌 참고 사항

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|비밀번호 로직 수정|  ![Simulator Screen Recording - iPhone 13 mini - 2023-01-09 at 00 09 31](https://user-images.githubusercontent.com/77267404/211204012-f6dfe531-32e6-4336-a55d-4163ea6b26c0.gif)  |

## 📮 관련 이슈
- Resolved: #96 
