### PR TITLE
[Feat] #236 - Sentry Capture 코드 추가

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
@@ -29,7 +29,7 @@ extension MainRepository: MainRepositoryInterface {
         return userService.getUserMainInfo()
             .mapError { error -> MainError in
                 guard let error = error as? APIError else {
-                    return MainError.networkError
+                    return MainError.networkError(message: "Moya 에러")
                 }
                 
                 switch error {
@@ -39,7 +39,7 @@ extension MainRepository: MainRepositoryInterface {
                     } else if statusCode == 401 {
                         return MainError.authFailed
                     }
-                    return MainError.networkError
+                    return MainError.networkError(message: "\(statusCode) 네트워크 에러")
                 case .tokenReissuanceFailed:
                     guard let appAccessToken = UserDefaultKeyList.Auth.appAccessToken else {
                         return MainError.authFailed
@@ -47,7 +47,7 @@ extension MainRepository: MainRepositoryInterface {
                     // accessToken이 빈 스트링인 경우는 플그 미등록 상태 / accessToken이 있지만 인증에 실패한 경우는 로그인 뷰로 보내기
                     return appAccessToken.isEmpty ? MainError.unregisteredUser : MainError.authFailed
                 default:
-                    return MainError.networkError
+                    return MainError.networkError(message: "API 에러 디폴트")
                 }
             }
             .map { $0.toDomain() }
@@ -58,7 +58,7 @@ extension MainRepository: MainRepositoryInterface {
         configService.getServiceAvailability()
             .mapError { error in
                 print(error)
-                return MainError.networkError
+                return MainError.networkError(message: "GetServiceState 에러")
             }
             .map { $0.toDomain() }
             .eraseToAnyPublisher()

--- a/SOPT-iOS/Projects/Domain/Sources/Error/MainError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/MainError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum MainError: Error {
-    case networkError
+    case networkError(message: String?)
     case unregisteredUser // 플그 미동록 유저
     case authFailed // 토큰 재발급 실패 등 인증 에러
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Error/MainError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/MainError.swift
@@ -13,3 +13,20 @@ public enum MainError: Error {
     case unregisteredUser // 플그 미동록 유저
     case authFailed // 토큰 재발급 실패 등 인증 에러
 }
+
+extension MainError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        func getDebugDescription() -> String {
+            switch self {
+            case .networkError(let message):
+                return  message ?? ""
+            case .unregisteredUser:
+                return "플그 미등록"
+            case .authFailed:
+                return "인증 실패"
+            }
+        }
+
+        return [NSDebugDescriptionErrorKey: getDebugDescription()]
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
@@ -51,7 +51,7 @@ extension DefaultMainUseCase: MainUseCase {
             .sink { [weak self] event in
                 print("MainUseCase getServiceState: \(event)")
                 if case Subscribers.Completion.failure = event {
-                    self?.mainErrorOccurred.send(.networkError)
+                    self?.mainErrorOccurred.send(.networkError(message: "GetServiceState 실패"))
                 }
             } receiveValue: { [weak self] serviceStateModel in
                 self?.serviceState.send(serviceStateModel)

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -98,6 +98,7 @@ extension MainViewModel {
         useCase.mainErrorOccurred
             .sink { error in
                 output.isLoading.send(false)
+                SentrySDK.capture(error: error)
                 switch error {
                 case .networkError:
                     output.needNetworkAlert.send()

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/BaseService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Foundation/BaseService.swift
@@ -13,6 +13,7 @@ import Core
 
 import Alamofire
 import Moya
+import Sentry
 
 open class BaseService<Target: TargetType> {
     
@@ -142,6 +143,7 @@ extension BaseService {
                         default: break
                         }
                     } catch let error {
+                        SentrySDK.capture(message: "디코딩 에러")
                         promise(.failure(error))
                     }
                 case .failure(let error):


### PR DESCRIPTION
## 🌴 PR 요약
- 지난 세미나에서 32기 활동 회원들이 앱을 사용했을 때 4명의 유저에게 메인뷰에서 네트워크 알럿이 보여지고 앱이 정상적으로 동작하지 않는 이슈가 있었습니다.
- 물론, 정말 네트워크 에러로 인해 이 AlertVC가 나오는건 바람직하지만 현재 추정상 다른 이유로도 해당 알럿이 보여지고 정상적으로 앱이 동작하지 않는 것 같습니다.
- 이전에 에러 핸들링을 하면서 네트워크 알럿뷰가 보여지게 되는 경우는 2가지로 설정했습니다. (엣지 케이스가 더 있을 수 있습니다.)
1. 정말 네트워크 에러(모야 에러)
2. Entity 디코딩 에러

- 정확한 원인 파악을 위해 이번에 Sentry의 capture를 지난번에 구현한 에러 핸들링 코드들에 넣어서 어디서 문제가 생겼는지 파악하고자 합니다.

🌱 작업한 브랜치
- feature/#236

## 🌱 PR Point
![image](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/e8100334-73e6-4050-98b3-af3ca321f89e)

에러의 연관값 스트링도 받아와서 센트리에서 확인하고 싶은데 이걸 8.7.0 이후 버전부터 지원을 하는 거 같아요 저희가 사용하고 있는 버전은 8.5.0이구요! 이걸 8.7.0 이상으로 올리고 싶은데 왜 안될까요....

그래서 https://docs.sentry.io/platforms/apple/guides/ios/usage/?original_referrer=https%3A%2F%2Fwww.google.com%2F 우선 이 링크에 있는 것처럼 예전 방식인 Error Description을 에러 타입에 추가하여 센트리 홈페이지에서 텍스트를 확인할 수 있도록 했습니다..!

![image](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/69af5984-76f5-4fc3-8b53-3e1c8ab7fa72)

- 이런식으로 나와요!

## 📮 관련 이슈
- Resolved: #236 
