### PR TITLE
[Fix] #227 - Sentry 설정 변경 및 dsym 파일 업로드 script 추가

### DIFF
--- a/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import Sentry
 
+import Network
 import Core
 
 @main
@@ -41,14 +42,15 @@ extension AppDelegate {
     private func configureSentry() {
         SentrySDK.start { options in
             options.dsn = Config.Sentry.DSN
-            #if DEV || TEST
-            options.debug = true
-            #endif
             options.enableCaptureFailedRequests = true
             options.attachScreenshot = true
             options.enableUserInteractionTracing = true
             options.attachViewHierarchy = true
             options.enableUIViewControllerTracing = true
+            options.enableNetworkBreadcrumbs = true
+            let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
+            options.failedRequestStatusCodes = [ httpStatusCodeRange ]
+            options.enableAutoBreadcrumbTracking = true
         }
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import Sentry
 
+import Network
 import Core
 
 @main
@@ -41,14 +42,15 @@ extension AppDelegate {
     private func configureSentry() {
         SentrySDK.start { options in
             options.dsn = Config.Sentry.DSN
-            #if DEV || TEST
-            options.debug = true
-            #endif
             options.enableCaptureFailedRequests = true
             options.attachScreenshot = true
             options.enableUserInteractionTracing = true
             options.attachViewHierarchy = true
             options.enableUIViewControllerTracing = true
+            options.enableNetworkBreadcrumbs = true
+            let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
+            options.failedRequestStatusCodes = [ httpStatusCodeRange ]
+            options.enableAutoBreadcrumbTracking = true
         }
     }
 }

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -42,6 +42,7 @@ public extension Project {
                 infoPlist: .extendingDefault(with: infoPlist),
                 sources: ["Sources/**/*.swift"],
                 resources: [.glob(pattern: "Resources/**", excluding: [])],
+                scripts: [.Sentry],
                 dependencies: [
                     internalDependencies,
                     externalDependencies,

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Scripts.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Scripts.swift
@@ -29,7 +29,7 @@ if which sentry-cli >/dev/null; then
 export SENTRY_ORG=sopt-1a
 export SENTRY_PROJECT=sopt-ios
 export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
-ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" --force-foreground 2>&1 >/dev/null)
+ERROR=$(sentry-cli upload-dif --include-sources "$DWARF_DSYM_FOLDER_PATH" --force-foreground 2>&1 >/dev/null)
 if [ ! $? -eq 0 ]; then
 echo "error: sentry-cli - $ERROR"
 fi

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Scripts.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Scripts.swift
@@ -21,4 +21,25 @@ else
     echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
 fi
 """, name: "SwiftLintString", basedOnDependencyAnalysis: false)
+    
+    static let Sentry = TargetScript.pre(
+        script: """
+if [ "${CONFIGURATION}" == "QA" ] || [ "${CONFIGURATION}" == "PROD" ]; then
+if which sentry-cli >/dev/null; then
+export SENTRY_ORG=sopt-1a
+export SENTRY_PROJECT=sopt-ios
+export SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ERROR=$(sentry-cli upload-dif "$DWARF_DSYM_FOLDER_PATH" --force-foreground 2>&1 >/dev/null)
+if [ ! $? -eq 0 ]; then
+echo "error: sentry-cli - $ERROR"
+fi
+else
+echo "error: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases"
+fi
+fi
+""",
+        name: "Sentry",
+        inputPaths: ["${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}"],
+        basedOnDependencyAnalysis: false
+    )
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#227

## 🌱 PR Point
1. Sentry에서 400 에러도 tracing 할 수 있도록 설정을 변경했습니다.

범위를 따로 지정해줘야 하더라구요!

options.debug는 제거했는데, 디버그 빌드 시에 앱 실행 시간이 아주 길어지기 때문입니다.
Sentry의 기능을 확인하고 싶으실 때 따로 추가하시면 될 것 같슴다!

2. Symbolication 및 source context를 추적하기 위한 dsym 업로드 [ [참고](https://docs.sentry.io/platforms/apple/dsym/#xcode-build-phase) ]

sentry에 dsym을 업로드하는 run script를 추가했습니다.
우선은 release config에서만 작동하도록 했는데, debug의 run에서 업로드하는 경우 dsym 파일 관리가 어려워질 것 같기 때문입니다.

- xcconfig에 Sentry Auth Token을 넣어두었습니다.
- 아래 명령어로 sentry cli를 설치해주세요. dsym 업로드를 자동화해주는 도구입니다.
```bash
curl -sL https://sentry.io/get-cli/ | bash
```

## 📮 관련 이슈
- Resolved: #227 
