### PR TITLE
[Fix] #100 - 스탬프 등록, 삭제, 수정 실패시 에러 처리

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-Stamp-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -53,6 +53,7 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
     public func postStamp(missionId: Int, stampData: ListDetailRequestModel) {
         let data = [stampData.imgURL as Any, stampData.content] as [Any]
         repository.postStamp(missionId: missionId, stampData: data)
+            .replaceError(with: ListDetailModel(image: "", content: "", date: "", stampId: 0))
             .sink { event in
                 print("completion: \(event)")
             } receiveValue: { model in
@@ -63,13 +64,15 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
     public func putStamp(missionId: Int, stampData: ListDetailRequestModel) {
         let data = [stampData.imgURL as Any, stampData.content] as [Any]
         repository.putStamp(missionId: missionId, stampData: data)
+            .replaceError(with: -1)
             .sink { result in
-                self.editSuccess.send(true)
+                self.editSuccess.send(result == -1 ? false: true)
             }.store(in: self.cancelBag)
     }
     
     public func deleteStamp(stampId: Int) {
         repository.deleteStamp(stampId: stampId)
+            .replaceError(with: false)
             .sink { success in
                 self.deleteSuccess.send(success)
             }.store(in: self.cancelBag)

--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -163,18 +163,30 @@ extension ListDetailVC {
         output.$listDetailModel
             .compactMap { $0 }
             .sink { model in
-                self.setData(model)
-                if self.sceneType == .none {
-                    self.presentCompletedVC(level: self.starLevel)
+                if model.image.isEmpty {
+                    let networkAlert = self.factory.makeNetworkAlertVC()
+                    self.present(networkAlert, animated: true) {
+                        self.backgroundDimmerView.removeFromSuperview()
+                    }
+                } else {
+                    self.setData(model)
+                    if self.sceneType == .none {
+                        self.presentCompletedVC(level: self.starLevel)
+                    }
+                    self.sceneType = .completed
+                    self.reloadData(self.sceneType)
                 }
-                self.sceneType = .completed
-                self.reloadData(self.sceneType)
             }.store(in: self.cancelBag)
         
         output.editSuccessed
             .sink { successed in
-                self.reloadData(.completed)
-                self.showToast(message: I18N.ListDetail.editCompletedToast)
+                if successed {
+                    self.reloadData(.completed)
+                    self.showToast(message: I18N.ListDetail.editCompletedToast)
+                } else {
+                    let networkAlert = self.factory.makeNetworkAlertVC()
+                    self.present(networkAlert, animated: true)
+                }
             }.store(in: self.cancelBag)
         
         output.showDeleteAlert
@@ -191,7 +203,8 @@ extension ListDetailVC {
                 if success {
                     self.navigationController?.popViewController(animated: true)
                 } else {
-                    self.makeAlert(title: I18N.Default.error, message: I18N.Default.networkError)
+                    let networkAlert = self.factory.makeNetworkAlertVC()
+                    self.present(networkAlert, animated: true)
                 }
             }.store(in: self.cancelBag)
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#100

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 지금은 이미지 용량 엄청 큰 것도 다 잘 올라가고, 압축을 1로 해도 시간만 쪼금 길어질 뿐이구 잘 올라가서 .. 
StampAPI에서 경로나 header 부분 틀리게 해두고 테스트 했습니다
- 에러 종류를 구체적으로 구분할 수가 없어서, 정상적이지 않은 경우 모두 networkAlert를 보이도록 했습니다
- post 스크린샷에서 띡 하고 덜 어두워지는 그것은 alertVC의 백그라운드인데 .. 네 .. 🫠

참고자료
https://taehoon95.tistory.com/167
https://icksw.tistory.com/288


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| post  | ![ezgif com-gif-maker - 2023-01-10T221042 114](https://user-images.githubusercontent.com/81167570/211560709-ed32e5e0-5aae-4c31-a83b-cbf493adfe50.gif) |
| delete | <img src="https://user-images.githubusercontent.com/81167570/211560828-4d5d2ade-f4da-47e4-95c1-9d607d8b8306.jpeg" width=300 /> |

## 📮 관련 이슈
- Resolved: #100 
