### PR TITLE
[Fix] #109 - 스탬프 등록시 뒤에 이미지가 업로드 되는 모습이 보이지 않도록 수정

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -210,8 +210,10 @@ extension ListDetailVC {
     }
     
     private func setData(_ model: ListDetailModel) {
-        if let imageURL = URL(string: model.image) {
-            self.missionImageView.kf.setImage(with: imageURL)
+        if self.sceneType != .none {
+            if let imageURL = URL(string: model.image) {
+                self.missionImageView.kf.setImage(with: imageURL)
+            }
         }
         self.textView.text = model.content
         self.dateLabel.text = model.date


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#109 

## 🌱 PR Point
스탬프 등록시 뒤에 이미지가 업로드 되는 모습이 보이지 않도록 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
스탬프 등록 성공 후 sceneType이 none에서 completed로 변환될 때는 setData에서 이미지가 업로드되지 않고 
이전에 올렸던 이미지를 그대로 유지하도록 했습니다


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #109 
