### PR TITLE
[Setting] #126 - Inject 의존성 추가

### DIFF
--- a/SOPT-Stamp-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/SOPT-Stamp-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -18,6 +18,7 @@ public extension TargetDependency.SPM {
     static let Moya = TargetDependency.external(name: "Moya")
     static let CombineMoya = TargetDependency.external(name: "CombineMoya")
     static let FLEX = TargetDependency.external(name: "FLEX")
+    static let Inject = TargetDependency.external(name: "Inject")
     static let Nimble = TargetDependency.external(name: "Nimble")
     static let Quick = TargetDependency.external(name: "Quick")
     static let lottie = TargetDependency.external(name: "Lottie")

--- a/SOPT-Stamp-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
+++ b/SOPT-Stamp-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
@@ -43,5 +43,19 @@ public extension Project {
         "UILaunchStoryboardName": "LaunchScreen",
         "LSSupportsOpeningDocumentsInPlace": true,
         "UIFileSharingEnabled": true,
+        "UIApplicationSceneManifest": [
+            "UIApplicationSupportsMultipleScenes": false,
+            "UISceneConfigurations": [
+                "UIWindowSceneSessionRoleApplication": [
+                    [
+                        "UISceneConfigurationName": "Default Configuration",
+                        "UISceneDelegateClassName": "$(PRODUCT_MODULE_NAME).SceneDelegate"
+                    ],
+                ]
+            ]
+        ],
+        "NSPhotoLibraryUsageDescription": "미션과 관련된 사진을 업로드하기 위해 갤러리 권한이 필요합니다.",
+        "App Transport Security Settings": ["Allow Arbitrary Loads": true],
+        "NSAppTransportSecurity": ["NSAllowsArbitraryLoads": true],
     ]
 }

--- a/SOPT-Stamp-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/SOPT-Stamp-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -8,6 +8,19 @@
 import ProjectDescription
 
 public extension SettingsDictionary {
+    static let allLoadSettings: Self = [
+        "OTHER_LDFLAGS" : [
+            "$(inherited) -all_load",
+            "-Xlinker -interposable"
+        ]
+    ]
+    
+    static let baseSettings: Self = [
+        "OTHER_LDFLAGS" : [
+            "-Xlinker -interposable"
+        ]
+    ]
+    
     func setProductBundleIdentifier(_ value: String = "com.iOS$(BUNDLE_ID_SUFFIX)") -> SettingsDictionary {
         merging(["PRODUCT_BUNDLE_IDENTIFIER": SettingValue(stringLiteral: value)])
     }
@@ -45,12 +58,6 @@ public extension SettingsDictionary {
     }
     
     func setCodeSignManual() -> SettingsDictionary {
-        merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
-            .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
-            .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "iPhone Developer")])
-    }
-    
-    func setCodeSignManualForApp() -> SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
             .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
             .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "iPhone Developer")])

--- a/SOPT-Stamp-iOS/Tuist/Dependencies.swift
+++ b/SOPT-Stamp-iOS/Tuist/Dependencies.swift
@@ -14,6 +14,7 @@ let spm = SwiftPackageManagerDependencies([
     .remote(url: "https://github.com/devxoul/Then", requirement: .upToNextMajor(from: "2")),
     .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
     .remote(url: "https://github.com/FLEXTool/FLEX.git", requirement: .upToNextMajor(from: "4.3.0")),
+    .remote(url: "https://github.com/krzysztofzablocki/Inject.git", requirement: .upToNextMajor(from: "1.0.5")),
     .remote(url: "https://github.com/Quick/Quick.git", requirement: .upToNextMajor(from: "5.0.0")),
     .remote(url: "https://github.com/Quick/Nimble.git", requirement: .upToNextMajor(from: "10.0.0")),
     .remote(url: "https://github.com/airbnb/lottie-ios", requirement: .upToNextMajor(from: "3.0.0"))

--- a/SOPT-Stamp-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-Stamp-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -19,10 +19,12 @@ public extension Project {
         let deploymentTarget = Environment.deploymentTarget
         let platform = Environment.platform
         
+        let baseSettings: SettingsDictionary = hasDynamicFramework
+        ? .allLoadSettings
+        : .baseSettings
+        
         let settings: Settings = .settings(
-            base: name.contains(Environment.workspaceName)
-            ? .init().setCodeSignManualForApp()
-            : .init().setCodeSignManual(),
+            base: baseSettings.setCodeSignManual(),
             debug: .init()
                 .setProvisioningDevelopment(),
             release: .init()
@@ -49,8 +51,12 @@ public extension Project {
                 resources: [.glob(pattern: "Resources/**", excluding: [])],
                 dependencies: [
                     internalDependencies,
-                    externalDependencies
-                ].flatMap { $0 }
+                    externalDependencies,
+                    [
+                        .SPM.Inject
+                    ]
+                ].flatMap { $0 },
+                settings: settings
             )
             
             projectTargets.append(target)
@@ -67,7 +73,8 @@ public extension Project {
                 deploymentTarget: deploymentTarget,
                 infoPlist: .default,
                 sources: ["Interface/Sources/**/*.swift"],
-                dependencies: interfaceDependencies
+                dependencies: interfaceDependencies,
+                settings: settings
             )
             
             projectTargets.append(target)
@@ -89,7 +96,8 @@ public extension Project {
                 infoPlist: .default,
                 sources: ["Sources/**/*.swift"],
                 resources: hasResources ? [.glob(pattern: "Resources/**", excluding: [])] : [],
-                dependencies: deps + internalDependencies + externalDependencies
+                dependencies: deps + internalDependencies + externalDependencies,
+                settings: settings
             )
             
             projectTargets.append(target)
@@ -112,9 +120,11 @@ public extension Project {
                 dependencies: [
                     deps,
                     [
-                        .SPM.FLEX
+                        .SPM.FLEX,
+                        .SPM.Inject
                     ]
-                ].flatMap { $0 }
+                ].flatMap { $0 },
+                settings: settings
             )
             
             projectTargets.append(target)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#126

## 🌱 PR Point
Inject 의존성을 추가했습니다.

## 📌 사용 방법
<!-- 참고할 사항이 있다면 적어주세요. -->

1. App Store에서 Injection III를 다운받습니다.

2. Open Project에서 워크스페이스 파일이 있는 경로를 지정합니다.
<img width="254" alt="image" src="https://user-images.githubusercontent.com/77208067/226254633-0b9c4f06-ae3d-439e-a82f-a1947a9bc501.png">

3. Inject.ViewControllerHost로 InjectViewController를 생성합니다.

<img width="753" alt="스크린샷 2023-03-20 오후 2 28 19" src="https://user-images.githubusercontent.com/77208067/226254766-92a51520-64b0-4e94-9cf9-e3e25ae9beb3.png">

4. 시뮬레이터 실행 후, 변경 사항을 입력한 뒤 저장(cmd + s)합니다.

## 영상
https://user-images.githubusercontent.com/77208067/226254758-5c460a50-7e95-48c0-93b9-cddc4af8fd16.mov

## 의견
- Deom App에서 Feature 단위로 사용하는 것이 가장 바람직할 것 같습니다.
   - BaseFeatureDependency에 있는 ViewControllable의 viewController 프로퍼티에 if debug로 분기하여 debug의 경우에만 Inject를 실행하도로 했습니다. 그러나 Inject 설정이 된 뷰컨트롤러 간의 화면전환이 불완전했습니다.
   - If Debug를 통해 분기할 수 있지만, 모든 화면이 Inject에 의존성을 가지게 하기 보다는, Demo에서만 Inject.ViewControllerHost를 호출하는 것이 좋아 보입니다.

- Demo에서 원활하게 디버깅을 하기 위해서 Data 모듈에 있는 Repository의 구현체를 가져와야 합니다. 
   - 1. 각 Feature의 Demo에서만 Data를 의존하여 각 Demo가 의존성을 가지고 오도록 할 수 있을 것 같습니다.
   - 2. Data Module을 아예 BaseFeatureDependency의 아래에 둘 수 있습니다. 모듈화를 통한 의존성 관리의 의미가 퇴색된다는 단점이 있습니다. 트레이드오프를 생각하고 결정하면 좋을 것 같아요.

## 남은 작업들
1. xcconfigs를 통해 빌드 세팅을 분기하고 test 환경을 설정해야 합니다.
2. release에서 필요하지 않은 의존성을 제거해야 합니다.

## 📮 관련 이슈
- Resolved: #126 
