### PR TITLE
[Add] #239 - FireBase 의존성 추가

### DIFF
--- a/SOPT-iOS/.gitignore
+++ b/SOPT-iOS/.gitignore
@@ -62,6 +62,8 @@ DerivedData/
 *.xcodeproj
 *.xcworkspace
 /Projects/Modules/Network/Sources/Config.swift
+/Projects/SOPT-iOS/Resources/GoogleService-Info.plist
+/Projects/Demo/Resources/GoogleService-Info.plist
 
 ### Tuist derived files ###
 graph.dot

--- a/SOPT-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/SOPT-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -23,6 +23,7 @@ public extension TargetDependency.SPM {
     static let Nimble = TargetDependency.external(name: "Nimble")
     static let Quick = TargetDependency.external(name: "Quick")
     static let lottie = TargetDependency.external(name: "Lottie")
+    static let FirebaseMessaging = TargetDependency.external(name: "FirebaseMessaging")
 }
 
 public extension TargetDependency.Carthage {

--- a/SOPT-iOS/Projects/Demo/Project.swift
+++ b/SOPT-iOS/Projects/Demo/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeModule(
     targets: [.app, .unitTest],
     internalDependencies: [
         .data,
-        .Features.RootFeature
+        .Features.RootFeature,
+        .SPM.FirebaseMessaging
     ]
 )

--- a/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Sentry
+import FirebaseCore
 
 import Network
 import Core
@@ -17,6 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application( _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         configureSentry()
+        FirebaseApp.configure()
         return true
     }
     

--- a/SOPT-iOS/Projects/SOPT-iOS/Project.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeModule(
     targets: [.app, .unitTest],
     internalDependencies: [
         .data,
-        .Features.RootFeature
+        .Features.RootFeature,
+        .SPM.FirebaseMessaging
     ]
 )

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Sentry
+import FirebaseCore
 
 import Network
 import Core
@@ -17,6 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application( _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         configureSentry()
+        FirebaseApp.configure()
         return true
     }
     

--- a/SOPT-iOS/Tuist/Dependencies.swift
+++ b/SOPT-iOS/Tuist/Dependencies.swift
@@ -20,6 +20,7 @@ let spm = SwiftPackageManagerDependencies([
     .remote(url: "https://github.com/Quick/Quick.git", requirement: .upToNextMajor(from: "5.0.0")),
     .remote(url: "https://github.com/Quick/Nimble.git", requirement: .upToNextMajor(from: "10.0.0")),
     .remote(url: "https://github.com/airbnb/lottie-ios", requirement: .upToNextMajor(from: "4.1.3")),
+    .remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .upToNextMajor(from: "10.10.0")),
 ], baseSettings: Settings.settings(
     configurations: XCConfig.framework
 ))


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#239

## 🌱 PR Point

### Firebase 세팅

아래와 같이 메인 앱과 테스트 앱 모두 firebase를 세팅했습니다.

<img width="590" alt="image" src="https://github.com/sopt-makers/SOPT-iOS/assets/77208067/fe87a44f-1afd-4094-bf2e-36e6de3a0eb4">

googleService plist 파일은 따로 전달드리겠슴다!

### Firebase는 정적 라이브러리로 사용되는 것이 권장됩니다
[링크](https://github.com/firebase/firebase-ios-sdk/blob/master/docs/firebase_in_libraries.md)의 이유로 ThirdpartyLib에서 import하는 방식을 사용하지 못했습니다...! 안되네요 하하

## 📮 관련 이슈
- Resolved: #239 
