### PR TITLE
[Feat] #179 - UserType 핸들링

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/UserType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/UserType.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 public enum UserType: String {
-    case visitor = "VISITOR" // 비회원
+    case visitor = "UNAUTHENTICATED" // 비회원
     case active = "ACTIVE" // 활동 회원
     case inactive = "INACTIVE" // 비활동 회원
-    case unregisteredInactive // 비활동 회원 + 플그 프로필 미등록
+    case unregisteredInactive = "UNREGISTERED" // 비활동 회원 + 플그 프로필 미등록
     
     public func makeDescription(recentHistory: Int) -> String {
         switch self {

--- a/SOPT-iOS/Projects/Core/Sources/Enum/UserType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/UserType.swift
@@ -8,10 +8,11 @@
 
 import Foundation
 
-public enum UserType {
-    case visitor // 비회원
-    case active // 활동 회원
-    case inactive // 비활동 회원
+public enum UserType: String {
+    case visitor = "VISITOR" // 비회원
+    case active = "ACTIVE" // 활동 회원
+    case inactive = "INACTIVE" // 비활동 회원
+    case unregisteredInactive // 비활동 회원 + 플그 프로필 미등록
     
     public func makeDescription(recentHistory: Int) -> String {
         switch self {
@@ -21,6 +22,8 @@ public enum UserType {
             return "\(recentHistory)\(I18N.Main.active)"
         case .inactive:
             return "\(recentHistory)\(I18N.Main.inactive)"
+        case .unregisteredInactive:
+            return I18N.Main.inactiveMember
         }
     }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -151,6 +151,8 @@ public struct I18N {
         public static let encourage = "안녕하세요, \nSOPT의 열정이 되어주세요!"
         public static let hello = "안녕하세요"
         public static let welcome = "안녕하세요, \nSOPT에 오신 것을 환영합니다!"
+        public static let failedToGetUserInfo = "활동 정보를 가져올 수 없어요."
+        public static let needToRegisterPlayground = "플레이그라운드에서 프로필을 업데이트하면\n 서비스를 원활하게 사용할 수 있어요."
         
         public static func userHistory(name: String, months: String) -> String {
             return "\(name) 님은 \nSOPT와 \(months)개월째"

--- a/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import Core
+
 public struct UserMainInfoModel {
     public let status, name: String
     public let profileImage: String?
@@ -16,6 +18,19 @@ public struct UserMainInfoModel {
     public let announcement: String?
     public let responseMessage: String?
     public var withError: Bool = false
+    
+    public var userType: UserType {
+        switch status {
+        case "": // 플그 미등록인 경우
+            return .unregisteredInactive
+        case UserType.active.rawValue:
+            return .active
+        case UserType.inactive.rawValue:
+            return .inactive
+        default:
+            return .visitor
+        }
+    }
     
     public init(status: String, name: String, profileImage: String?, historyList: [Int], attendanceScore: Float?, announcement: String?, responseMessage: String?) {
         self.status = status

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
@@ -37,6 +37,7 @@ extension DefaultMainUseCase: MainUseCase {
             .sink { event in
                 print("MainUseCase: \(event)")
             } receiveValue: { [weak self] userMainInfoModel in
+                self?.setUserType(with: userMainInfoModel?.userType)
                 self?.userMainInfo.send(userMainInfoModel)
             }.store(in: self.cancelBag)
     }
@@ -48,5 +49,16 @@ extension DefaultMainUseCase: MainUseCase {
             } receiveValue: { [weak self] serviceStateModel in
                 self?.serviceState.send(serviceStateModel)
             }.store(in: self.cancelBag)
+    }
+    
+    private func setUserType(with userType: UserType?) {
+        switch userType {
+        case .none, .unregisteredInactive, .inactive: // nil인 경우도 플그 미등록 유저로 취급
+            UserDefaultKeyList.Auth.isActiveUser = false
+        case .active:
+            UserDefaultKeyList.Auth.isActiveUser = true
+        default:
+            UserDefaultKeyList.Auth.isActiveUser = false
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
@@ -182,7 +182,7 @@ extension AppMyPageVC {
                 self.soptampSectionGroup,
                 self.etcSectionGroup
             )
-        case .visitor:
+        case .visitor, .unregisteredInactive:
             self.contentStackView.addArrangedSubviews(
                 self.servicePolicySectionGroup,
                 self.etcForVisitorsSectionGroup

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
@@ -153,7 +153,7 @@ extension AlertVC {
             descriptionLabel.snp.makeConstraints { make in
                 make.centerX.equalToSuperview()
                 make.centerY.equalToSuperview().offset(-6)
-                make.leading.trailing.equalToSuperview().inset(30)
+                make.leading.trailing.equalToSuperview().inset(7)
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryCVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryCVC.swift
@@ -95,7 +95,7 @@ extension UserHistoryCVC {
         }
         
         // 플그에 기수 정보 입력 안한 비활동 회원 대응 (추후 제거)
-        if userType == .inactive {
+        if userType == .inactive || userType == .unregisteredInactive {
             if allHistory == nil {
                 self.userTypeLabel.text = I18N.Main.inactiveMember
             }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryCVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryCVC.swift
@@ -96,6 +96,7 @@ extension UserHistoryCVC {
         
         // 플그에 기수 정보 입력 안한 비활동 회원 대응 (추후 제거)
         if userType == .inactive || userType == .unregisteredInactive {
+            self.userTypeLabel.backgroundColor = DSKitAsset.Colors.black40.color
             if allHistory == nil {
                 self.userTypeLabel.text = I18N.Main.inactiveMember
             }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/UsersHistory/UserHistoryHeaderView.swift
@@ -62,7 +62,7 @@ extension UserHistoryHeaderView {
             if userType == .visitor {
                 let text = I18N.Main.encourage
                 setAttributedTextToUserInfoLabel(text: text, name: nil)
-            } else if userType == .inactive {
+            } else if userType == .inactive || userType == .unregisteredInactive {
                 let text = I18N.Main.welcome
                 setAttributedTextToUserInfoLabel(text: text, name: nil)
             }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -103,7 +103,12 @@ extension MainVC {
         
         output.getUserMainInfoDidComplete
             .sink { [weak self] _ in
-                guard let userMainInfo = self?.viewModel.userMainInfo, userMainInfo.withError == false else {
+                guard let userMainInfo = self?.viewModel.userMainInfo else {
+                    self?.collectionView.reloadData()
+                    return
+                }
+                
+                guard userMainInfo.withError == false else {
                     self?.presentNetworkAlertVC()
                     return
                 }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -228,7 +228,7 @@ extension MainVC: UICollectionViewDelegate {
           safariViewController.playgroundStyle()
           self.present(safariViewController, animated: true)
       case(3, _):
-          guard viewModel.userType != .visitor else { return }
+          guard viewModel.userType != .visitor && viewModel.userType != .unregisteredInactive else { return }
           
           presentSoptampFeature()
       default: break

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -109,10 +109,18 @@ extension MainVC {
                 }
                 self?.collectionView.reloadData()
             }.store(in: self.cancelBag)
-        
+   
         output.isServiceAvailable
             .sink { isServiceAvailable in
                 print("현재 앱 서비스 사용 가능(심사 X)?: \(isServiceAvailable)")
+            }.store(in: self.cancelBag)
+        
+        // 플그 프로필 미등록 유저 알림
+        output.needPlaygroundProfileRegistration
+            .sink { [weak self] needRegistration in
+                if needRegistration {
+                    self?.presentPlaygroundRegisterationAlertVC()
+                }
             }.store(in: self.cancelBag)
     }
     
@@ -173,6 +181,19 @@ extension MainVC {
             }).viewController
         
         self.present(networkAlertVC, animated: false)
+    }
+    
+    private func presentPlaygroundRegisterationAlertVC() {
+        let alertVC = self.factory.makeAlertVC(
+            type: .networkErr,
+            theme: .main,
+            title: I18N.Main.failedToGetUserInfo,
+            description: I18N.Main.needToRegisterPlayground,
+            customButtonTitle: "",
+            customAction: nil)
+            .viewController
+        
+        self.present(alertVC, animated: false)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -36,6 +36,7 @@ public class MainViewModel: ViewModelType {
     public struct Output {
         var getUserMainInfoDidComplete = PassthroughSubject<Void, Never>()
         var isServiceAvailable = PassthroughSubject<Bool, Never>()
+        var needPlaygroundProfileRegistration = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - init
@@ -70,7 +71,11 @@ extension MainViewModel {
         useCase.userMainInfo.asDriver()
             .sink { [weak self] userMainInfo in
                 self?.userMainInfo = userMainInfo
+                self?.userType = userMainInfo?.userType ?? .unregisteredInactive
                 output.getUserMainInfoDidComplete.send()
+                if self?.userType == .unregisteredInactive {
+                    output.needPlaygroundProfileRegistration.send(true)
+                }
             }.store(in: self.cancelBag)
         
         useCase.serviceState.asDriver()
@@ -88,7 +93,7 @@ extension MainViewModel {
         case .active:
             self.mainServiceList = [.attendance, .member, .project]
             self.otherServiceList = [.officialHomepage, .crew]
-        case .inactive:
+        case .inactive, .unregisteredInactive:
             self.mainServiceList = [.faq, .member, .project]
             self.otherServiceList = [.crew, .officialHomepage]
         }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -70,10 +70,12 @@ extension MainViewModel {
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.userMainInfo.asDriver()
             .sink { [weak self] userMainInfo in
-                self?.userMainInfo = userMainInfo
-                self?.userType = userMainInfo?.userType ?? .unregisteredInactive
+                guard let self = self else { return }
+                self.userMainInfo = userMainInfo
+                self.userType = userMainInfo?.userType ?? .unregisteredInactive
+                self.setServiceList(with: self.userType)
                 output.getUserMainInfoDidComplete.send()
-                if self?.userType == .unregisteredInactive {
+                if self.userType == .unregisteredInactive {
                     output.needPlaygroundProfileRegistration.send(true)
                 }
             }.store(in: self.cancelBag)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#179

## 🌱 PR Point
- UserType에 .unregisteredInactive (비활동 + 플그 미등록 유저)를 추가했습니다.
- UserType 열거형에 String으로 원시값을 주어 서버에서 받은 유저 Status와 1대1로 대응 될 수 있게 했습니다.
- 메인뷰 조회 API를 호출 시나리오
    - 네트워크 에러 발생 -> UserMainInfoModel의 withError 속성이 true로 viewModel에 들어옴 -> NetworkAlertVC 보여주고 확인 버튼 누르면 api retry 
    - 네트워크 에러는 아니어서 모델이 viewModel로 들어왔는데 nil이거나 서버에서 받은 status 판별 결과 unregisteredInactive 라면 플그 프로필을 등록하라는 AlertVC 등장
    - 정상적으로 viewModel까지 모델이 넘어오고 프로퍼티들도 정상적으로 채워져 있다면 VC에서도 AlertVC 표시 X
 
- 이전까지는 플그 웹뷰에서 로그인을 할 때만 UserDefaults에 유저타입 정보를 저장했었는데 이러면 자동 로그인을 했을 때는 유저 타입을 업데이트 할 수 없었습니다. 그래서, 메인뷰 조희 API response로 오는 유저 타입(status)을 이용해 UserDefaults의 유저 타입 정보를 갱신하도록 했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 플그 미등록 유저를 고려하다 보니 코드가 조금 복잡해지고 꼬여서 제가 테스트했을 때는 문제가 없었지만 나중에 다양한 테스트 케이스의 유저가 들어오게 되면 어떤 오류가 발생할지 솔직히 감이 잘 안 와요. 플그 가입 시 프로필 등록을 필수로 하는 프로세스가 최대한 빠르게 적용되는 것이 저희 앱에도 좋을 것 같습니다!
- 플그 미등록 유저의 경우 AppMyPage에서 visitor와 같은 레이아웃들이 그려지도록 했는데 이게 맞을까요? @elesahich 
- 로그인 API를 호출 했을 때 플그 미등록 유저를 핸들링 하는 것은 하지 않았는데 아마도 400왔을 때 UserType만 새로 만든 .unregisteredInactive로 지정해서 makeMainVC 호출하면 되지 않을까 싶습니다. 그냥 inactive로 넘겨도 어차피 mainVC에서 서버 통신을 한번 더 해서 userType을 갱신하기 때문에 큰 문제는 없을 것 같아요!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|플그 미등록 알럿|<img src="https://user-images.githubusercontent.com/77267404/232832456-15e15d7a-6337-4248-8095-04cf9b783b62.png" width =300>|

## 📮 관련 이슈
- Resolved: #179 
