### PR TITLE
[Fix] #229 - URL State 생성 방식 UUID로 수정, Sentry 캡쳐

### DIFF
--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/VC/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/VC/SignInVC.swift
@@ -19,6 +19,7 @@ import MainFeatureInterface
 
 import SnapKit
 import Then
+import Sentry
 
 public class SignInVC: UIViewController, SignInViewControllable {
     
@@ -216,11 +217,14 @@ extension SignInVC {
     }
     
     private func openPlaygroundURL() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyyMMddHHmmss"
-        let state = dateFormatter.string(from: Date())
+        let state = UUID().uuidString
         UserDefaultKeyList.Auth.requestState = state
-        let safari = SFSafariViewController(url: URL(string: ExternalURL.Playground.login(state: state))!)
+        guard let url = URL(string: ExternalURL.Playground.login(state: state)) else {
+            SentrySDK.capture(message: "Invalid URL string: \(ExternalURL.Playground.login(state: state))")
+            makeAlert(title: "URL 에러", message: "잘못된 URL이 생성되었습니다. 개발자에게 문의주시면 감사하겠습니다.")
+            return
+        }
+        let safari = SFSafariViewController(url: url)
         safari.modalPresentationStyle = .fullScreen
         safari.playgroundStyle()
         self.present(safari, animated: true)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- hotifx/#229

## 🌱 PR Point
Sentry 로그를 확인하면 로그인 버튼 탭  이후 publisher의 receive가 호출된 이후에, SOPT-iOS에서 문제가 생깁니다.
그리고 SOPT-iOS로 나오는 이유는 Static Framework로 설정하였기에 Feature의 코드가 app bundle에 합쳐졌기 때문입니다.
제 생각에는 이 부분이 openPlaygroundURL이고, URL의 state를 DateFormatter의 동적으로 생성하면서 사용자의 설정에 따라 Date가 예외 문자열, 예를 들어 ?를 포함하게 될 수도 있다는 생각이 들었습니다. 

따라서 이 부분을 UUID를 사용하는 것으로 수정했고, URL을 생성하지 못한 경우 sentry에서 caputre하도록 했습니다.

## 참고 dsym
지금 archive 시에 자동으로 dsym이 업로드되도록 하고 있는데, 모종의 이유로 일부가 업로드 되지 않는 경우가 있습니다.
이를 방지하기 위해 아카이브 이후 dsym 파일들의 경로를 찾아서 아래 커맨드를 입력해 줘야 합니다.
+ fastlane을 사용하면 자동화할 수 있을 것 같습니다.
```
sentry-cli upload-dif --include-sources  --auth-token ca6f3cedad264619a8347fdd96ef0ee0bddec36632684059b99001d17f7b5db0 --org sopt-1a --project sopt-ios /Users/junholee/Library/Developer/Xcode/Archives/2023-05-04/SOPT-iOS-PROD\ 2023-05-04\ 7.19\ PM.xcarchive/dSYMs
```

## 📮 관련 이슈
- Resolved: #229 
