### PR TITLE
[Fix] #210 - 메인뷰 무한 로딩 이슈 처리

### DIFF
--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -65,10 +65,6 @@ public class MainVC: UIViewController, MainViewControllable {
         self.setLayout()
         self.setDelegate()
         self.registerCells()
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         self.requestUserInfo.send(())
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#210

## 🌱 PR Point
- 메인뷰에 무한 로딩 문제가 있어서 이를 해결했습니다. (다른 뷰에 갔다가 돌아오면 계속 로딩이 걸리는 현상)
- 기존에는 viewWillAppear 시점에 계속 서버통신을 시도했는데 viewDidLoad로 옮겼습니댜.
- 메인뷰 관련 에러 핸들링 로직이 완성되면 viewWillAppear에서 서버 통신을 하도록 바꿀 수 있습니다.


## 📮 관련 이슈
- Resolved: #210 
