### PR TITLE
[Fix] #207- 출석조회 레이아웃 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -212,7 +212,7 @@ public struct I18N {
         public static let today = "오늘은 "
         public static let dayIs = " 날이에요"
         public static let unscheduledDay = "일정이 없는"
-        public static let notCheckedDay = "출석점수를 체크하지 않습니다"
+        public static let noAttendanceSession = "출석 점수가 반영되지 않아요."
         public static let currentAttendanceScore = "현재 출석점수는 "
         public static let scoreIs = " 입니다!"
         public static let myAttendance = "나의 출결 현황"

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -230,6 +230,8 @@ public struct I18N {
         public static let inputCodeDescription = "출석 코드 다섯 자리를 입력해 주세요."
         public static let codeMismatch = "코드가 일치하지 않아요!"
         public static let takeAttendance = "출석하기"
+        
+        public static let infoButtonToastMessage = "제2장 제10조(출석)를 확인해주세요"
     }
     
     public struct MyPage {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
@@ -35,6 +35,7 @@ extension DefaultMainUseCase: MainUseCase {
         repository.getUserMainInfo()
             .sink { event in
                 print("MainUseCase: \(event)")
+                self.userMainInfo.send(completion: .finished)
             } receiveValue: { [weak self] userMainInfoModel in
                 self?.setUserType(with: userMainInfoModel?.userType)
                 self?.userMainInfo.send(userMainInfoModel)
@@ -45,6 +46,7 @@ extension DefaultMainUseCase: MainUseCase {
         repository.getServiceState()
             .sink { event in
                 print("MainUseCase: \(event)")
+                self.serviceState.send(completion: .finished)
             } receiveValue: { [weak self] serviceStateModel in
                 self?.serviceState.send(serviceStateModel)
             }.store(in: self.cancelBag)

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -27,11 +27,7 @@ public final class ShowAttendanceVC: UIViewController, ShowAttendanceViewControl
     private var cancelBag = CancelBag()
     
     public var sceneType: AttendanceScheduleType {
-        get {
-            return self.viewModel.sceneType ?? .scheduledDay
-        } set(type) {
-            self.viewModel.sceneType = type
-        }
+        return self.viewModel.sceneType ?? .unscheduledDay
     }
     
     private var viewWillAppear = PassthroughSubject<Void, Never>()
@@ -206,14 +202,12 @@ extension ShowAttendanceVC {
                 
                 self.headerScheduleView.layoutIfNeeded()
                 
-                if self.viewModel.sceneType == .scheduledDay {
-                    self.sceneType = .scheduledDay
-                    self.headerScheduleView.updateLayout(.scheduledDay)
+                if self.sceneType == .scheduledDay {
+                    self.headerScheduleView.scheduleType = .scheduledDay
                     self.setScheduledData(model)
                     self.attendanceButton.isHidden = false
                 } else {
-                    self.sceneType = .unscheduledDay
-                    self.headerScheduleView.updateLayout(.unscheduledDay)
+                    self.headerScheduleView.scheduleType = .unscheduledDay
                     self.attendanceButton.isHidden = true
                 }
                 self.endRefresh()

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -16,6 +16,7 @@ import DSKit
 
 import SnapKit
 import AttendanceFeatureInterface
+import SafariServices
 
 public final class ShowAttendanceVC: UIViewController, ShowAttendanceViewControllable {
     
@@ -277,9 +278,9 @@ extension ShowAttendanceVC {
     
     @objc
     private func infoButtonDidTap() {
-        if let url = URL(string: "https://sopt.org/rules") {
-            UIApplication.shared.open(url)
-        }
+        let safariViewController = SFSafariViewController(url: URL(string: "https://sopt.org/rules")!)
+        safariViewController.playgroundStyle()
+        self.present(safariViewController, animated: true)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/AttendanceScoreComponents/MyAttendanceStateExtension.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/AttendanceScoreComponents/MyAttendanceStateExtension.swift
@@ -1,0 +1,24 @@
+//
+//  MyAttendanceStateExtension.swift
+//  AttendanceFeature
+//
+//  Created by devxsby on 2023/04/25.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import DSKit
+
+extension AttendanceStateType {
+    
+    public var image: UIImage {
+        switch self {
+        case .attendance: return DSKitAsset.Assets.opStateAttendance.image
+        case .absent: return DSKitAsset.Assets.opStateAbsent.image
+        case .tardy: return DSKitAsset.Assets.opStateTardy.image
+        case .participate: return DSKitAsset.Assets.opStateParticipate.image
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/AttendanceScoreComponents/MyAttendanceStateTVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/AttendanceScoreComponents/MyAttendanceStateTVC.swift
@@ -84,17 +84,7 @@ extension MyAttendanceStateTVC {
     func setData(model: AttendanceModel) {
         guard let status = AttendanceStateType(rawValue: model.status.lowercased()) else { return }
         
-        switch status {
-        case .attendance:
-            stateImageView.image = DSKitAsset.Assets.opStateAttendance.image
-        case .absent:
-            stateImageView.image = DSKitAsset.Assets.opStateAbsent.image
-        case .tardy:
-            stateImageView.image = DSKitAsset.Assets.opStateTardy.image
-        case .participate:
-            stateImageView.image = DSKitAsset.Assets.opStateParticipate.image
-        }
-        
+        stateImageView.image = status.image
         titleLabel.text = model.name
         dateLabel.text = model.date
     }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayAttendanceView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayAttendanceView.swift
@@ -74,11 +74,14 @@ extension TodayAttendanceView {
     }
     
     func setTodayAttendances(_ attendances: [AttendanceStepModel]) {
+        
+        print("setTodayAttendances 스케쥴 들어옴")
+        
         todayAttendanceStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         for attendance in attendances {
             let attendanceStepView = OPAttendanceStepView(step: attendance)
-            todayAttendanceStackView.addArrangedSubviews(attendanceStepView)
+            todayAttendanceStackView.addArrangedSubview(attendanceStepView)
             attendanceStepView.snp.makeConstraints {
                 $0.height.equalTo(Metric.attendanceStepHeight)
                 $0.width.equalTo(Metric.attendanceStepWidth)

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayAttendanceView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayAttendanceView.swift
@@ -74,9 +74,7 @@ extension TodayAttendanceView {
     }
     
     func setTodayAttendances(_ attendances: [AttendanceStepModel]) {
-        
-        print("setTodayAttendances 스케쥴 들어옴")
-        
+                
         todayAttendanceStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         for attendance in attendances {

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
@@ -22,6 +22,14 @@ final class TodayScheduleView: UIView {
         static let todayAttendanceHeight = 51.f
     }
     
+    // MARK: - Properties
+    
+    var scheduleType: AttendanceScheduleType = .scheduledDay {
+        didSet {
+            updateLayout(scheduleType)
+        }
+    }
+    
     // MARK: - UI Components
 
     private let dateImageView: UIImageView = {
@@ -117,8 +125,8 @@ final class TodayScheduleView: UIView {
     init(type: AttendanceScheduleType) {
         super.init(frame: .zero)
         
-        confiureContentView()
-        setLayout(type)
+        initContentView()
+        initLayout(type)
     }
 
     required init?(coder: NSCoder) {
@@ -126,19 +134,17 @@ final class TodayScheduleView: UIView {
     }
 }
 
-// MARK: - Methods
+// MARK: - UI & Layout
 
 extension TodayScheduleView {
     
-    private func confiureContentView() {
+    private func initContentView() {
         self.backgroundColor = DSKitAsset.Colors.black60.color
         self.clipsToBounds = true
         self.layer.cornerRadius = 16
     }
     
-    private func setLayout(_ type: AttendanceScheduleType) {
-        print("setLayout: 스케쥴 기본 레이아웃")
-
+    private func initLayout(_ type: AttendanceScheduleType) {
         addSubview(containerStackView)
         
         containerStackView.snp.makeConstraints {
@@ -150,37 +156,23 @@ extension TodayScheduleView {
         }
         
         if case .unscheduledDay = type {
-            print("setLayout: 스케쥴 X 버전으로")
-            
-            dateAndPlaceStackView.isHidden = true
-            subtitleLabel.isHidden = true
-            todayAttendanceView.isHidden = true
+            isHiddenScheduledLayout(true)
         }
     }
     
-    func updateLayout(_ type: AttendanceScheduleType) {
+    private func updateLayout(_ type: AttendanceScheduleType) {
         if case .unscheduledDay = type {
-            print("updateLayout: 스케쥴 X --------------------","\n")
-            
-            dateAndPlaceStackView.isHidden = true
-            todayAttendanceView.isHidden = true
-            subtitleLabel.isHidden = true
-            
-            titleLabel.text = I18N.Attendance.today + I18N.Attendance.unscheduledDay + I18N.Attendance.dayIs
-            titleLabel.setTypoStyle(DSKitFontFamily.Suit.medium.font(size: 16))
-            
+            isHiddenScheduledLayout(true)
+            addUnscheduledTitle()
         } else {
-            print("updateLayout: 스케쥴 O --------------------","\n")
-            
-            dateAndPlaceStackView.isHidden = false
-            todayAttendanceView.isHidden = false
-            subtitleLabel.isHidden = false
+            isHiddenScheduledLayout(false)
         }
     }
     
-    private func setDefaultLayout() {
-        dateImageView.image = DSKitAsset.Assets.opDate.image
-        placeImageView.image = DSKitAsset.Assets.opPlace.image
+    private func isHiddenScheduledLayout(_ bool: Bool) {
+        dateAndPlaceStackView.isHidden = bool
+        todayAttendanceView.isHidden = bool
+        subtitleLabel.isHidden = bool
     }
 }
 
@@ -189,9 +181,9 @@ extension TodayScheduleView {
 extension TodayScheduleView {
     
     func setData(date: String, place: String, todaySchedule: String, description: String?) {
-        print("스케쥴 setData 들어옴")
         
         setDefaultLayout()
+        
         dateLabel.text = date
         placeLabel.text = place
         titleLabel.text = I18N.Attendance.today + todaySchedule + I18N.Attendance.dayIs
@@ -200,13 +192,27 @@ extension TodayScheduleView {
         subtitleLabel.text = description
         subtitleLabel.isHidden = ((description?.isEmpty) == nil || description == "")
         
-        if subtitleLabel.text == "출석 점수가 반영되지 않아요." {
-            todayAttendanceView.isHidden = true
-        }
+        checkNoAttendanceSession()
     }
     
     func setAttendanceInfo(_ attendances: [AttendanceStepModel], _ hasAttendance: Bool) {
         todayAttendanceView.setTodayAttendances(attendances)
         todayAttendanceView.isHidden = !hasAttendance
+    }
+    
+    private func addUnscheduledTitle() {
+        titleLabel.text = I18N.Attendance.today + I18N.Attendance.unscheduledDay + I18N.Attendance.dayIs
+        titleLabel.setTypoStyle(DSKitFontFamily.Suit.medium.font(size: 16))
+    }
+        
+    private func setDefaultLayout() {
+        dateImageView.image = DSKitAsset.Assets.opDate.image
+        placeImageView.image = DSKitAsset.Assets.opPlace.image
+    }
+    
+    private func checkNoAttendanceSession() {
+        if subtitleLabel.text == I18N.Attendance.noAttendanceSession {
+            todayAttendanceView.isHidden = true
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
@@ -90,7 +90,7 @@ final class TodayScheduleView: UIView {
     }()
     
     private lazy var todayInfoStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [placeStackView, dateAndPlaceStackView, titleLabel])
+        let stackView = UIStackView(arrangedSubviews: [dateAndPlaceStackView, titleLabel])
         stackView.axis = .vertical
         stackView.spacing = 8
         stackView.alignment = .leading

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Views/TodayScheduleView.swift
@@ -98,11 +98,7 @@ final class TodayScheduleView: UIView {
         return stackView
     }()
     
-    private let todayAttendanceView: TodayAttendanceView = {
-        let view = TodayAttendanceView()
-        view.isHidden = true
-        return view
-    }()
+    private let todayAttendanceView = TodayAttendanceView()
     
     private lazy var containerStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
@@ -141,38 +137,44 @@ extension TodayScheduleView {
     }
     
     private func setLayout(_ type: AttendanceScheduleType) {
+        print("setLayout: 스케쥴 기본 레이아웃")
+
         addSubview(containerStackView)
-        
-        todayAttendanceView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-        }
         
         containerStackView.snp.makeConstraints {
             $0.edges.equalToSuperview().inset(32)
         }
         
+        todayAttendanceView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+        }
+        
         if case .unscheduledDay = type {
-            todayInfoStackView.isHidden = true
+            print("setLayout: 스케쥴 X 버전으로")
             
-            addSubview(titleLabel)
-            titleLabel.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview().inset(32)
-                $0.leading.equalToSuperview().offset(32)
-            }
+            dateAndPlaceStackView.isHidden = true
+            subtitleLabel.isHidden = true
+            todayAttendanceView.isHidden = true
         }
     }
     
     func updateLayout(_ type: AttendanceScheduleType) {
         if case .unscheduledDay = type {
-            todayInfoStackView.isHidden = true
+            print("updateLayout: 스케쥴 X --------------------","\n")
+            
+            dateAndPlaceStackView.isHidden = true
+            todayAttendanceView.isHidden = true
+            subtitleLabel.isHidden = true
             
             titleLabel.text = I18N.Attendance.today + I18N.Attendance.unscheduledDay + I18N.Attendance.dayIs
             titleLabel.setTypoStyle(DSKitFontFamily.Suit.medium.font(size: 16))
-            addSubview(titleLabel)
-            titleLabel.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview().inset(32)
-                $0.leading.equalToSuperview().offset(32)
-            }
+            
+        } else {
+            print("updateLayout: 스케쥴 O --------------------","\n")
+            
+            dateAndPlaceStackView.isHidden = false
+            todayAttendanceView.isHidden = false
+            subtitleLabel.isHidden = false
         }
     }
     
@@ -187,6 +189,8 @@ extension TodayScheduleView {
 extension TodayScheduleView {
     
     func setData(date: String, place: String, todaySchedule: String, description: String?) {
+        print("스케쥴 setData 들어옴")
+        
         setDefaultLayout()
         dateLabel.text = date
         placeLabel.text = place
@@ -195,6 +199,10 @@ extension TodayScheduleView {
                                   font: DSKitFontFamily.Suit.bold.font(size: 18))
         subtitleLabel.text = description
         subtitleLabel.isHidden = ((description?.isEmpty) == nil || description == "")
+        
+        if subtitleLabel.text == "출석 점수가 반영되지 않아요." {
+            todayAttendanceView.isHidden = true
+        }
     }
     
     func setAttendanceInfo(_ attendances: [AttendanceStepModel], _ hasAttendance: Bool) {

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -70,8 +70,11 @@ extension MainViewModel {
     }
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
-        useCase.userMainInfo.asDriver()
-            .sink { [weak self] userMainInfo in
+        useCase.userMainInfo
+            .sink { event in
+                print("MainViewModel: \(event)")
+                output.isLoading.send(false)
+            } receiveValue: { [weak self] userMainInfo in
                 output.isLoading.send(false)
                 guard let self = self else { return }
                 self.userMainInfo = userMainInfo
@@ -83,8 +86,11 @@ extension MainViewModel {
                 }
             }.store(in: self.cancelBag)
         
-        useCase.serviceState.asDriver()
-            .sink { serviceState in
+        useCase.serviceState
+            .sink { event in
+                print("MainViewModel: \(event)")
+                output.isLoading.send(false)
+            } receiveValue: { serviceState in
                 output.isLoading.send(false)
                 output.isServiceAvailable.send(serviceState.isAvailable)
             }.store(in: self.cancelBag)

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/Toast.swift
@@ -23,7 +23,7 @@ public class Toast {
         
         toastContainer.backgroundColor = DSKitAsset.Colors.soptampGray600.color
         toastContainer.alpha = 1
-        toastContainer.layer.cornerRadius = 9
+        toastContainer.layer.cornerRadius = 10
         toastContainer.clipsToBounds = true
         toastContainer.isUserInteractionEnabled = false
         

--- a/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
@@ -18,9 +18,17 @@ extension AttendanceAPI {
 //            return SampleData.Lecture.absentCaseOne
 //            return SampleData.Lecture.absenctCaseTwo
 //            return SampleData.Lecture.tardy
-//            return  SampleData.Lecture.eventSession
+//            return SampleData.Lecture.eventSession
 //            return SampleData.Lecture.noAttendanceSession
-            return SampleData.Lecture.attendanceComplete
+            let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
+                                SampleData.Lecture.absenctCaseTwo, SampleData.Lecture.eventSession]
+
+//            let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
+//                                SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
+//                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession]
+            let randomIndex = Int.random(in: 0..<lectureCases.count)
+            return lectureCases[randomIndex]
+//            return SampleData.Lecture.attendanceComplete
         case .total:
             return SampleData.Total.success
         case .lectureRound:

--- a/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
@@ -21,11 +21,8 @@ extension AttendanceAPI {
 //            return SampleData.Lecture.eventSession
 //            return SampleData.Lecture.noAttendanceSession
             let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
-                                SampleData.Lecture.absenctCaseTwo, SampleData.Lecture.eventSession]
-
-//            let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
-//                                SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
-//                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession]
+                                SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
+                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession]
             let randomIndex = Int.random(in: 0..<lectureCases.count)
             return lectureCases[randomIndex]
 //            return SampleData.Lecture.attendanceComplete

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/AttendanceService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/AttendanceService.swift
@@ -25,8 +25,8 @@ public protocol AttendanceService {
 extension DefaultAttendanceService: AttendanceService {
     
     public func fetchAttendanceSchedule() -> AnyPublisher<BaseEntity<AttendanceScheduleEntity>, Error> {
-//        opRequestObjectInCombine(AttendanceAPI.lecture)
-        test.requestObjectInCombine(AttendanceAPI.lecture)
+        opRequestObjectInCombine(AttendanceAPI.lecture)
+//        test.requestObjectInCombine(AttendanceAPI.lecture)
     }
     
     public func fetchAttendanceScore() -> AnyPublisher<BaseEntity<AttendanceScoreEntity>, Error> {

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/AttendanceService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/AttendanceService.swift
@@ -25,7 +25,8 @@ public protocol AttendanceService {
 extension DefaultAttendanceService: AttendanceService {
     
     public func fetchAttendanceSchedule() -> AnyPublisher<BaseEntity<AttendanceScheduleEntity>, Error> {
-        opRequestObjectInCombine(AttendanceAPI.lecture)
+//        opRequestObjectInCombine(AttendanceAPI.lecture)
+        test.requestObjectInCombine(AttendanceAPI.lecture)
     }
     
     public func fetchAttendanceScore() -> AnyPublisher<BaseEntity<AttendanceScoreEntity>, Error> {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#207

## 🌱 PR Point
- refresh할때 새로운 데이터가 들어올때 레이아웃이 깨지는 오류가 나오지 않도록 조정했어요.
- info버튼 누르면 회칙이 외부 사파리로 연결되지 않고 웹 뷰로 띄운는거로 바꿨어요.
- 1차 qa 피드백 받은 상단 오늘의 스케쥴 보이는 부분 위치 → 장소 순으로 보이도록 바꿨어요

## 📌 참고 사항
- 출석하기 버튼 부분은 영인님이 작업하신다고 하셔서 안건들였어요.!
 (지금 출석 버튼이 안보이는 때에도 영역이 잡혀서 하단에 검정색 부분으로 조금 잘리네요..!)
- 무한로딩뷰가 뜨는 경우가 있어서 일단 vc에서 로딩뷰 연결은 해제해놨어요.

## 📸 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-04-24 at 00 25 57](https://user-images.githubusercontent.com/80062632/233909722-15c94d6d-b767-4003-941d-8c804143a01a.gif)

## 📮 관련 이슈
- Resolved: #207
