### PR TITLE
[Fix] #232 - 출석하기 버튼 안보이는 에러 해결

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
@@ -23,11 +23,12 @@ extension String {
     public func setDateFormat(dateString: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        
         guard let date = dateFormatter.date(from: self) else { return "00:00" }
         
         dateFormatter.dateFormat = dateString
-        dateFormatter.locale = Locale(identifier: "ko_KR")
-        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         return dateFormatter.string(from: date)
     }
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -263,8 +263,8 @@ extension ShowAttendanceVC {
     private func setScheduledData(_ model: AttendanceScheduleModel) {
         
         if self.sceneType == .scheduledDay {
-            guard let date = viewModel.formatTimeInterval(startDate: model.startDate,
-                                                          endDate: model.endDate) else { return }
+            let date = viewModel.formatTimeInterval(startDate: model.startDate,
+                                                          endDate: model.endDate)
             headerScheduleView.setData(date: date,
                                        place: model.location,
                                        todaySchedule: model.name,

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -88,8 +88,9 @@ extension ShowAttendanceViewModel {
             .sink(receiveValue: { model in
                 if model.type != SessionType.noSession.rawValue {
                     self.sceneType = .scheduledDay
-                    guard let convertedStartDate = self.convertDateString(model.startDate),
-                          let convertedEndDate = self.convertDateString(model.endDate) else { return }
+                    
+                    let convertedStartDate = self.convertDateString(model.startDate)
+                    let convertedEndDate = self.convertDateString(model.endDate)
 
                     let newModel = AttendanceScheduleModel(type: model.type,
                                                            id: model.id,
@@ -141,10 +142,10 @@ extension ShowAttendanceViewModel {
             .store(in: self.cancelBag)
     }
     
-    private func convertDateString(_ dateString: String) -> String? {
+    private func convertDateString(_ dateString: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        guard let date = dateFormatter.date(from: dateString) else { return nil }
+        guard let date = dateFormatter.date(from: dateString) else { return "" }
         
         dateFormatter.dateFormat = "M월 d일 EEEE H:mm"
         dateFormatter.locale = Locale(identifier: "ko_KR")
@@ -152,12 +153,12 @@ extension ShowAttendanceViewModel {
         return dateFormatter.string(from: date)
     }
     
-    func formatTimeInterval(startDate: String, endDate: String) -> String? {
+    func formatTimeInterval(startDate: String, endDate: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M월 d일 EEEE HH:mm"
-        
+    
         guard let startDateObject = dateFormatter.date(from: startDate),
-              let endDateObject = dateFormatter.date(from: endDate) else { return nil }
+              let endDateObject = dateFormatter.date(from: endDate) else { return "" }
         
         let formattedStartDate = dateFormatter.string(from: startDateObject)
         

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -145,17 +145,20 @@ extension ShowAttendanceViewModel {
     private func convertDateString(_ dateString: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        
         guard let date = dateFormatter.date(from: dateString) else { return "" }
         
         dateFormatter.dateFormat = "M월 d일 EEEE H:mm"
-        dateFormatter.locale = Locale(identifier: "ko_KR")
-        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
         return dateFormatter.string(from: date)
     }
     
     func formatTimeInterval(startDate: String, endDate: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "M월 d일 EEEE HH:mm"
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
     
         guard let startDateObject = dateFormatter.date(from: startDate),
               let endDateObject = dateFormatter.date(from: endDate) else { return "" }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/AttendanceSampleData.swift
@@ -20,12 +20,13 @@ extension AttendanceAPI {
 //            return SampleData.Lecture.tardy
 //            return SampleData.Lecture.eventSession
 //            return SampleData.Lecture.noAttendanceSession
-            let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
-                                SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
-                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession]
-            let randomIndex = Int.random(in: 0..<lectureCases.count)
-            return lectureCases[randomIndex]
+//            let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
+//                                SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
+//                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession]
+//            let randomIndex = Int.random(in: 0..<lectureCases.count)
+//            return lectureCases[randomIndex]
 //            return SampleData.Lecture.attendanceComplete
+            return SampleData.Lecture.errorSession
         case .total:
             return SampleData.Total.success
         case .lectureRound:

--- a/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
@@ -10,6 +10,25 @@ import Foundation
 
 enum SampleData {
     enum Lecture {
+        static let errorSession = Data(
+        """
+        {
+          "success": true,
+          "message": "세미나 조회 성공",
+          "data": {
+                "type": "HAS_ATTENDANCE",
+                "id": 1,
+                "location": "건국대학교 경영관",
+                "name":"2차 세미나",
+                "startDate": "2023-04-06T14:13:51",
+                "endDate": "",
+                "message": "",
+                "attendances": []
+            }
+        }
+        """.utf8
+        )
+        
         static let noSession = Data(
         """
         {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#232

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
서버랑 함께 에러 케이스 재현하려고 계속 노력했으나 재현은 불가능했고, 결국 추정 가능한 케이스는 이 경우밖에 없었습니다.

서버측에서 말하기를 빈 String이나 다른 형태의 timeStamp가 떨어질 케이스는 존재하지 않을 것 같다고 하긴 했는데 
일단은 이렇게라도 처리해서 다른 형태가 내려와도 출석하기 버튼은 활성화될 수 있도록 수정했습니다.

기존에 만약 다른 형태의 timeStamp가 떨어진다면 
```Swift
output.scheduleModel = newModel
```  
해당 코드가 수행되지 않아 scheduleModel 역시 옵셔널이므로 하단 출석하기 버튼 활성화 로직이 수행되지 않았습니다.

따라서 기존에 옵셔널 형태를 수정하여 빈 값으로 보일 수 있도록 했습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://github.com/sopt-makers/SOPT-iOS/assets/74968390/d04b4011-e40a-439a-b2b3-557dfafcb4c3" width=230>|


## 📮 관련 이슈
- Resolved: #232 
