### PR TITLE
[Fix] #220 - 토큰 재발급 수정사항 반영

### DIFF
--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/AuthAPI.swift
@@ -24,10 +24,8 @@ extension AuthAPI: BaseAPI {
     // MARK: - Header
     public var headers: [String: String]? {
         switch self {
-        case .signIn:
+        case .signIn, .reissuance:
             return HeaderType.json.value
-        case .reissuance:
-            return HeaderType.jsonWithToken.value
         }
     }
     

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/AlamoInterceptor.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/AlamoInterceptor.swift
@@ -16,7 +16,26 @@ public class AlamoInterceptor: RequestInterceptor {
     
     public typealias AdapterResult = Swift.Result<URLRequest, Error>
     private var authService = DefaultAuthService()
-
+    
+    public func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var adaptedRequest = urlRequest
+        adaptedRequest = validateHeader(&adaptedRequest)
+        completion(.success(adaptedRequest))
+    }
+    
+    // Note: 토큰 재발급 시 AccessToken 갱신
+    // @준호
+    private func validateHeader(_ urlRequest: inout URLRequest) -> URLRequest {
+        let headers = urlRequest.headers.map {
+            guard $0.name == "Authorization" else {
+                return $0
+            }
+            return HTTPHeader(name: $0.name, value: UserDefaultKeyList.Auth.appAccessToken ?? "")
+        }
+        urlRequest.headers = HTTPHeaders(headers)
+        return urlRequest
+    }
+    
     public func retry(_ request: Alamofire.Request, for session: Alamofire.Session, dueTo error: Swift.Error, completion: @escaping (RetryResult) -> Void) {
         // token 재발급 API가 아니며 && 로그인 실패가 아니며 && 토큰이 만료된 경우(401)
         guard let pathComponents = request.request?.url?.pathComponents,

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/AlamoInterceptor.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/AlamoInterceptor.swift
@@ -19,13 +19,13 @@ public class AlamoInterceptor: RequestInterceptor {
     
     public func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         var adaptedRequest = urlRequest
-        adaptedRequest = validateHeader(&adaptedRequest)
+        validateHeader(&adaptedRequest)
         completion(.success(adaptedRequest))
     }
     
     // Note: 토큰 재발급 시 AccessToken 갱신
     // @준호
-    private func validateHeader(_ urlRequest: inout URLRequest) -> URLRequest {
+    private func validateHeader(_ urlRequest: inout URLRequest) {
         let headers = urlRequest.headers.map {
             guard $0.name == "Authorization" else {
                 return $0
@@ -33,7 +33,6 @@ public class AlamoInterceptor: RequestInterceptor {
             return HTTPHeader(name: $0.name, value: UserDefaultKeyList.Auth.appAccessToken ?? "")
         }
         urlRequest.headers = HTTPHeaders(headers)
-        return urlRequest
     }
     
     public func retry(_ request: Alamofire.Request, for session: Alamofire.Session, dueTo error: Swift.Error, completion: @escaping (RetryResult) -> Void) {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#220

## 🌱 PR Point

토큰 재발급 API에서 Authorization Header에 만료된 토큰이 존재하면 401 에러가 발생하고 있었습니다.

- header를 사용하지 않는 방향으로 수정했습니다.

현재 사용 중인 interceptor는 retry 시에 request를 다시 만드는 것이 아니라 실패했던 urlRequest 값을 저장하고 다시 실행하는 방식이었습니다.

- 따라서 adapt를 통해 header를 갱신해주는 작업을 추가했습니다.
- 더 좋은 방식 있다면 알려주세요!

## 📮 관련 이슈
- Resolved: #220 
