### PR TITLE
[Feat] #251 - download-private 스크립트 작성

### DIFF
--- a/SOPT-iOS/.gitignore
+++ b/SOPT-iOS/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+.env
 
 # Icon must end with two
 Icon

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -21,3 +21,58 @@ regenerate:
 	rm -rf **/*.xcodeproj
 	rm -rf *.xcworkspace
 	tuist generate
+	
+# Privates 파일 다운로드
+
+BASE_URL=https://raw.githubusercontent.com/sopt-makers/SOPT-iOS-Private/main
+
+download-privates:
+
+	# Get Github Access Token
+	
+	@if [ ! -f .env ]; then \
+		read -p "Enter your GitHub access token: " token; \
+		echo "GITHUB_ACCESS_TOKEN=$$token" > .env; \
+	fi
+	
+	$(eval export $(shell cat .env))
+	
+	# fastlane .env
+
+	@if [ ! -d fastlane ]; then \
+		mkdir -p fastlane; \
+	fi
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o fastlane/.env $(BASE_URL)/fastlane/.env
+	
+	# Config.swift
+	
+	@if [ ! -d Projects/Modules/Network/Sources ]; then \
+		mkdir -p Projects/Modules/Network/Sources; \
+	fi
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/Modules/Network/Sources/Config.swift $(BASE_URL)/Projects/Modules/Network/Sources/Config.swift
+	
+	# Xcconfigs
+
+	@if [ ! -d xcconfigs/Base ]; then \
+		mkdir -p xcconfigs/Base/Projects; \
+		mkdir -p xcconfigs/Base/Targets; \
+	fi
+
+	@if [ ! -d xcconfigs/targets ]; then \
+		mkdir -p xcconfigs/targets; \
+	fi
+	
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Common.xcconfig $(BASE_URL)/xcconfigs/Base/Common.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-Development.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-Development.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-PROD.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-PROD.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-QA.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-QA.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-Test.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-Test.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Shared.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Shared.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Application.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Application.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Extension.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Extension.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Framework.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Framework.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/StaticLibrary.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/StaticLibrary.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Demo.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Demo.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Framework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Framework.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-StaticFramework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-StaticFramework.xcconfig
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Tests.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Tests.xcconfig

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -29,11 +29,17 @@ BASE_URL=https://raw.githubusercontent.com/sopt-makers/SOPT-iOS-Private/main
 download-privates:
 
 	# Get Github Access Token
-	
 	@if [ ! -f .env ]; then \
 		read -p "Enter your GitHub access token: " token; \
 		echo "GITHUB_ACCESS_TOKEN=$$token" > .env; \
+	else \
+		/bin/bash -c "source .env; make _download-privates"; \
+		exit 0; \
 	fi
+	
+	make _download-privates
+
+_download-privates:
 	
 	$(eval export $(shell cat .env))
 	
@@ -76,3 +82,16 @@ download-privates:
 	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Framework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Framework.xcconfig
 	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-StaticFramework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-StaticFramework.xcconfig
 	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Tests.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Tests.xcconfig
+	
+	# GoogleService-info
+
+	@if [ ! -d Projects/SOPT-iOS/Resources ]; then \
+		mkdir -p Projects/SOPT-iOS/Resources; \
+	fi
+	
+	@if [ ! -d Projects/Demo/Resources ]; then \
+		mkdir -p Projects/Demo/Resources; \
+	fi
+	
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/SOPT-iOS/Resources/GoogleService-Info.plist $(BASE_URL)/Projects/SOPT-iOS/Resources/GoogleService-Info.plist
+	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/Demo/Resources/GoogleService-Info.plist $(BASE_URL)/Projects/Demo/Resources/GoogleService-Info.plist

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -26,9 +26,30 @@ regenerate:
 
 BASE_URL=https://raw.githubusercontent.com/sopt-makers/SOPT-iOS-Private/main
 
+XCCONFIG_PATHS = \
+    xcconfigs/Base Common.xcconfig \
+    xcconfigs/Base/Projects Project-Development.xcconfig \
+    xcconfigs/Base/Projects Project-PROD.xcconfig \
+    xcconfigs/Base/Projects Project-QA.xcconfig \
+    xcconfigs/Base/Projects Project-Test.xcconfig \
+    xcconfigs/Base/Projects Shared.xcconfig \
+    xcconfigs/Base/Targets Application.xcconfig \
+    xcconfigs/Base/Targets Extension.xcconfig \
+    xcconfigs/Base/Targets Framework.xcconfig \
+    xcconfigs/Base/Targets StaticLibrary.xcconfig \
+    xcconfigs/targets iOS-Demo.xcconfig \
+    xcconfigs/targets iOS-Framework.xcconfig \
+    xcconfigs/targets iOS-StaticFramework.xcconfig \
+    xcconfigs/targets iOS-Tests.xcconfig
+    
+define download_file
+	mkdir -p $(1)
+	curl -H "Authorization: token $(2)" -o $(1)/$(3) $(BASE_URL)/$(1)/$(3)
+endef
+
 download-privates:
 
-	# Get Github Access Token
+	# Get GitHub Access Token
 	@if [ ! -f .env ]; then \
 		read -p "Enter your GitHub access token: " token; \
 		echo "GITHUB_ACCESS_TOKEN=$$token" > .env; \
@@ -45,53 +66,26 @@ _download-privates:
 	
 	# fastlane .env
 
-	@if [ ! -d fastlane ]; then \
-		mkdir -p fastlane; \
-	fi
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o fastlane/.env $(BASE_URL)/fastlane/.env
+	$(call download_file,fastlane,$$GITHUB_ACCESS_TOKEN,.env)
 	
 	# Config.swift
 	
-	@if [ ! -d Projects/Modules/Network/Sources ]; then \
-		mkdir -p Projects/Modules/Network/Sources; \
-	fi
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/Modules/Network/Sources/Config.swift $(BASE_URL)/Projects/Modules/Network/Sources/Config.swift
+	$(call download_file,Projects/Modules/Network/Sources,$$GITHUB_ACCESS_TOKEN,Config.swift)
 	
 	# Xcconfigs
 
-	@if [ ! -d xcconfigs/Base ]; then \
-		mkdir -p xcconfigs/Base/Projects; \
-		mkdir -p xcconfigs/Base/Targets; \
-	fi
-
-	@if [ ! -d xcconfigs/targets ]; then \
-		mkdir -p xcconfigs/targets; \
-	fi
-	
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Common.xcconfig $(BASE_URL)/xcconfigs/Base/Common.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-Development.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-Development.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-PROD.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-PROD.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-QA.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-QA.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Project-Test.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Project-Test.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Projects/Shared.xcconfig $(BASE_URL)/xcconfigs/Base/Projects/Shared.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Application.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Application.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Extension.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Extension.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/Framework.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/Framework.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/Base/Targets/StaticLibrary.xcconfig $(BASE_URL)/xcconfigs/Base/Targets/StaticLibrary.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Demo.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Demo.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Framework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Framework.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-StaticFramework.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-StaticFramework.xcconfig
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o xcconfigs/targets/iOS-Tests.xcconfig $(BASE_URL)/xcconfigs/targets/iOS-Tests.xcconfig
+	$(eval TOTAL_ITEMS = $(words $(XCCONFIG_PATHS)))
+	$(foreach index, $(shell seq 1 2 $(TOTAL_ITEMS)), \
+		$(eval DIR = $(word $(index), $(XCCONFIG_PATHS))) \
+		$(eval FILE = $(word $(shell expr $(index) + 1), $(XCCONFIG_PATHS))) \
+		$(call download_file,$(DIR),$$GITHUB_ACCESS_TOKEN,$(FILE)); \
+	)
 	
 	# GoogleService-info
-
-	@if [ ! -d Projects/SOPT-iOS/Resources ]; then \
-		mkdir -p Projects/SOPT-iOS/Resources; \
-	fi
 	
-	@if [ ! -d Projects/Demo/Resources ]; then \
-		mkdir -p Projects/Demo/Resources; \
-	fi
+	$(call download_file,Projects/SOPT-iOS/Resources,$$GITHUB_ACCESS_TOKEN,GoogleService-Info.plist)
+	$(call download_file,Projects/Demo/Resources,$$GITHUB_ACCESS_TOKEN,GoogleService-Info.plist)
 	
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/SOPT-iOS/Resources/GoogleService-Info.plist $(BASE_URL)/Projects/SOPT-iOS/Resources/GoogleService-Info.plist
-	curl -H "Authorization: token $$GITHUB_ACCESS_TOKEN" -o Projects/Demo/Resources/GoogleService-Info.plist $(BASE_URL)/Projects/Demo/Resources/GoogleService-Info.plist
+	# TestConfig.swift
+	
+	$(call download_file,Projects/Modules/TestCore/Sources,$$GITHUB_ACCESS_TOKEN,TestConfig.swift)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#251

## 🌱 PR Point

보안이 필요한 파일들을 편하게 관리할 수 있도록 private repo를 통해 관리하고, make script를 통해 다운로드합니다.
어차피 private repo에 접근할 수 있는 github access token이 필요하기 떄문에 gitignore시키지 않았습니다.

필요성
- 기존 gitignore된 파일들을 주고 받기가 어려움
- 버전 관리의 어려움
- 싱크를 맞추기 어려웠음

사용 방법
1. make download-privates 입력
2. Github Access Token을 입력하면 .env 파일이 생성되어 환경변수에 저장. 이후로는 download-privates만 입력하면 됨

https://github.com/sopt-makers/SOPT-iOS/assets/77208067/42f5855d-fa81-40e2-a15c-ce86a307c9cf

### 참고(github access token 생성) : [링크](https://blog.pocu.academy/ko/2022/01/06/how-to-generate-personal-access-token-for-github.html)
read:org 권한 체크해주세요!

## 📮 관련 이슈
- Resolved: #251 
