### PR TITLE
[Feat] #202 - 1차 QA UI반영

### DIFF
--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -39,7 +39,7 @@ public class MainVC: UIViewController, MainViewControllable {
     public var factory: factoryType!
     private var cancelBag = CancelBag()
     
-    private var requestUserInfo = CurrentValueSubject<Void, Never>(())
+    private var requestUserInfo = PassthroughSubject<Void, Never>()
 
     // MARK: - UI Components
     
@@ -65,6 +65,11 @@ public class MainVC: UIViewController, MainViewControllable {
         self.setLayout()
         self.setDelegate()
         self.registerCells()
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.requestUserInfo.send(())
     }
 }
 
@@ -122,6 +127,11 @@ extension MainVC {
                 if needRegistration {
                     self?.presentPlaygroundRegisterationAlertVC()
                 }
+            }.store(in: self.cancelBag)
+        
+        output.isLoading
+            .sink { [weak self] isLoading in
+                isLoading ? self?.showLoading() : self?.stopLoading()
             }.store(in: self.cancelBag)
     }
     

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -74,10 +74,6 @@ extension MainVC {
     private func setUI() {
         self.navigationController?.isNavigationBarHidden = true
         view.backgroundColor = DSKitAsset.Colors.black100.color
-        
-        if viewModel.userType == .visitor {
-            self.naviBar.setRightButtonImage(image: DSKitAsset.Assets.btnLogout.image)
-        }
     }
     
     private func setLayout() {

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -28,7 +28,7 @@ public class MainViewModel: ViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-        let requestUserInfo: CurrentValueSubject<Void, Never>
+        let requestUserInfo: PassthroughSubject<Void, Never>
     }
     
     // MARK: - Outputs
@@ -37,6 +37,7 @@ public class MainViewModel: ViewModelType {
         var getUserMainInfoDidComplete = PassthroughSubject<Void, Never>()
         var isServiceAvailable = PassthroughSubject<Bool, Never>()
         var needPlaygroundProfileRegistration = PassthroughSubject<Bool, Never>()
+        var isLoading = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - init
@@ -57,6 +58,7 @@ extension MainViewModel {
         
         input.requestUserInfo
             .sink { [weak self] _ in
+                output.isLoading.send(true)
                 guard let self = self else { return }
                 if self.userType != .visitor {
                     self.useCase.getUserMainInfo()
@@ -70,6 +72,7 @@ extension MainViewModel {
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.userMainInfo.asDriver()
             .sink { [weak self] userMainInfo in
+                output.isLoading.send(false)
                 guard let self = self else { return }
                 self.userMainInfo = userMainInfo
                 self.userType = userMainInfo?.userType ?? .unregisteredInactive
@@ -82,6 +85,7 @@ extension MainViewModel {
         
         useCase.serviceState.asDriver()
             .sink { serviceState in
+                output.isLoading.send(false)
                 output.isServiceAvailable.send(serviceState.isAvailable)
             }.store(in: self.cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/SettingFeature/Sources/SettingScene/VC/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/SettingFeature/Sources/SettingScene/VC/SentenceEditVC.swift
@@ -79,6 +79,7 @@ extension SentenceEditVC {
         let saveButtonTapped = self.saveButton
             .publisher(for: .touchUpInside)
             .compactMap { _ in self.textView.text }
+            .filter { !$0.isEmpty }
             .asDriver()
         
         let input = SentenceEditViewModel.Input(textChanged: textViewTextChanged,

--- a/SOPT-iOS/Projects/Features/SettingFeature/Sources/SettingScene/VC/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/SettingFeature/Sources/SettingScene/VC/SentenceEditVC.swift
@@ -43,7 +43,6 @@ public class SentenceEditVC: UIViewController, SentenceEditViewControllable {
         tv.setTypoStyle(DSKitFontFamily.Suit.medium.font(size: 16))
         tv.layer.cornerRadius = 9.adjustedH
         tv.layer.borderWidth = 1.adjustedH
-        tv.layer.borderColor = DSKitAsset.Colors.purple100.color.cgColor
         tv.isEditable = true
         tv.textContainerInset = UIEdgeInsets(top: 13, left: 16, bottom: 13, right: 16)
         tv.delegate = self
@@ -80,7 +79,6 @@ extension SentenceEditVC {
         let saveButtonTapped = self.saveButton
             .publisher(for: .touchUpInside)
             .compactMap { _ in self.textView.text }
-            .filter { !$0.isEmpty }
             .asDriver()
         
         let input = SentenceEditViewModel.Input(textChanged: textViewTextChanged,
@@ -155,8 +153,17 @@ extension SentenceEditVC {
 
 extension SentenceEditVC: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        guard text != "\n" else { return false }
         guard let str = textView.text else { return true }
         let newLength = str.count + text.count - range.length
         return newLength <= 42
+    }
+    
+    public func textViewDidBeginEditing(_ textView: UITextView) {
+        textView.layer.borderColor = DSKitAsset.Colors.purple100.color.cgColor
+    }
+    
+    public func textViewDidEndEditing(_ textView: UITextView) {
+        textView.layer.borderColor = nil
     }
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/NoticePopUpVC.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/NoticePopUpVC.swift
@@ -59,6 +59,7 @@ public class NoticePopUpVC: UIViewController, NoticePopUpViewControllable {
                                                  attributes: [.font: UIFont.SoptampFont.caption3,
                                                               .foregroundColor: DSKitAsset.Colors.white.color]),
                               for: .normal)
+        $0.titleLabel?.adjustsFontSizeToFitWidth = true
     }
 
     private let updateButton = UIButton(type: .custom).then {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/StampGuideScene/VC/StampGuideVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/StampGuideScene/VC/StampGuideVC.swift
@@ -44,6 +44,7 @@ public class StampGuideVC: UIViewController, StampGuideViewControllable {
         collectionView.isScrollEnabled = true
         collectionView.isPagingEnabled = true
         collectionView.showsHorizontalScrollIndicator = false
+        collectionView.backgroundColor = .clear
         return collectionView
     }()
     

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
@@ -220,6 +220,7 @@ extension STNavigationBar {
             titleButton.setImage(DSKitAsset.Assets.icDownArrow.image, for: .normal)
             titleButton.setTitleColor(.black, for: .normal)
             titleButton.semanticContentAttribute = .forceRightToLeft
+            titleButton.titleLabel?.adjustsFontSizeToFitWidth = true
         case .titleWithLeftButton:
             rightButton.isHidden = true
             leftButton.setImage(UIImage(asset: DSKitAsset.Assets.icArrow), for: .normal)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#202

## 🌱 PR Point
- 메인뷰 네비바 우측 버튼 이미지가 비회원일 때도 마이페이지 이미지와 동일하게 사람 모양으로 보이도록 수정했습니다.
- 한마디 편집 뷰에서 사용자가 TextView에서 편집을 시작할 때 테두리 색이 보라색으로 바뀌고 편집이 끝나면 테두리 색을 없애도록 했습니다.
- 한마디를 빈 스트링을 만들어도 저장 할 수 있도록 했습니다.
- 한마디 TextView에서 엔터로 줄바꿈하는 것을 막았습니다.
- 솝탬프 가이드 뷰에서 스크롤을 하면 좌우 영역이 검은색으로 나오는 현상을 수정했습니다.
- 메인뷰에서 서버 통신시 로딩뷰를 보여주도록 했습니다. (추후 에러 처리하고 로직 변경 가능성 높음)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 한마디 편집에서 빈 스트링으로 한마디를 업데이트 하는 것을 막았던 거는 의도된 사항인가요? 일단 QA 내용이라 수정을 하긴 했지만 빈스트링으로 올리면 안되는 이유가 있다면 다시 되돌려 놓겠습니다!
- 솝탬프 미션 리트스 뷰에서 나온 QA사항들 (볼드체로 설정하면 글자 잘림, 메뉴 UI)은 반영하지 않았습니다.. 글자 잘림은 코드에서 width를 딱히 준 것 같지 않던데 왜 잘리는 건지 좀 더 찾아봐야 할 것 같습니다.

## 📸 스크린샷
- 생략

## 📮 관련 이슈
- Resolved: #202 
