### PR TITLE
[Fix] #294 푸시토큰 등록 버그 수정

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
@@ -46,4 +46,12 @@ extension AppMyPageRepository: AppMyPageRepositoryInterface {
             .map(\.isOptIn)
             .asDriver()
     }
+    
+    public func deregisterPushToken(with token: String) -> AnyPublisher<Bool, Error> {
+        self.userService.deregisterPushToken(with: token)
+            .map {
+                return 200..<300 ~= $0
+            }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
@@ -14,4 +14,5 @@ public protocol AppMyPageRepositoryInterface {
     func resetStamp() -> Driver<Bool>
     func getNotificationIsAllowed() -> Driver<Bool>
     func optInPushNotificationInGeneral(to isOn: Bool) -> Driver<Bool>
+    func deregisterPushToken(with token: String) -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MainUseCase.swift
@@ -64,12 +64,8 @@ extension DefaultMainUseCase: MainUseCase {
     
     public func getMainViewDescription() {
         repository.getMainViewDescription()
-            .sink { [weak self] event in
-                print("MainUseCase getMainViewDescription: \(event)")
-                if case Subscribers.Completion.failure = event {
-                    self?.mainErrorOccurred.send(.networkError(message: "GetMainViewDescription 실패"))
-                }
-            } receiveValue: { [weak self] mainDescriptionModel in
+            .replaceError(with: .defaultDescription)
+            .sink { [weak self] mainDescriptionModel in
                 self?.mainDescription.send(mainDescriptionModel)
             }.store(in: self.cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
@@ -47,6 +47,7 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     private let viewWillAppear = PassthroughSubject<Void, Never>()
     private let resetButtonTapped = PassthroughSubject<Bool, Never>()
     private let alertSwitchTapped = PassthroughSubject<Bool, Never>()
+    private let logoutButtonTapped = PassthroughSubject<Void, Never>()
     private let cancelBag = CancelBag()
     
     // MARK: - Views
@@ -292,8 +293,7 @@ extension AppMyPageVC {
                 description: I18N.MyPage.logoutDialogDescription,
                 customButtonTitle: I18N.MyPage.logoutDialogGrantButtonTitle,
                 customAction: { [weak self] in
-                    self?.logout()
-                    self?.onShowLogin?()
+                    self?.logoutButtonTapped.send()
                 },
                 animated: true
             )
@@ -335,7 +335,8 @@ extension AppMyPageVC {
         let input = AppMyPageViewModel.Input(
             viewWillAppear: self.viewWillAppear.asDriver(),
             alertSwitchTapped: self.alertSwitchTapped.asDriver(),
-            resetButtonTapped: self.resetButtonTapped.asDriver()
+            resetButtonTapped: self.resetButtonTapped.asDriver(),
+            logoutButtonTapped: self.logoutButtonTapped.asDriver()
         )
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
@@ -355,6 +356,12 @@ extension AppMyPageVC {
             .filter { $0 }
             .sink { [weak self] _ in
                 self?.showToast(message: I18N.MyPage.resetSuccess)
+            }.store(in: self.cancelBag)
+        
+        output.deregisterPushTokenSuccess
+            .sink { [weak self] success in
+                self?.logout()
+                self?.onShowLogin?()
             }.store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -20,6 +20,7 @@ public final class AppMyPageViewModel: MyPageViewModelType {
         let viewWillAppear: Driver<Void>
         let alertSwitchTapped: Driver<Bool>
         let resetButtonTapped: Driver<Bool>
+        let logoutButtonTapped: Driver<Void>
     }
     
     // MARK: - Outputs
@@ -28,6 +29,7 @@ public final class AppMyPageViewModel: MyPageViewModelType {
         let resetSuccessed = PassthroughSubject<Bool, Never>()
         let originNotificationIsAllowed = PassthroughSubject<Bool, Never>()
         let alertSettingOptInEditedResult = PassthroughSubject<Bool, Never>()
+        let deregisterPushTokenSuccess = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - MyPageCoordinatable
@@ -62,6 +64,12 @@ extension AppMyPageViewModel {
                 owner.useCase.resetStamp()
             }.store(in: cancelBag)
         
+        input.logoutButtonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.useCase.deregisterPushToken()
+            }.store(in: cancelBag)
+        
         return output
     }
     
@@ -85,6 +93,13 @@ extension AppMyPageViewModel {
             .asDriver()
             .sink { isOn in
                 output.alertSettingOptInEditedResult.send(isOn)
+            }.store(in: cancelBag)
+        
+        self.useCase
+            .deregisterPushTokenSuccess
+            .asDriver()
+            .sink { success in
+                output.deregisterPushTokenSuccess.send(success)
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -58,7 +58,7 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
     
     private let emptyView: NotificationEmptyView = {
         let view = NotificationEmptyView()
-        view.isHidden = true
+        view.isHidden = false
         return view
     }()
     

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
@@ -85,6 +85,7 @@ extension UserAPI: BaseAPI {
         case .editSentence(let sentence):
             params["profileMessage"] = sentence
         case .registerPushToken(let pushToken):
+            params["platform"] = "iOS"
             params["pushToken"] = pushToken
         case .optInPushNotificationInGeneral(let isOn):
             params["isOptIn"] = isOn

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
@@ -20,6 +20,7 @@ public enum UserAPI {
     case getUserMainInfo
     case withdrawal
     case registerPushToken(token: String)
+    case deregisterPushToken(token: String)
     case fetchActiveGenerationStatus
     case getNotificationIsAllowed
     case optInPushNotificationInGeneral(isOn: Bool)
@@ -46,7 +47,7 @@ extension UserAPI: BaseAPI {
             return "/main"
         case .withdrawal:
             return ""
-        case .registerPushToken:
+        case .registerPushToken, .deregisterPushToken:
             return "/push-token"
         case .fetchActiveGenerationStatus:
             return "/generation"
@@ -73,6 +74,8 @@ extension UserAPI: BaseAPI {
             return .delete
         case .registerPushToken:
            return .post
+        case .deregisterPushToken:
+            return .delete
         }
     }
     
@@ -85,6 +88,9 @@ extension UserAPI: BaseAPI {
         case .editSentence(let sentence):
             params["profileMessage"] = sentence
         case .registerPushToken(let pushToken):
+            params["platform"] = "iOS"
+            params["pushToken"] = pushToken
+        case .deregisterPushToken(let pushToken):
             params["platform"] = "iOS"
             params["pushToken"] = pushToken
         case .optInPushNotificationInGeneral(let isOn):

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/UserAPI.swift
@@ -112,7 +112,7 @@ extension UserAPI: BaseAPI {
     public var task: Task {
         switch self {
         case .changeNickname, .editSentence, .registerPushToken,
-                .optInPushNotificationInGeneral, .optInPushNotificationInDetail:
+                .optInPushNotificationInGeneral, .optInPushNotificationInDetail, .deregisterPushToken:
             return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/UserService.swift
@@ -23,6 +23,7 @@ public protocol UserService {
     func getUserMainInfo() -> AnyPublisher<MainEntity, Error>
     func withdraw() -> AnyPublisher<Int, Error>
     func registerPushToken(with token: String) -> AnyPublisher<Int, Error>
+    func deregisterPushToken(with token: String) -> AnyPublisher<Int, Error>
     func fetchActiveGenerationStatus() -> AnyPublisher<UsersActiveGenerationStatusEntity, Error>
     func getNotificationIsAllowed() -> AnyPublisher<GeneralNotificationOptInEntity, Error>
     func optInPushNotificationInGeneral(to isOn: Bool) -> AnyPublisher<GeneralNotificationOptInEntity, Error>
@@ -57,6 +58,10 @@ extension DefaultUserService: UserService {
     
     public func registerPushToken(with token: String) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.registerPushToken(token: token))
+    }
+    
+    public func deregisterPushToken(with token: String) -> AnyPublisher<Int, Error> {
+        requestObjectInCombineNoResult(.deregisterPushToken(token: token))
     }
     
     public func fetchNotificationSettings() -> AnyPublisher<DetailNotificationOptInEntity, Error> {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#294

## 🌱 PR Point
- 오늘 여러 작업을 하면서 여러차례의 머지 + 컨플릭을 해결하는 과정에서 누락된 코드가 있었습니다.
- 푸시 토큰을 등록하는 API의 Body에 platform 필드가 추가되었는데 지난 PR에 있었지만 머지 과정에서 누락되었습니다. ([링크](https://github.com/sopt-makers/SOPT-iOS/pull/286/files#diff-9660d7dfeae193975f8e58b3944eecc49fe96ca1b645c0fc1b57c2d6a9100fcf))
- 그리고 PROD 서버 배포전에 심사를 통과할 수 있게 메인 뷰에서 Description 을 받아오는 API에 대한 에러처리 로직을 수정했습니다.
- 기존에는 실패하면 네트워크 에러 팝업을 보여줬지만 이제는 디폴트 디스크립션을 제공하도록 했습니다. (방문자용 디스크립션과 동일)
- 그리고 PROD 서버 배포 전에 알림 리스트 뷰의 엠티뷰가 나오지 않아서 이를 수정했습니다.
- 로그아웃 시에 푸시토큰을 해제하는 API 를 호출해야 하는데 이 부분이 빠져있어서 추가했습니다.
- 해당 API가 실패해도 로그아웃 자체는 진행되도록 했습니다.



## 📮 관련 이슈
- Resolved: #294
