### PR TITLE
[Chore] #284 - 출석 뷰 그라데이션 넣는 로직 변경

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/createGradientLayer.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/createGradientLayer.swift
@@ -1,0 +1,37 @@
+//
+//  createGradientLayer.swift
+//  Core
+//
+//  Created by devxsby on 2023/09/20.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+public extension UIView {
+    
+    @frozen
+    enum GradientDirection {
+        case vertical
+        case horizontal
+    }
+    
+    @discardableResult
+    func createGradientLayer(colors: [UIColor], direction: GradientDirection) -> CAGradientLayer {
+        let gradient = CAGradientLayer()
+        gradient.frame = bounds
+        gradient.colors = colors.map { $0.cgColor }
+        
+        switch direction {
+        case .vertical:
+            gradient.startPoint = CGPoint(x: 0.5, y: 0)
+            gradient.endPoint = CGPoint(x: 0.5, y: 1)
+        case .horizontal:
+            gradient.startPoint = CGPoint(x: 0, y: 0.5)
+            gradient.endPoint = CGPoint(x: 1, y: 0.5)
+        }
+        
+        layer.insertSublayer(gradient, at: 0)
+        return gradient
+    }
+}

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -15,7 +15,9 @@ import Domain
 import DSKit
 
 import SnapKit
+
 import AttendanceFeatureInterface
+import BaseFeatureDependency
 import SafariServices
 
 public final class ShowAttendanceVC: UIViewController, ShowAttendanceViewControllable {
@@ -66,6 +68,8 @@ public final class ShowAttendanceVC: UIViewController, ShowAttendanceViewControl
         stackView.addArrangedSubview(attendanceButton)
         return stackView
     }()
+    
+    private let attendanceGradientView = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 200))
     
     private let attendanceButton: OPCustomButton = {
         let button = OPCustomButton()
@@ -123,11 +127,11 @@ extension ShowAttendanceVC {
         self.navigationController?.navigationBar.isHidden = true
         self.view.backgroundColor = DSKitAsset.Colors.black100.color
         containerScrollView.backgroundColor = DSKitAsset.Colors.black100.color
-        attendanceButtonStackView.layer.applyShadow(color: .black, alpha: 1, x: 0, y: -8, blur: 250, spread: 0, radius: 8.0) // 버튼 위쪽 그라데이션 추가
+        attendanceGradientView.createGradientLayer(colors: [.clear, .black], direction: .vertical)
     }
     
     private func setLayout() {
-        view.addSubviews(navibar, containerScrollView, attendanceButtonStackView)
+        view.addSubviews(navibar, containerScrollView, attendanceGradientView, attendanceButtonStackView)
         containerScrollView.addSubview(contentView)
         contentView.addSubviews(headerScheduleView, attendanceScoreView)
         attendanceScoreView.addSubview(infoButton)
@@ -156,6 +160,12 @@ extension ShowAttendanceVC {
             $0.top.equalTo(headerScheduleView.snp.bottom).offset(20)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             $0.bottom.equalToSuperview()
+        }
+        
+        attendanceGradientView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(200)
         }
         
         attendanceButtonStackView.snp.makeConstraints {
@@ -226,9 +236,11 @@ extension ShowAttendanceVC {
                     self.headerScheduleView.scheduleType = .scheduledDay
                     self.setScheduledData(model)
                     self.attendanceButton.isHidden = false
+                    self.attendanceGradientView.isHidden = false
                 } else {
                     self.headerScheduleView.scheduleType = .unscheduledDay
                     self.attendanceButton.isHidden = true
+                    self.attendanceGradientView.isHidden = true
                 }
                 self.endRefresh()
             })
@@ -241,7 +253,7 @@ extension ShowAttendanceVC {
                 self.setScoreData(model)
                 self.endRefresh()
             }.store(in: self.cancelBag)
-       
+        
         output.attendanceButtonInfo
             .withUnretained(self)
             .sink { owner, info in
@@ -271,7 +283,7 @@ extension ShowAttendanceVC {
         
         if self.sceneType == .scheduledDay {
             let date = viewModel.formatTimeInterval(startDate: model.startDate,
-                                                          endDate: model.endDate)
+                                                    endDate: model.endDate)
             headerScheduleView.setData(date: date,
                                        place: model.location,
                                        todaySchedule: model.name,

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/VC/ShowAttendanceVC.swift
@@ -163,8 +163,7 @@ extension ShowAttendanceVC {
         }
         
         attendanceGradientView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
             $0.height.equalTo(200)
         }
         


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#284

## 🌱 PR Point
- 하단 출석 버튼 위에 있는 그라디언트 넣는 부분 디자인 변경을 반영했습니다.
- 눈을 크게 뜨고 보시면 달라요 ^^..
- 어디선가 쓸 수 있기를 바라며 유틸 파일로 분리했습니다!

## 📌 참고 사항
- `attendanceGradientView` 선언 부분 프레임 크기를 안잡으면 뷰에 나타나지 않아서 일단 잡아놨는데 다른 방법은 뭐가 있을까요?

## 📸 스크린샷
| 이전 | 이후 |
|:--:|:--:|
|![Simulator Screenshot - iPhone 14 Pro - 2023-09-20 at 14 14 08](https://github.com/sopt-makers/SOPT-iOS/assets/80062632/f4b07c62-b0d2-4423-b1c2-62fdbd83e831)|![Simulator Screenshot - iPhone 14 Pro - 2023-09-20 at 20 08 43](https://github.com/sopt-makers/SOPT-iOS/assets/80062632/b59e046d-3031-41cf-b721-d1848298d37b)|

## 📮 관련 이슈
- Resolved: #284
