### PR TITLE
[Feat] #204 - 출석 완료 상태 반영 및 에러 수정

### DIFF
--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo/Sources/ModuleFactory/DIContainer.swift
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo/Sources/ModuleFactory/DIContainer.swift
@@ -97,11 +97,12 @@ extension DIContainer: Features {
         return showAttendanceVC
     }
     
-    func makeAttendanceVC(lectureRound: AttendanceRoundModel) -> AttendanceViewControllable {
+    func makeAttendanceVC(lectureRound: AttendanceRoundModel, dismissCompletion: (() -> Void)?) -> AttendanceViewControllable {
         let repository = AttendanceRepository(service: attendanceService)
         let useCase = DefaultAttendanceUseCase(repository: repository)
         let viewModel = AttendanceViewModel(useCase: useCase, lectureRound: lectureRound)
         let attendanceVC = AttendanceVC(viewModel: viewModel, factory: self)
+        attendanceVC.dismissCompletion = dismissCompletion
         return attendanceVC
     }
     

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -16,9 +16,9 @@ enum TodayAttendanceType: String {
 }
 
 enum TakenAttendanceType: Int, CaseIterable {
-    case notYet = 0
-    case first = 1
-    case second = 2
+    case notYet
+    case first
+    case second
 }
 
 public protocol ShowAttendanceUseCase {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -79,9 +79,8 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
                 }
                 /// 출석하는 날(세미나, 행사, 솝커톤, 데모데이)에 출석버튼 보이게
                 if model.type != SessionType.noSession.rawValue {
-                    owner.setTakenAttendance(model.attendances) { [weak self] in
-                        self?.fetchLectureRound(lectureId: model.id)
-                    }
+                    owner.setTakenAttendance(model.attendances)
+                    owner.fetchLectureRound(lectureId: model.id)
                 }
             })
             .store(in: cancelBag)
@@ -170,9 +169,7 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
     /*
      출석 열린 상태에서 출석 완료한 경우 "n차 출석종료"
      */
-    private func setTakenAttendance(_ model: [TodayAttendanceModel],
-                                    completion: @escaping () -> Void) {
+    private func setTakenAttendance(_ model: [TodayAttendanceModel]) {
         takenAttendance = TakenAttendanceType.allCases.first { $0.rawValue == model.count } ?? .notYet
-        completion()
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -110,7 +110,7 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
                 print("completion: fetchLectureRound \(event)")
             }, receiveValue: { result in
                 /// 출석 진행중인데 이미 출석 완료한 경우
-                if self.takenAttendance != .notYet && self.takenAttendance.rawValue == result?.round {
+                if self.takenAttendance.rawValue == result?.round {
                     let n = self.takenAttendance.rawValue
                     self.lectureRoundErrorTitle.send(I18N.Attendance.afterNthAttendance(n))
                 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -110,7 +110,7 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
                 print("completion: fetchLectureRound \(event)")
             }, receiveValue: { result in
                 /// 출석 진행중인데 이미 출석 완료한 경우
-                if self.takenAttendance != .notYet {
+                if self.takenAttendance != .notYet && self.takenAttendance.rawValue == result?.round {
                     let n = self.takenAttendance.rawValue
                     self.lectureRoundErrorTitle.send(I18N.Attendance.afterNthAttendance(n))
                 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureViewControllable.swift
@@ -16,5 +16,5 @@ public protocol AttendanceViewControllable: ViewControllable { }
 
 public protocol AttendanceFeatureViewBuildable {
     func makeShowAttendanceVC() -> ShowAttendanceViewControllable
-    func makeAttendanceVC(lectureRound: AttendanceRoundModel) -> AttendanceViewControllable
+    func makeAttendanceVC(lectureRound: AttendanceRoundModel, dismissCompletion: (() -> Void)?) -> AttendanceViewControllable
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/VC/AttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/VC/AttendanceVC.swift
@@ -36,7 +36,11 @@ public final class AttendanceVC: UIViewController, AttendanceViewControllable {
     private var cancelBag = CancelBag()
     public var factory: AttendanceFeatureViewBuildable
     
+    public var dismissCompletion: (() -> Void)?
+    
     private var viewWillAppear = PassthroughSubject<Void, Never>()
+    
+    
     // MARK: - UI Components
     
     /// 출석하기 모달 뷰
@@ -284,7 +288,9 @@ extension AttendanceVC {
             .filter { $0 }
             .withUnretained(self)
             .sink { owner, _ in
-                owner.dismiss(animated: true)
+                owner.dismiss(animated: true) {
+                    owner.dismissCompletion?()
+                }
             }
             .store(in: self.cancelBag)
         

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/ViewModel/AttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/ViewModel/AttendanceViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Foundation
 
 import Core
 import Domain
@@ -73,6 +74,7 @@ extension AttendanceViewModel {
         
         input.attendanceButtonDidTap
             .withUnretained(self)
+            .throttle(for: 0.5, scheduler: RunLoop.main, latest: true)
             .sink { owner, _ in
                 let lectureRoundId = owner.lectureRound.subLectureId
                 let code = owner.codeText

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/ViewModel/AttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/AttendanceScene/ViewModel/AttendanceViewModel.swift
@@ -74,7 +74,7 @@ extension AttendanceViewModel {
         
         input.attendanceButtonDidTap
             .withUnretained(self)
-            .throttle(for: 0.5, scheduler: RunLoop.main, latest: true)
+            .throttle(for: 0.5, scheduler: RunLoop.main, latest: false)
             .sink { owner, _ in
                 let lectureRoundId = owner.lectureRound.subLectureId
                 let code = owner.codeText

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Component/OPAttendanceStepView.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/Component/OPAttendanceStepView.swift
@@ -111,7 +111,7 @@ extension OPAttendanceStepView {
         stepImageView.image = type.image
         if type.shadow {
             stepImageView.layer.applyShadow(
-                color: DSKitAsset.Colors.purple40.color,
+                color: UIColor.init(red: 158, green: 0, blue: 255),
                 alpha: 0.3,
                 x: 0,
                 y: 0,

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -178,7 +178,7 @@ extension ShowAttendanceVC {
     
     private func bindViewModels() {
         
-        let viewWillAppear = Driver.just(())
+        let viewWillAppear = viewWillAppear.asDriver()
         let refreshStarted = refresher.publisher(for: .valueChanged)
             .mapVoid()
             .asDriver()

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -133,7 +133,7 @@ extension ShowAttendanceVC {
         containerScrollView.snp.makeConstraints {
             $0.top.equalTo(navibar.snp.bottom)
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(attendanceButton.snp.top)
+            $0.bottom.equalTo(attendanceButton.snp.top).offset(-13)
         }
         
         contentView.snp.makeConstraints {
@@ -149,7 +149,7 @@ extension ShowAttendanceVC {
         attendanceScoreView.snp.makeConstraints {
             $0.top.equalTo(headerScheduleView.snp.bottom).offset(20)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
-            $0.bottom.equalToSuperview().offset(-13)
+            $0.bottom.equalToSuperview()
         }
         
         attendanceButton.snp.makeConstraints {

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -34,7 +34,7 @@ public final class ShowAttendanceVC: UIViewController, ShowAttendanceViewControl
     }
     
     private var viewWillAppear = PassthroughSubject<Void, Never>()
-  
+    
     // MARK: - UI Components
     
     private lazy var containerScrollView: UIScrollView = {
@@ -145,7 +145,7 @@ extension ShowAttendanceVC {
             $0.top.equalToSuperview().offset(15)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
-
+        
         attendanceScoreView.snp.makeConstraints {
             $0.top.equalTo(headerScheduleView.snp.bottom).offset(20)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
@@ -180,7 +180,11 @@ extension ShowAttendanceVC {
         attendanceButton.publisher(for: .touchUpInside)
             .withUnretained(self)
             .sink { owner, _ in
-                let vc = owner.factory.makeAttendanceVC(lectureRound: owner.viewModel.lectureRound).viewController
+                let vc = owner.factory.makeAttendanceVC(
+                    lectureRound: owner.viewModel.lectureRound,
+                    dismissCompletion: { [weak self] in
+                        self?.viewWillAppear.send(())
+                    }).viewController
                 vc.modalTransitionStyle = .crossDissolve
                 vc.modalPresentationStyle = .overFullScreen
                 owner.present(vc, animated: true)

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -56,20 +56,24 @@ extension ShowAttendanceViewModel {
         let output = Output()
         
         self.bindOutput(output: output, cancelBag: cancelBag)
-       
+        
         input.viewWillAppear
-            .sink {
+            .withUnretained(self)
+            .sink { owner, _ in
                 output.isLoading.send(true)
+                owner.useCase.fetchAttendanceSchedule()
+                owner.useCase.fetchAttendanceScore()
             }
             .store(in: cancelBag)
         
-        input.viewWillAppear.merge(with: input.refreshStarted)
+        input.refreshStarted
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.fetchAttendanceSchedule()
                 owner.useCase.fetchAttendanceScore()
-            }.store(in: cancelBag)
-    
+            }
+        .store(in: self.cancelBag)
+        
         return output
     }
   

--- a/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
@@ -48,6 +48,54 @@ enum SampleData {
         """.utf8
         )
         
+        static let firstAbsentCaseOne = Data(
+        """
+        {
+          "success": true,
+          "message": "세미나 조회 성공",
+          "data": {
+                "type": "HAS_ATTENDANCE",
+                "id": 1,
+                "location": "건국대학교 경영관",
+                "name":"2차 세미나",
+                "startDate": "2023-04-06T14:13:51",
+                "endDate": "2023-04-06T18:13:51",
+                "message": "",
+                "attendances": [
+                    {
+                        "status": "ABSENT",
+                      "attendedAt": "2023-04-07T14:12:09"
+                    }
+                ]
+            }
+        }
+        """.utf8
+        )
+        
+        static let firstAttendanceCaseOne = Data(
+        """
+        {
+          "success": true,
+          "message": "세미나 조회 성공",
+          "data": {
+                "type": "HAS_ATTENDANCE",
+                "id": 1,
+                "location": "건국대학교 경영관",
+                "name":"2차 세미나",
+                "startDate": "2023-04-06T14:13:51",
+                "endDate": "2023-04-06T18:13:51",
+                "message": "",
+                "attendances": [
+                    {
+                        "status": "ATTENDANCE",
+                      "attendedAt": "2023-04-07T14:12:09"
+                    }
+                ]
+            }
+        }
+        """.utf8
+        )
+        
         static let absentCaseOne = Data(
         """
         {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#204

## 🌱 PR Point

출석 완료 시, 하단 출석하기 버튼 비활성화 로직과
여러 디테일한 에러들 수정했습니다.
(하나의 이슈에서 너무 많은 일을 했는데 . 먼저 죄송 .. )

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

1. **출석 완료된 경우, n차 출석 종료 표시되도록 수정**
출석 열려있을 때, 만약 현재 출석 현황 개수가 출석의 차수와 같다면 비활성화되도록 로직 구현하였습니다. 
(또 알고리즘을 했습니다 . ^^)
<br/>

2. **디자인 QA 반영**
그림자 색과 출석하기 버튼 상단 offset 고정했습니다.
<br/>

3. **출석하기 버튼에 throttle 추가**
추가하는 게 맞다는 판단으로 0.5초로 throttle 추가해뒀습니다.
```Swift
input.attendanceButtonDidTap
    .withUnretained(self)
    .throttle(for: 0.5, scheduler: RunLoop.main, latest: false)
    .sink { owner, _ in
        let lectureRoundId = owner.lectureRound.subLectureId
        let code = owner.codeText
        owner.useCase.postAttendance(lectureRoundId: lectureRoundId, code: code)
    }
    .store(in: self.cancelBag)
```
<br/>

4. **로딩뷰 로직 수정**
기존에 viewWillAppear에서 로딩뷰를 시작하고 있었는데 무한로딩이 발생했습니다.
그래서 서버 호출하기 전에 시작하도록 수정했습니다.
<br/>

5. **출석하기 뷰 dismissCompletion 추가**
출석하기 코드 입력 후, dimiss하고 나서 다시 서버 호출해서 새로고침해야 해서 dismissCompletion 추가해서 해결했습니다 !
```Swift
let vc = owner.factory.makeAttendanceVC(
    lectureRound: owner.viewModel.lectureRound,
    dismissCompletion: { [weak self] in
        self?.viewWillAppear.send(())
    }).viewController
```
<br/>

6. **하단 출석하기 버튼 레이아웃 업데이트 안되는 이슈 해결**
StackView 추가해서 .. hidden 처리로 해결했습니다 ..^^
<br/>

![Simulator Screen Recording - iPhone 14 Pro - 2023-04-25 at 12 05 13](https://user-images.githubusercontent.com/74968390/234171425-34767bd9-055a-49e8-abc7-a6f26a9a145c.gif)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #204 
