### PR TITLE
[Feat] #255 - 알림 디테일 뷰 UI

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -264,6 +264,7 @@ public struct I18N {
         public static let notification = "알림"
         public static let readAll = "모두 읽음"
         public static let emptyNotification = "아직 도착한 알림이 없어요."
+        public static let shortcut = "바로가기"
     }
 }
     

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -261,6 +261,7 @@ public struct I18N {
     }
     
     public struct Notification {
+        public static let notification = "알림"
         public static let readAll = "모두 읽음"
         public static let emptyNotification = "아직 도착한 알림이 없어요."
     }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/NotificationDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/NotificationDetailRepository.swift
@@ -1,0 +1,27 @@
+//
+//  NotificationDetailRepository.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+import Core
+import Domain
+import Network
+
+public class NotificationDetailRepository {
+    
+    private let networkService: UserService
+    private let cancelBag = CancelBag()
+    
+    public init(service: UserService) {
+        self.networkService = service
+    }
+}
+
+extension NotificationDetailRepository: NotificationDetailRepositoryInterface {
+    
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/NotificationDetailTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/NotificationDetailTransform.swift
@@ -1,0 +1,19 @@
+//
+//  NotificationDetailTransform.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Network
+
+extension NotificationDetailEntity {
+
+    public func toDomain() -> NotificationDetailModel {
+        return NotificationDetailModel.init()
+    }
+}

--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.sopt-stamp-iOS</string>
+	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/Demo/Sources/ModuleFactory/DIContainer.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/ModuleFactory/DIContainer.swift
@@ -275,4 +275,13 @@ extension DIContainer: Features {
         
         return notificationListVC
     }
+    
+    func makeNotificationDetailVC() -> NotificationDetailViewControllable {
+        let repository = NotificationDetailRepository(service: userService)
+        let useCase = DefaultNotificationDetailUseCase(repository: repository)
+        let viewModel = NotificationDetailViewModel(useCase: useCase)
+        let notificationDetailVC = NotificationDetailVC(viewModel: viewModel, factory: self)
+
+        return notificationDetailVC
+    }
 }

--- a/SOPT-iOS/Projects/Demo/Sources/ModuleFactory/DIContainer.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/ModuleFactory/DIContainer.swift
@@ -266,12 +266,10 @@ extension DIContainer: Features {
     // MARK: - NotificationFeature
     
     func makeNotificationListVC() -> NotificationListViewControllable {
-        let notificationListVC = NotificationListVC()
-        let repository = NotificationListRepository(service: userService) // 임시로 aut
+        let repository = NotificationListRepository(service: userService)
         let useCase = DefaultNotificationListUseCase(repository: repository)
         let viewModel = NotificationListViewModel(useCase: useCase)
-        notificationListVC.viewModel = viewModel
-        notificationListVC.factory = self
+        let notificationListVC = NotificationListVC(viewModel: viewModel, factory: self)
         
         return notificationListVC
     }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/NotificationDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/NotificationDetailModel.swift
@@ -1,0 +1,16 @@
+//
+//  NotificationDetailModel.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct NotificationDetailModel {
+
+    public init() {
+        
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/NotificationDetailRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/NotificationDetailRepositoryInterface.swift
@@ -1,0 +1,13 @@
+//
+//  NotificationDetailRepositoryInterface.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+public protocol NotificationDetailRepositoryInterface {
+  
+}

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/NotificationDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/NotificationDetailUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  NotificationDetailUseCase.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+import Core
+
+public protocol NotificationDetailUseCase {
+
+}
+
+public class DefaultNotificationDetailUseCase {
+  
+    private let repository: NotificationDetailRepositoryInterface
+    private var cancelBag = CancelBag()
+  
+    public init(repository: NotificationDetailRepositoryInterface) {
+        self.repository = repository
+    }
+}
+
+extension DefaultNotificationDetailUseCase: NotificationDetailUseCase {
+  
+}

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationFeatureViewControllable.swift
@@ -10,6 +10,9 @@ import Core
 
 public protocol NotificationListViewControllable: ViewControllable { }
 
+public protocol NotificationDetailViewControllable: ViewControllable { }
+
 public protocol NotificationFeatureViewBuildable {
     func makeNotificationListVC() -> NotificationListViewControllable
+    func makeNotificationDetailVC() -> NotificationDetailViewControllable
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
@@ -33,6 +33,66 @@ public final class NotificationDetailVC: UIViewController, NotificationDetailVie
     private lazy var naviBar = OPNavigationBar(self, type: .oneLeftButton)
         .addMiddleLabel(title: I18N.Notification.notification)
     
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        let scrollViewInset: UIEdgeInsets = .init(top: 0, left: 0, bottom: 80, right: 0)
+        scrollView.contentInset = scrollViewInset
+        scrollView.scrollIndicatorInsets = scrollViewInset
+        return scrollView
+    }()
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = DSKitAsset.Colors.black80.color
+        view.layer.cornerRadius = 10
+        return view
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .Attendance.h1
+        label.textColor = DSKitAsset.Colors.gray10.color
+        label.textAlignment = .left
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private let dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = DSKitAsset.Colors.black40.color
+        return view
+    }()
+    
+    private let textView: UITextView = {
+        let textView = UITextView()
+        textView.font = .Main.body1
+        textView.textColor = DSKitAsset.Colors.gray20.color
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.showsVerticalScrollIndicator = false
+        textView.isScrollEnabled = false
+        textView.textContainer.lineFragmentPadding = 0
+        return textView
+    }()
+    
+    private let shortCutButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.baseBackgroundColor = DSKitAsset.Colors.purple100.color
+        config.image = DSKitAsset.Assets.btnArrowRight.image.withTintColor(DSKitAsset.Colors.gray10.color)
+        config.background.cornerRadius = 10
+        config.imagePlacement = .trailing
+        config.contentInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 0)
+        
+        var attributeContainer = AttributeContainer()
+        attributeContainer.font = UIFont.Attendance.h1
+        attributeContainer.foregroundColor = DSKitAsset.Colors.gray10.color
+        
+        config.attributedTitle = AttributedString(I18N.Notification.shortcut, attributes: attributeContainer)
+        
+        let button = UIButton(configuration: config)
+        return button
+    }()
+    
     // MARK: - initialization
     
     public init(viewModel: NotificationDetailViewModel, factory: factoryType) {
@@ -60,13 +120,59 @@ public final class NotificationDetailVC: UIViewController, NotificationDetailVie
 extension NotificationDetailVC {
     private func setUI() {
         view.backgroundColor = DSKitAsset.Colors.black100.color
+        
+        // 임시 텍스트
+        titleLabel.text = "[GO SOPT] 32기 전체 회계 공지"
+        textView.text = I18N.ServiceUsagePolicy.termsOfService
     }
     
     private func setLayout() {
-        self.view.addSubviews(naviBar)
+        self.view.addSubviews(naviBar, scrollView, shortCutButton)
         
         naviBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(naviBar.snp.bottom).offset(20)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        setScrollViewLayout()
+        
+        shortCutButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(56)
+        }
+    }
+    
+    private func setScrollViewLayout() {
+        self.scrollView.addSubviews(contentView)
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalToSuperview()
+        }
+        
+        contentView.addSubviews(titleLabel, dividerView, textView)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(24)
+            make.leading.trailing.equalToSuperview().inset(12)
+        }
+        
+        dividerView.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(14)
+            make.leading.trailing.equalToSuperview().inset(12)
+            make.height.equalTo(1)
+        }
+        
+        textView.snp.makeConstraints { make in
+            make.top.equalTo(dividerView.snp.bottom).offset(24)
+            make.leading.trailing.equalToSuperview().inset(12)
+            make.bottom.equalToSuperview().inset(24)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
@@ -30,6 +30,8 @@ public final class NotificationDetailVC: UIViewController, NotificationDetailVie
   
     // MARK: - UI Components
     
+    private lazy var naviBar = OPNavigationBar(self, type: .oneLeftButton)
+        .addMiddleLabel(title: I18N.Notification.notification)
     
     // MARK: - initialization
     
@@ -57,11 +59,15 @@ public final class NotificationDetailVC: UIViewController, NotificationDetailVie
 
 extension NotificationDetailVC {
     private func setUI() {
-        
+        view.backgroundColor = DSKitAsset.Colors.black100.color
     }
     
     private func setLayout() {
+        self.view.addSubviews(naviBar)
         
+        naviBar.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
@@ -1,0 +1,76 @@
+//
+//  NotificationDetailVC.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import DSKit
+
+import Combine
+import SnapKit
+import Then
+
+import BaseFeatureDependency
+import NotificationFeatureInterface
+
+public final class NotificationDetailVC: UIViewController, NotificationDetailViewControllable {
+    
+    public typealias factoryType = AlertViewBuildable
+    
+    // MARK: - Properties
+    
+    public var viewModel: NotificationDetailViewModel
+    public var factory: factoryType
+    private var cancelBag = CancelBag()
+  
+    // MARK: - UI Components
+    
+    
+    // MARK: - initialization
+    
+    public init(viewModel: NotificationDetailViewModel, factory: factoryType) {
+        self.viewModel = viewModel
+        self.factory = factory
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        self.bindViewModels()
+        self.setUI()
+        self.setLayout()
+    }
+}
+
+// MARK: - UI & Layout
+
+extension NotificationDetailVC {
+    private func setUI() {
+        
+    }
+    
+    private func setLayout() {
+        
+    }
+}
+
+// MARK: - Methods
+
+extension NotificationDetailVC {
+  
+    private func bindViewModels() {
+        let input = NotificationDetailViewModel.Input()
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+    }
+}

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
@@ -110,6 +110,7 @@ public final class NotificationDetailVC: UIViewController, NotificationDetailVie
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.bindViewModels()
+        self.bindViews()
         self.setUI()
         self.setLayout()
     }
@@ -184,5 +185,13 @@ extension NotificationDetailVC {
     private func bindViewModels() {
         let input = NotificationDetailViewModel.Input()
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+    }
+    
+    private func bindViews() {
+        self.shortCutButton.publisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                print("바로가기 버튼 터치: \(owner)")
+            }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  NotificationDetailViewModel.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Core
+import Domain
+
+public class NotificationDetailViewModel: ViewModelType {
+
+    // MARK: - Properties
+    
+    private let useCase: NotificationDetailUseCase
+    private var cancelBag = CancelBag()
+  
+    // MARK: - Inputs
+    
+    public struct Input {
+    
+    }
+    
+    // MARK: - Outputs
+    
+    public struct Output {
+    
+    }
+    
+    // MARK: - init
+  
+    public init(useCase: NotificationDetailUseCase) {
+        self.useCase = useCase
+    }
+}
+
+// MARK: - Methods
+
+extension NotificationDetailViewModel {
+    public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        self.bindOutput(output: output, cancelBag: cancelBag)
+        // input,output 상관관계 작성
+    
+        return output
+    }
+  
+    private func bindOutput(output: Output, cancelBag: CancelBag) {
+    
+    }
+}

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -30,7 +30,8 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
     
     // MARK: - UI Components
     
-    lazy var naviBar = OPNavigationBar(self, type: .bothButtons)
+    private lazy var naviBar = OPNavigationBar(self, type: .bothButtons)
+        .addMiddleLabel(title: I18N.Notification.notification)
         .addRightButton(with: nil)
         .addRightButton(with: I18N.Notification.readAll, titleColor: DSKitAsset.Colors.purple100.color)
     
@@ -147,7 +148,11 @@ extension NotificationListVC {
 
 extension NotificationListVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print(indexPath)
+        
+        if collectionView == notificationListCollectionView {
+            let notificationDetailVC = factory.makeNotificationDetailVC().viewController
+            self.navigationController?.pushViewController(notificationDetailVC, animated: true)
+        }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -24,8 +24,8 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
 
     // MARK: - Properties
     
-    public var viewModel: NotificationListViewModel!
-    public var factory: factoryType!
+    public var viewModel: NotificationListViewModel
+    public var factory: factoryType
     private var cancelBag = CancelBag()
     
     // MARK: - UI Components
@@ -57,6 +57,19 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
         view.isHidden = true
         return view
     }()
+    
+    
+    // MARK: - initialization
+    
+    public init(viewModel: NotificationListViewModel, factory: factoryType) {
+        self.viewModel = viewModel
+        self.factory = factory
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - View Life Cycle
     

--- a/SOPT-iOS/Projects/Modules/DSKit/Resources/Colors.xcassets/Main/GrayScale/gray20.colorset/Contents.json
+++ b/SOPT-iOS/Projects/Modules/DSKit/Resources/Colors.xcassets/Main/GrayScale/gray20.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF1",
+          "green" : "0xEF",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationDetailEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationDetailEntity.swift
@@ -1,0 +1,13 @@
+//
+//  NotificationDetailEntity.swift
+//  NotificationFeature
+//
+//  Created by sejin on 2023/06/16.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct NotificationDetailEntity {
+    
+}

--- a/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
+++ b/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.sopt-stamp-iOS</string>
+	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/ModuleFactory/DIContainer.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/ModuleFactory/DIContainer.swift
@@ -266,12 +266,10 @@ extension DIContainer: Features {
     // MARK: - NotificationFeature
     
     func makeNotificationListVC() -> NotificationListViewControllable {
-        let notificationListVC = NotificationListVC()
         let repository = NotificationListRepository(service: userService)
         let useCase = DefaultNotificationListUseCase(repository: repository)
         let viewModel = NotificationListViewModel(useCase: useCase)
-        notificationListVC.viewModel = viewModel
-        notificationListVC.factory = self
+        let notificationListVC = NotificationListVC(viewModel: viewModel, factory: self)
         
         return notificationListVC
     }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/ModuleFactory/DIContainer.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/ModuleFactory/DIContainer.swift
@@ -267,12 +267,21 @@ extension DIContainer: Features {
     
     func makeNotificationListVC() -> NotificationListViewControllable {
         let notificationListVC = NotificationListVC()
-        let repository = NotificationListRepository(service: userService) // 임시로 aut
+        let repository = NotificationListRepository(service: userService)
         let useCase = DefaultNotificationListUseCase(repository: repository)
         let viewModel = NotificationListViewModel(useCase: useCase)
         notificationListVC.viewModel = viewModel
         notificationListVC.factory = self
         
         return notificationListVC
+    }
+    
+    func makeNotificationDetailVC() -> NotificationDetailViewControllable {
+        let repository = NotificationDetailRepository(service: userService)
+        let useCase = DefaultNotificationDetailUseCase(repository: repository)
+        let viewModel = NotificationDetailViewModel(useCase: useCase)
+        let notificationDetailVC = NotificationDetailVC(viewModel: viewModel, factory: self)
+
+        return notificationDetailVC
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
🌱 작업한 브랜치
- feature/#255

## 🌱 PR Point
- 알림 디테일 뷰 UI 를 구현했습니다.
- 일단은 알림 리스트 뷰에서 아무 Cell 클릭하면 동일한 디테일 뷰로 넘어가도록 했습니다.
- 하단에 있는 바로가기 버튼은 알림의 종류가 공지 속성이면 숨김 처리해야합니다. 이는 API 연결하면서 처리하겠습니다!

++ 위젯 구현을 위해 App Group을 생성해서 Prod와 Demo앱 모두에 적용했습니다. 그룹 명 : group.com.sopt-stamp-iOS

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 이제 알림 뷰 관련 API 들 연결 작업 하겠습니다. (디바이스 토큰 등록, 알림 리스트 조회 api)
- 노션 명세서에 알림 관련 api 들이 올라왔는데 "알림 단건 등록 api"가 어떤 건지 확실하지가 않아서 이건 내일 전체 모임에서 한번 물어볼 예정입니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|NotificationDetailVC|![Simulator Screen Recording - iPhone 14 - 2023-06-17 at 22 51 45](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/72111919-9e9a-40b6-90ad-11cd574213ee)|

## 📮 관련 이슈
- Resolved: #255 
