### PR TITLE
[Feat] 솝탬프 최근 기수인 경우 최근 기수에 맞추어 버튼, 랭킹리스트를 반환하도록 개선

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
@@ -16,11 +16,17 @@ public class MissionListRepository {
     
     private let missionService: MissionService
     private let rankService: RankService
+    private let userService: UserService
     private let cancelBag = CancelBag()
     
-    public init(missionService: MissionService, rankService: RankService) {
+    public init(
+        missionService: MissionService,
+        rankService: RankService,
+        userService: UserService
+    ) {
         self.missionService = missionService
         self.rankService = rankService
+        self.userService = userService
     }
 }
 
@@ -31,6 +37,13 @@ extension MissionListRepository: MissionListRepositoryInterface {
         }
         
         return fetchRankDetail(userName: userName)
+    }
+    
+    public func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error> {
+        self.userService
+            .fetchActiveGenerationStatus()
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
     }
 }
 

--- a/SOPT-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/RankingRepository.swift
@@ -23,9 +23,9 @@ public class RankingRepository {
 }
 
 extension RankingRepository: RankingRepositoryInterface {
-    public func fetchRankingListModel() -> AnyPublisher<[Domain.RankingModel], Error> {
+    public func fetchRankingListModel(isCurrentGeneration: Bool) -> AnyPublisher<[Domain.RankingModel], Error> {
         return self.rankService
-            .fetchRankingList()
+            .fetchRankingList(isCurrentGeneration: isCurrentGeneration)
             .map({ entity in
                 entity.map { $0.toDomain() }
             })

--- a/SOPT-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/Rankingtransform.swift
@@ -13,7 +13,6 @@ import Domain
 import Network
 
 extension RankingEntity {
-    
     public func toDomain() -> RankingModel {
         return .init(username: self.nickname,
                      score: self.point,

--- a/SOPT-iOS/Projects/Data/Sources/Transform/UsersActiveGenerationStateTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/UsersActiveGenerationStateTransform.swift
@@ -1,0 +1,28 @@
+//
+//  UsersActiveGenerationStatusTransform.swift
+//  Data
+//
+//  Created by Ian on 9/20/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Domain
+import Network
+
+extension UsersActiveGenerationStatusEntity {
+    func toDomain() -> UsersActiveGenerationStatusViewResponse {
+        .init(
+            currentGeneration: self.currentGeneration,
+            status: self.status.toDomain()
+        )
+    }
+}
+
+extension Network.UsersActivationState {
+    func toDomain() -> Domain.UsersActivationState {
+        switch self {
+        case .ACTIVE: return .ACTIVE
+        case .INACTIVE: return .INACTIVE
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -90,7 +90,8 @@ extension AppDelegate {
             implement: {
                 MissionListRepository(
                     missionService: DefaultMissionService(),
-                    rankService: DefaultRankService()
+                    rankService: DefaultRankService(),
+                    userService: DefaultUserService()
                 )
             }
         )

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MissionListRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MissionListRepositoryInterface.swift
@@ -12,4 +12,5 @@ import Core
 
 public protocol MissionListRepositoryInterface {
     func fetchMissionList(type: MissionListFetchType, userName: String?) -> AnyPublisher<[MissionListModel], Error>
+    func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/RankingRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/RankingRepositoryInterface.swift
@@ -9,5 +9,5 @@
 import Combine
 
 public protocol RankingRepositoryInterface {
-    func fetchRankingListModel() -> AnyPublisher<[RankingModel], Error>
+    func fetchRankingListModel(isCurrentGeneration: Bool) -> AnyPublisher<[RankingModel], Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Response/UsersActiveGenerationInfoViewResponse.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Response/UsersActiveGenerationInfoViewResponse.swift
@@ -1,0 +1,25 @@
+//
+//  UsersActiveGenerationStatusViewResponse.swift
+//  Domain
+//
+//  Created by Ian on 9/20/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+public struct UsersActiveGenerationStatusViewResponse: Equatable {
+    public let currentGeneration: Int
+    public let status: UsersActivationState
+    
+    public init(
+        currentGeneration: Int,
+        status: UsersActivationState
+    ) {
+        self.currentGeneration = currentGeneration
+        self.status = status
+    }
+}
+
+public enum UsersActivationState: String, Decodable {
+    case ACTIVE
+    case INACTIVE
+}

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
@@ -13,7 +13,10 @@ import Core
 public protocol MissionListUseCase {
     func fetchMissionList(type: MissionListFetchType)
     func fetchOtherUserMissionList(userName: String)
+    func fetchIsActiveGenerationUser()
+
     var missionListModelsFetched: PassthroughSubject<[MissionListModel], Error> { get set }
+    var usersActiveGenerationInfo: PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error> { get set }
 }
 
 public class DefaultMissionListUseCase {
@@ -21,7 +24,8 @@ public class DefaultMissionListUseCase {
     private let repository: MissionListRepositoryInterface
     private var cancelBag = CancelBag()
     public var missionListModelsFetched = PassthroughSubject<[MissionListModel], Error>()
-  
+    public var usersActiveGenerationInfo = PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error>()
+    
     public init(repository: MissionListRepositoryInterface) {
         self.repository = repository
     }
@@ -36,6 +40,16 @@ extension DefaultMissionListUseCase: MissionListUseCase {
                 self.missionListModelsFetched.send(model)
             })
             .store(in: cancelBag)
+    }
+    
+    public func fetchIsActiveGenerationUser() {
+        self.repository
+            .fetchIsActiveGenerationUser()
+            .sink(receiveCompletion: { event in
+                print("completion: \(event)")
+            }, receiveValue: { usersActiveGenerationStatus in
+                self.usersActiveGenerationInfo.send(usersActiveGenerationStatus)
+            }).store(in: self.cancelBag)
     }
     
     public func fetchOtherUserMissionList(userName: String) {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/RankingUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/RankingUseCase.swift
@@ -11,7 +11,7 @@ import Combine
 import Core
 
 public protocol RankingUseCase {
-    func fetchRankingList()
+    func fetchRankingList(isCurrentGeneration: Bool)
     func findMyRanking()
     var rankingListModelFetched: CurrentValueSubject<[RankingModel], Error> { get }
     var myRanking: PassthroughSubject<(section: Int, item: Int), Error> { get set }
@@ -30,8 +30,9 @@ public class DefaultRankingUseCase {
 }
 
 extension DefaultRankingUseCase: RankingUseCase {
-    public func fetchRankingList() {
-        self.repository.fetchRankingListModel()
+    public func fetchRankingList(isCurrentGeneration: Bool) {
+        self.repository
+            .fetchRankingListModel(isCurrentGeneration: isCurrentGeneration)
             .map { model in
                 var newModel = model
                 let myRankingIndex = self.findMyRankingIndex(model: model)

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
@@ -7,7 +7,13 @@
 //
 
 import Core
+import Domain
 import BaseFeatureDependency
+
+public enum RankingViewType {
+    case all
+    case currentGeneration(info: UsersActiveGenerationStatusViewResponse)
+}
 
 public protocol StampFeatureViewBuildable {
     func makeMissionListVC(sceneType: MissionListSceneType) -> MissionListViewControllable
@@ -22,6 +28,6 @@ public protocol StampFeatureViewBuildable {
         starLevel: StarViewLevel,
         completionHandler: (() -> Void)?
     ) -> MissionCompletedViewControllable
-    func makeRankingVC() -> RankingViewControllable
+    func makeRankingVC(rankingViewType: RankingViewType) -> RankingViewControllable
     func makeStampGuideVC() -> StampGuideViewControllable
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
@@ -14,7 +14,8 @@ public protocol MissionListViewControllable: ViewControllable & MissionListCoord
 public protocol MissionListCoordinatable {
     var onSwiped: (() -> Void)? { get set }
     var onNaviBackTap: (() -> Void)? { get set }
-    var onRankingButtonTap: (() -> Void)? { get set }
+    var onRankingButtonTap: ((RankingViewType) -> Void)? { get set }
+    var onCurrentGenerationRankingButtonTap: ((RankingViewType) -> Void)? { get set }
     var onGuideTap: (() -> Void)? { get set }
     var onCellTap: ((MissionListModel, _ username: String?) -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/RankingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/RankingCoordinator.swift
@@ -18,10 +18,16 @@ final class RankingCoordinator: DefaultCoordinator {
     
     private let factory: StampFeatureViewBuildable
     private let router: Router
+    private let rankingViewType: RankingViewType
     
-    public init(router: Router, factory: StampFeatureViewBuildable) {
+    public init(
+        router: Router,
+        factory: StampFeatureViewBuildable,
+        rankingViewType: RankingViewType
+    ) {
         self.factory = factory
         self.router = router
+        self.rankingViewType = rankingViewType
     }
     
     public override func start() {
@@ -29,7 +35,7 @@ final class RankingCoordinator: DefaultCoordinator {
     }
     
     private func showRanking() {
-        var ranking = factory.makeRankingVC()
+        var ranking = factory.makeRankingVC(rankingViewType: self.rankingViewType)
         ranking.onSwiped = { [weak self] in
             self?.router.popModule()
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -61,10 +61,13 @@ extension StampBuilder: StampFeatureViewBuildable {
         return missionCompletedVC
     }
     
-    public func makeRankingVC() -> RankingViewControllable {
+    public func makeRankingVC(rankingViewType: RankingViewType) -> RankingViewControllable {
         let useCase = DefaultRankingUseCase(repository: rankingRepository)
-        let viewModel = RankingViewModel(useCase: useCase)
-        let rankingVC = RankingVC()
+        let viewModel = RankingViewModel(
+            rankingViewType: rankingViewType,
+            useCase: useCase
+        )
+        let rankingVC = RankingVC(rankingViewType: rankingViewType)
         rankingVC.viewModel = viewModel
         return rankingVC
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -62,10 +62,11 @@ final class StampCoordinator: DefaultCoordinator {
         guideCoordinator.start()
     }
     
-    private func runRankingFlow() {
+    private func runRankingFlow(rankingViewType: RankingViewType) {
         let rankingCoordinator = RankingCoordinator(
             router: Router(rootController: rootController!),
-            factory: factory
+            factory: factory,
+            rankingViewType: rankingViewType
         )
         rankingCoordinator.finishFlow = { [weak self, weak rankingCoordinator] in
             self?.removeDependency(rankingCoordinator)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -41,8 +41,11 @@ final class StampCoordinator: DefaultCoordinator {
         missionList.onGuideTap = { [weak self] in
             self?.showGuide()
         }
-        missionList.onRankingButtonTap = { [weak self] in
-            self?.runRankingFlow()
+        missionList.onRankingButtonTap = { [weak self] rankingViewType in
+            self?.runRankingFlow(rankingViewType: rankingViewType)
+        }
+        missionList.onCurrentGenerationRankingButtonTap = { [weak self] rankingViewType in
+            self?.runRankingFlow(rankingViewType: rankingViewType)
         }
         missionList.onCellTap = { [weak self] model, username in
             self?.runMissionDetailFlow(model, username)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -118,7 +118,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
         bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
         bt.tintColor = .white
         bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
-        let attributedStr = NSMutableAttributedString(string: "랭킹 보기")
+        let attributedStr = NSMutableAttributedString(string: "전체 랭킹")
         let style = NSMutableParagraphStyle()
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -29,6 +29,7 @@ public class MissionListViewModel: ViewModelType {
     
     public class Output: NSObject {
         @Published var missionListModel: [MissionListModel]?
+        @Published var usersActivateGenerationStatus: UsersActiveGenerationStatusViewResponse?
     }
     
     // MARK: - init
@@ -48,6 +49,7 @@ extension MissionListViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.fetchMissionList(type: input.missionTypeSelected.value)
+                owner.useCase.fetchIsActiveGenerationUser()
             }.store(in: cancelBag)
         
         input.missionTypeSelected
@@ -66,7 +68,14 @@ extension MissionListViewModel {
             self.useCase.fetchOtherUserMissionList(userName: userName)
         default:
             self.useCase.fetchMissionList(type: type)
+            
         }
+    }
+    
+    private func fetchIsActiveGerationUser(type: MissionListFetchType) {
+        guard case .default = self.missionListsceneType else { return }
+        
+        self.useCase.fetchIsActiveGenerationUser()
     }
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
@@ -77,5 +86,12 @@ extension MissionListViewModel {
                 output.missionListModel = model
             })
             .store(in: self.cancelBag)
+        
+        self.useCase
+            .usersActiveGenerationInfo
+            .asDriver()
+            .sink { usersActivateGenerationStatus in
+                output.usersActivateGenerationStatus = usersActivateGenerationStatus
+            }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -67,6 +67,22 @@ public class RankingVC: UIViewController, RankingViewControllable {
     }()
     
     // MARK: - View Life Cycle
+    private let rankingViewType: RankingViewType
+    
+    init(rankingViewType: RankingViewType) {
+        self.rankingViewType = rankingViewType
+
+        super.init(nibName: nil, bundle: nil)
+
+        guard case .currentGeneration(let info) = rankingViewType else { return }
+        
+        let navigationTitle = String(describing: info.currentGeneration) + "기 랭킹"
+        self.naviBar.setTitle(navigationTitle)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
@@ -10,11 +10,14 @@ import Combine
 
 import Core
 import Domain
+import StampFeatureInterface
 
 public class RankingViewModel: ViewModelType {
     
     private let useCase: RankingUseCase
     private var cancelBag = CancelBag()
+    
+    private let rankingViewType: RankingViewType
     
     // MARK: - Inputs
     
@@ -33,7 +36,11 @@ public class RankingViewModel: ViewModelType {
     
     // MARK: - init
     
-    public init(useCase: RankingUseCase) {
+    public init(
+        rankingViewType: RankingViewType,
+        useCase: RankingUseCase
+    ) {
+        self.rankingViewType = rankingViewType
         self.useCase = useCase
     }
 }
@@ -47,7 +54,10 @@ extension RankingViewModel {
         input.viewDidLoad.merge(with: input.refreshStarted)
             .withUnretained(self)
             .sink { owner, _ in
-                owner.useCase.fetchRankingList()
+                switch self.rankingViewType {
+                case .all: owner.useCase.fetchRankingList(isCurrentGeneration: false)
+                case .currentGeneration: owner.useCase.fetchRankingList(isCurrentGeneration: true)
+                }
             }.store(in: self.cancelBag)
         
         input.showMyRankingButtonTapped

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/RankAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/RankAPI.swift
@@ -13,6 +13,7 @@ import Moya
 
 public enum RankAPI {
     case rank
+    case currentRank
     case rankDetail(userName: String)
 }
 
@@ -34,6 +35,8 @@ extension RankAPI: BaseAPI {
         switch self {
         case .rank:
             return ""
+        case .currentRank:
+            return "/current"
         case .rankDetail:
             return "/detail"
         }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
@@ -20,6 +20,7 @@ public enum UserAPI {
     case getUserMainInfo
     case withdrawal
     case registerPushToken(token: String)
+    case fetchActiveGenerationStatus
 }
 
 extension UserAPI: BaseAPI {
@@ -43,13 +44,15 @@ extension UserAPI: BaseAPI {
             return ""
         case .registerPushToken:
             return "/push-token"
+        case .fetchActiveGenerationStatus:
+            return "/generation"
         }
     }
     
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .getNicknameAvailable, .getUserMainInfo, .fetchSoptampUser:
+        case .getNicknameAvailable, .getUserMainInfo, .fetchSoptampUser, .fetchActiveGenerationStatus:
             return .get
         case .editSentence, .changeNickname:
             return .patch

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/UsersActiveGenerationStatusEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/UsersActiveGenerationStatusEntity.swift
@@ -1,0 +1,30 @@
+//
+//  UsersActiveGenerationStatusEntity.swift
+//  Network
+//
+//  Created by Ian on 9/20/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+public struct UsersActiveGenerationStatusEntity {
+    public let currentGeneration: Int
+    public let status: UsersActivationState
+}
+
+extension UsersActiveGenerationStatusEntity: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case currentGeneration, status
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.currentGeneration = (try? container.decode(Int.self, forKey: .currentGeneration)) ?? 0
+        self.status = (try? container.decode(UsersActivationState.self, forKey: .status)) ?? .INACTIVE
+    }
+}
+
+public enum UsersActivationState: String, Decodable {
+    case ACTIVE
+    case INACTIVE
+}

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/RankService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/RankService.swift
@@ -15,14 +15,13 @@ import Moya
 public typealias DefaultRankService = BaseService<RankAPI>
 
 public protocol RankService {
-    func fetchRankingList() -> AnyPublisher<[RankingEntity], Error>
+    func fetchRankingList(isCurrentGeneration: Bool) -> AnyPublisher<[RankingEntity], Error>
     func fetchRankDetail(userName: String) -> AnyPublisher<RankDetailEntity, Error>
 }
 
 extension DefaultRankService: RankService {
-
-    public func fetchRankingList() -> AnyPublisher<[RankingEntity], Error> {
-        requestObjectInCombine(RankAPI.rank)
+    public func fetchRankingList(isCurrentGeneration: Bool) -> AnyPublisher<[RankingEntity], Error> {
+        requestObjectInCombine(isCurrentGeneration ? RankAPI.currentRank : RankAPI.rank)
     }
     
     public func fetchRankDetail(userName: String) -> AnyPublisher<RankDetailEntity, Error> {

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
@@ -23,6 +23,7 @@ public protocol UserService {
     func getUserMainInfo() -> AnyPublisher<MainEntity, Error>
     func withdraw() -> AnyPublisher<Int, Error>
     func registerPushToken(with token: String) -> AnyPublisher<Int, Error>
+    func fetchActiveGenerationStatus() -> AnyPublisher<UsersActiveGenerationStatusEntity, Error>
 }
 
 extension DefaultUserService: UserService {
@@ -52,5 +53,9 @@ extension DefaultUserService: UserService {
  
     public func registerPushToken(with token: String) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.registerPushToken(token: token))
+    }
+    
+    public func fetchActiveGenerationStatus() -> AnyPublisher<UsersActiveGenerationStatusEntity, Error> {
+        requestObjectInCombine(.fetchActiveGenerationStatus)
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -90,7 +90,8 @@ extension AppDelegate {
             implement: {
                 MissionListRepository(
                     missionService: DefaultMissionService(),
-                    rankService: DefaultRankService()
+                    rankService: DefaultRankService(),
+                    userService: DefaultUserService()
                 )
             }
         )


### PR DESCRIPTION
## 🌴 PR 요약
제목과 같고요

🌱 작업한 브랜치
- feature/add-current-rank-option-on-soptamp

## 🌱 PR Point
1. 4칸 인덴트가 길다는 생각을 했습니다.. 😀 2칸 제법 멋드러집니다
2. 특별히 염려되는 것은 없습니다

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|            <center> 사진과 </center>             |    <center> 간단한 설명이에요 </center>     |
| :-----------------------------------------: | :-------------------------: |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/afec43be-2e9a-47f9-9ef3-f9c65118bce3">| 32기가 최신이고, 활동 기수일 때 |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/b38ad3bc-97ff-4d7a-8d37-cc5df3690af6"> | 32기 랭킹 버튼을 눌러 들어갔을 때 |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/da4616db-d37d-461d-9146-a3862b880c4e"> | 전체 랭킹 버튼을 눌러 들어갔을 때  |
| <img width="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/d3a53144-85e9-4627-a0c3-78dbe5e2dd9a"> | 활동기수 아닐 때 |

## 📮 관련 이슈

- Resolved: #287 
