### PR TITLE
[Improvement] 설정 하위 뷰에 있는 보라색 제거

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
@@ -40,11 +40,10 @@ extension DefaultSplashUseCase: SplashUseCase {
         .sink { event in
             print("DefaultSplashUseCase : \(event)")
         } receiveValue: { appNoticeModel in
-#if DEV
+#if DEV || TEST
             self.appNoticeModel.send(nil)
             return
 #endif
-          
             guard appNoticeModel.withError == false else {
                 self.appNoticeModel.send(appNoticeModel)
                 return

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMyPageSubScenes/VC/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMyPageSubScenes/VC/SentenceEditVC.swift
@@ -159,10 +159,12 @@ extension SentenceEditVC: UITextViewDelegate {
     }
     
     public func textViewDidBeginEditing(_ textView: UITextView) {
-        textView.layer.borderColor = DSKitAsset.Colors.purple100.color.cgColor
+        textView.layer.borderColor = DSKitAsset.Colors.white100.color.cgColor
+        textView.backgroundColor = DSKitAsset.Colors.black100.color
     }
     
     public func textViewDidEndEditing(_ textView: UITextView) {
+        textView.backgroundColor = DSKitAsset.Colors.black80.color
         textView.layer.borderColor = nil
     }
 }

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/AppComponents/AppTextFieldView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/AppComponents/AppTextFieldView.swift
@@ -74,7 +74,7 @@ public enum AppTextFieldViewState {
         case .normal, .editing:
             return nil
         case .confirmAlert:
-            return DSKitAsset.Colors.purple100.color // 이건 어디서 쓰는건지 피그마에 안 나와있네
+            return DSKitAsset.Colors.purple100.color
         case .warningAlert:
             return DSKitAsset.Colors.red100.color
         }
@@ -175,7 +175,6 @@ public class AppTextFieldView: UIView {
     private let subTitleLabel = UILabel()
     private let textField = UITextField()
     
-    // 얘도 없어진거 아녀유? (@승호) 확인하고 이 주석 지우겟음
     private let rightButton = UIButton()
     private let alertlabel = UILabel()
 

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/AppComponents/AppTextFieldView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/AppComponents/AppTextFieldView.swift
@@ -63,7 +63,7 @@ public enum AppTextFieldViewState {
         case .normal:
             return nil
         case .editing, .confirmAlert:
-            return DSKitAsset.Colors.purple100.color.cgColor
+            return DSKitAsset.Colors.white100.color.cgColor
         case .warningAlert:
             return DSKitAsset.Colors.red100.color.cgColor
         }
@@ -74,7 +74,7 @@ public enum AppTextFieldViewState {
         case .normal, .editing:
             return nil
         case .confirmAlert:
-            return DSKitAsset.Colors.purple100.color
+            return DSKitAsset.Colors.purple100.color // 이건 어디서 쓰는건지 피그마에 안 나와있네
         case .warningAlert:
             return DSKitAsset.Colors.red100.color
         }
@@ -175,6 +175,7 @@ public class AppTextFieldView: UIView {
     private let subTitleLabel = UILabel()
     private let textField = UITextField()
     
+    // 얘도 없어진거 아녀유? (@승호) 확인하고 이 주석 지우겟음
     private let rightButton = UIButton()
     private let alertlabel = UILabel()
 


### PR DESCRIPTION
## 🌴 PR 요약
설정 하위에 보라색을 제거해 보았어요

🌱 작업한 브랜치
- improvement/eliminate~

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|            <center>as-is</center>             |    <center>to-be</center>     |
| :-----------------------------------------: | :-------------------------: |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/953ca62b-0d1e-4224-91d2-383de8bc50f1">| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/dcb766d7-a6d2-4942-b3e6-25e5504938a7"> |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/de74e65f-9c57-40c4-83e0-64612b42ea97">| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/597a9adf-3315-4b62-93b9-676d294aaf9a"> |

## 📮 관련 이슈
- Resolved: #276 
