### PR TITLE
[Fix] #117 - 공지 팝업 수정

### DIFF
--- a/SOPT-Stamp-iOS/Projects/Presentation/Sources/SplashScene/VC/NoticePopUpVC.swift
+++ b/SOPT-Stamp-iOS/Projects/Presentation/Sources/SplashScene/VC/NoticePopUpVC.swift
@@ -48,9 +48,9 @@ public class NoticePopUpVC: UIViewController {
         $0.layer.cornerRadius = 4
     }
     
-    private let noticeContentLabel = UILabel().then {
+    private let noticeContentTextView = UITextView().then {
         $0.text = I18N.Notice.notice
-        $0.numberOfLines = 0
+        $0.isEditable = false
         $0.font = .caption3
         $0.textColor = DSKitAsset.Colors.gray900.color
         $0.textAlignment = .center
@@ -100,7 +100,7 @@ extension NoticePopUpVC {
     
     public func setData(type: NoticePopUpType, content: String) {
         self.type = type
-        self.noticeContentLabel.text = content
+        self.noticeContentTextView.text = content
         self.changeLayout(with: type)
     }
     
@@ -148,7 +148,7 @@ extension NoticePopUpVC {
     
     private func setLayout() {
         view.addSubviews(backgroundDimmerView, noticeView)
-        noticeView.addSubviews(noticeTitleLabel, noticeContentLabel, buttonStackView)
+        noticeView.addSubviews(noticeTitleLabel, noticeContentTextView, buttonStackView)
         
         backgroundDimmerView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
@@ -164,13 +164,14 @@ extension NoticePopUpVC {
             make.height.equalTo(34)
         }
         
-        noticeContentLabel.snp.makeConstraints { make in
+        noticeContentTextView.snp.makeConstraints { make in
             make.top.equalTo(noticeTitleLabel.snp.bottom).offset(12)
+            make.height.equalTo(283)
             make.leading.trailing.equalToSuperview().inset(24)
         }
         
         buttonStackView.snp.makeConstraints { make in
-            make.top.equalTo(noticeContentLabel.snp.bottom).offset(12)
+            make.top.equalTo(noticeContentTextView.snp.bottom).offset(12)
             make.leading.trailing.equalToSuperview().inset(24)
             make.bottom.equalToSuperview().inset(24)
         }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#117

## 🌱 PR Point
- 앱 실행 시 발생하는 공지 팝업의 공지 내용 UI를 UILabel에서 UITextView로 변경했습니다.
- 해당 TextView의 isEditable을 false로 설정했습니다.
- 공지 내용이 짧더라도 일정한 높이를 유지하도록 했습니다.
- SplashVC의 viewDidLoad 실행되고 1초 후에 바인딩이 이루어져 서버 통신을 하도록 했습니다. (기획 요청 사항) 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 건강하세요

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|공지 팝업|![Simulator Screen Recording - iPhone 13 mini - 2023-01-26 at 18 09 40](https://user-images.githubusercontent.com/77267404/214797952-241272b3-fe4c-4ff5-a68f-603b6ea47df7.gif)|

## 📮 관련 이슈
- Resolved: #117 
