### PR TITLE
[Feat] #296 - 알림 스펙 변경 적용

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -269,7 +269,7 @@ public struct I18N {
         public static let termsOfUse = "서비스 이용 약관"
         public static let sendFeedback = "의견 보내기"
         public static let alertSectionTitle = "알림 설정"
-        public static let alertListItemTitle = "알림"
+        public static let alertListItemTitle = "알림 설정하기"
         public static let alertByFeaturesListItemTitle = "기능별 알림"
         public static let soptampSectionTitle = "솝탬프 설정"
         public static let editOnlineSentence = "한 마디 편집"

--- a/SOPT-iOS/Projects/Data/Sources/Repository/NotificationDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/NotificationDetailRepository.swift
@@ -28,4 +28,10 @@ extension NotificationDetailRepository: NotificationDetailRepositoryInterface {
             .map { $0 == 200 }
             .eraseToAnyPublisher()
     }
+    
+    public func getNotificationDetail(notificationId: Int) -> AnyPublisher<NotificationDetailModel, Error> {
+        service.getNotificationDetail(notificationId: notificationId)
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/NotificationListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/NotificationListRepository.swift
@@ -30,7 +30,7 @@ extension NotificationListRepository: NotificationListRepositoryInterface {
     }
     
     public func readAllNotifications() -> AnyPublisher<Bool, Error> {
-        service.readNotification(notificationId: 0)
+        service.readNotification(notificationId: nil)
             .map { $0 == 200 }
             .eraseToAnyPublisher()
     }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/MainTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/MainTransform.swift
@@ -14,7 +14,7 @@ import Network
 extension MainEntity {
     public func toDomain() -> UserMainInfoModel? {
         guard let user = user, !user.name.isEmpty else { return nil }
-        return UserMainInfoModel.init(status: user.status, name: user.name, profileImage: user.profileImage, historyList: user.historyList, attendanceScore: operation?.attendanceScore, announcement: operation?.announcement, exists: exists)
+        return UserMainInfoModel.init(status: user.status, name: user.name, profileImage: user.profileImage, historyList: user.historyList, attendanceScore: operation?.attendanceScore, announcement: operation?.announcement, isAllConfirm: isAllConfirm)
     }
 }
 

--- a/SOPT-iOS/Projects/Data/Sources/Transform/NotificationDetailTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/NotificationDetailTransform.swift
@@ -14,6 +14,13 @@ import Network
 extension NotificationDetailEntity {
 
     public func toDomain() -> NotificationDetailModel {
-        return NotificationDetailModel.init()
+        return NotificationDetailModel.init(notificationId: notificationId,
+                                            userId: userId,
+                                            title: title,
+                                            content: content,
+                                            deepLink: deepLink,
+                                            webLink: webLink,
+                                            createdAt: createdAt,
+                                            updatedAt: updatedAt)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/NotificationListTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/NotificationListTransform.swift
@@ -13,13 +13,12 @@ import Network
 
 extension NotificationListEntity {
     public func toDomain() -> NotificationListModel {
-        return NotificationListModel.init(id: id,
+        return NotificationListModel.init(notificationId: notificationId,
                                           userId: userId,
                                           title: title,
                                           content: content,
-                                          type: type,
+                                          category: category,
                                           isRead: isRead,
-                                          createdAt: createdAt,
-                                          updatedAt: updatedAt)
+                                          createdAt: createdAt)
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/NotificationDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/NotificationDetailModel.swift
@@ -9,8 +9,24 @@
 import Foundation
 
 public struct NotificationDetailModel {
-
-    public init() {
-        
+    public let notificationId: Int
+    public let userId: Int
+    public let title: String
+    public let content: String?
+    public let deepLink: String?
+    public let webLink: String?
+    public let createdAt: String
+    public let updatedAt: String?
+    
+    public init(notificationId: Int, userId: Int, title: String, content: String?,
+                deepLink: String?, webLink: String?, createdAt: String, updatedAt: String?) {
+        self.notificationId = notificationId
+        self.userId = userId
+        self.title = title
+        self.content = content
+        self.deepLink = deepLink
+        self.webLink = webLink
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/NotificationListModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/NotificationListModel.swift
@@ -10,26 +10,24 @@ import Foundation
 import Core
 
 public struct NotificationListModel: Hashable {
-    public let id: Int
+    public let notificationId: Int
     public let userId: Int
     public let title: String
     public let content: String
-    public let type: String?
+    public let category: String?
     public var isRead: Bool
     public let createdAt: String
-    public let updatedAt: String?
     public var formattedCreatedAt: String {
         self.createdAt.serverTimeToString(forUse: .forNotification)
     }
 
-    public init(id: Int, userId: Int, title: String, content: String, type: String?, isRead: Bool, createdAt: String, updatedAt: String?) {
-        self.id = id
+    public init(notificationId: Int, userId: Int, title: String, content: String, category: String?, isRead: Bool, createdAt: String) {
+        self.notificationId = notificationId
         self.userId = userId
         self.title = title
         self.content = content
-        self.type = type
+        self.category = category
         self.isRead = isRead
         self.createdAt = createdAt
-        self.updatedAt = updatedAt
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/NotificationListModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/NotificationListModel.swift
@@ -13,7 +13,7 @@ public struct NotificationListModel: Hashable {
     public let notificationId: Int
     public let userId: Int
     public let title: String
-    public let content: String
+    public let content: String?
     public let category: String?
     public var isRead: Bool
     public let createdAt: String
@@ -21,7 +21,7 @@ public struct NotificationListModel: Hashable {
         self.createdAt.serverTimeToString(forUse: .forNotification)
     }
 
-    public init(notificationId: Int, userId: Int, title: String, content: String, category: String?, isRead: Bool, createdAt: String) {
+    public init(notificationId: Int, userId: Int, title: String, content: String?, category: String?, isRead: Bool, createdAt: String) {
         self.notificationId = notificationId
         self.userId = userId
         self.title = title

--- a/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
@@ -16,7 +16,7 @@ public struct UserMainInfoModel: Equatable {
     public let historyList: [Int]
     public let attendanceScore: Float?
     public let announcement: String?
-    public let exists: Bool?
+    public let isAllConfirm: Bool?
     
     public var userType: UserType {
         switch status {
@@ -29,13 +29,13 @@ public struct UserMainInfoModel: Equatable {
         }
     }
     
-    public init(status: String, name: String, profileImage: String?, historyList: [Int], attendanceScore: Float?, announcement: String?, exists: Bool?) {
+    public init(status: String, name: String, profileImage: String?, historyList: [Int], attendanceScore: Float?, announcement: String?, isAllConfirm: Bool?) {
         self.status = status
         self.name = name
         self.profileImage = profileImage
         self.historyList = historyList
         self.attendanceScore = attendanceScore
         self.announcement = announcement
-        self.exists = exists
+        self.isAllConfirm = isAllConfirm
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/NotificationDetailRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/NotificationDetailRepositoryInterface.swift
@@ -12,4 +12,5 @@ import Combine
 
 public protocol NotificationDetailRepositoryInterface {
     func readNotification(notificationId: Int) -> AnyPublisher<Bool, Error>
+    func getNotificationDetail(notificationId: Int) -> AnyPublisher<NotificationDetailModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/NotificationDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/NotificationDetailUseCase.swift
@@ -12,8 +12,10 @@ import Core
 
 public protocol NotificationDetailUseCase {
     var readSuccess: PassthroughSubject<Bool, Error> { get }
+    var notificationDetail: PassthroughSubject<NotificationDetailModel, Never> { get }
     
     func readNotification(notificationId: Int)
+    func getNotificationDetail(notificationId: Int)
 }
 
 public class DefaultNotificationDetailUseCase {
@@ -22,6 +24,7 @@ public class DefaultNotificationDetailUseCase {
     private var cancelBag = CancelBag()
     
     public let readSuccess = PassthroughSubject<Bool, Error>()
+    public let notificationDetail = PassthroughSubject<NotificationDetailModel, Never>()
   
     public init(repository: NotificationDetailRepositoryInterface) {
         self.repository = repository
@@ -37,5 +40,15 @@ extension DefaultNotificationDetailUseCase: NotificationDetailUseCase {
             } receiveValue: { [weak self] readSuccess in
                 self?.readSuccess.send(readSuccess)
             }.store(in: self.cancelBag)
+    }
+    
+    public func getNotificationDetail(notificationId: Int) {
+        repository.getNotificationDetail(notificationId: notificationId)
+            .sink { event in
+                print("ReadNotification State: \(event)")
+            } receiveValue: { [weak self] notificationDetail in
+                self?.notificationDetail.send(notificationDetail)
+            }.store(in: self.cancelBag)
+
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
@@ -18,5 +18,6 @@ public protocol MyPageCoordinatable {
     var onEditNicknameItemTap: (() -> Void)? { get set }
     var onWithdrawalItemTap: ((UserType) -> Void)? { get set }
     var onShowLogin: (() -> Void)? { get set }
+    var onAlertButtonTap: ((String) -> Void)? { get set }
 }
 public typealias MyPageViewModelType = ViewModelType

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
@@ -18,6 +18,5 @@ public protocol MyPageCoordinatable {
     var onEditNicknameItemTap: (() -> Void)? { get set }
     var onWithdrawalItemTap: ((UserType) -> Void)? { get set }
     var onShowLogin: (() -> Void)? { get set }
-    var onAlertSettingByFeaturesItemTap: (() -> Void)? { get set }
 }
 public typealias MyPageViewModelType = ViewModelType

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
@@ -41,11 +41,11 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     public var onWithdrawalItemTap: ((UserType) -> Void)?
     public var onLoginItemTap: (() -> Void)?
     public var onShowLogin: (() -> Void)?
-    
+    public var onAlertButtonTap: ((String) -> Void)?
+
     // MARK: Combine
     private let viewWillAppear = PassthroughSubject<Void, Never>()
     private let resetButtonTapped = PassthroughSubject<Bool, Never>()
-    private let alertSwitchTapped = PassthroughSubject<Bool, Never>()
     private let logoutButtonTapped = PassthroughSubject<Void, Never>()
     private let cancelBag = CancelBag()
     
@@ -101,7 +101,6 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     
     private lazy var alertListItem = MyPageSectionListItemView(
         title: I18N.MyPage.alertListItemTitle,
-        rightItemType: .switch(isOn: false),
         frame: self.view.frame
     )
 
@@ -253,6 +252,10 @@ extension AppMyPageVC {
         self.sendFeedbackListItem.addTapGestureRecognizer {
             openExternalLink(urlStr: ExternalURL.GoogleForms.serviceProposal)
         }
+        
+        self.alertListItem.addTapGestureRecognizer {
+            self.onAlertButtonTap?(UIApplication.openSettingsURLString)
+        }
 
         self.editOnelineSentenceListItem.addTapGestureRecognizer {
             self.onEditOnelineSentenceItemTap?()
@@ -302,14 +305,6 @@ extension AppMyPageVC {
 
 extension AppMyPageVC {
     private func bindViews() {
-        self.alertListItem
-            .signalForRightSwitchClick()
-            .throttle(for: 0.3, scheduler: RunLoop.main, latest: true)
-            .sink { [weak self] isOn in
-                self?.alertSwitchTapped.send(isOn)
-            }
-            .store(in: self.cancelBag)
-        
         self.navigationBar
             .leftButtonTapped
             .withUnretained(self)
@@ -321,7 +316,6 @@ extension AppMyPageVC {
     private func bindViewModels() {
         let input = AppMyPageViewModel.Input(
             viewWillAppear: self.viewWillAppear.asDriver(),
-            alertSwitchTapped: self.alertSwitchTapped.asDriver(),
             resetButtonTapped: self.resetButtonTapped.asDriver(),
             logoutButtonTapped: self.logoutButtonTapped.asDriver()
         )

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
@@ -41,7 +41,6 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     public var onWithdrawalItemTap: ((UserType) -> Void)?
     public var onLoginItemTap: (() -> Void)?
     public var onShowLogin: (() -> Void)?
-    public var onAlertSettingByFeaturesItemTap: (() -> Void)?
     
     // MARK: Combine
     private let viewWillAppear = PassthroughSubject<Void, Never>()
@@ -95,8 +94,7 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     private lazy var alertSectionGroup = MypageSectionGroupView(
         headerTitle: I18N.MyPage.alertSectionTitle,
         subviews: [
-            self.alertListItem,
-            self.alertByFeaturesListItem,
+            self.alertListItem
         ],
         frame: self.view.frame
     )
@@ -106,13 +104,6 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
         rightItemType: .switch(isOn: false),
         frame: self.view.frame
     )
-    
-    private lazy var alertByFeaturesListItem = MyPageSectionListItemView(
-        title: I18N.MyPage.alertByFeaturesListItemTitle,
-        frame: self.view.frame
-    ).then {
-        $0.isHidden = true
-    }
 
     // MARK: Soptamp
     private lazy var soptampSectionGroup = MypageSectionGroupView(
@@ -306,10 +297,6 @@ extension AppMyPageVC {
         self.loginListItem.addTapGestureRecognizer {
             self.onShowLogin?()
         }
-        
-        self.alertByFeaturesListItem.addTapGestureRecognizer {
-            self.onAlertSettingByFeaturesItemTap?()
-        }
     }
 }
 
@@ -343,13 +330,11 @@ extension AppMyPageVC {
         output.originNotificationIsAllowed
             .sink { [weak self] isAllowed in
                 self?.alertListItem.configureSwitch(to: isAllowed)
-                self?.alertByFeaturesListItem.isHidden = !isAllowed
             }.store(in: self.cancelBag)
         
         output.alertSettingOptInEditedResult
             .sink { [weak self] isAllowed in
                 self?.alertListItem.configureSwitch(to: isAllowed)
-                self?.alertByFeaturesListItem.isHidden = !isAllowed
             }.store(in: self.cancelBag)
         
         output.resetSuccessed

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -18,7 +18,6 @@ public final class AppMyPageViewModel: MyPageViewModelType {
     
     public struct Input {
         let viewWillAppear: Driver<Void>
-        let alertSwitchTapped: Driver<Bool>
         let resetButtonTapped: Driver<Bool>
         let logoutButtonTapped: Driver<Void>
     }
@@ -52,12 +51,6 @@ extension AppMyPageViewModel {
                 self.useCase.fetchUserNotificationIsAllowed()
             }.store(in: cancelBag)
         
-        input.alertSwitchTapped
-            .withUnretained(self)
-            .sink { owner, isOn in
-                owner.useCase.optInPushNotificationInGeneral(to: isOn)
-            }.store(in: cancelBag)
-
         input.resetButtonTapped
             .withUnretained(self)
             .sink { owner, _ in

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -63,11 +63,7 @@ final class MyPageCoordinator: DefaultMyPageCoordinator {
         myPage.onWithdrawalItemTap = { [weak self] userType in
             self?.showWithdrawal(userType: userType)
         }
-        
-        myPage.onAlertSettingByFeaturesItemTap = { [weak self] in
-            let onNotificationSettingByFeaturesVC = self?.factory.makeAlertSettingByFeatures()
-            self?.router.push(onNotificationSettingByFeaturesVC)
-        }
+
         router.push(myPage)
     }
     

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -63,6 +63,10 @@ final class MyPageCoordinator: DefaultMyPageCoordinator {
         myPage.onWithdrawalItemTap = { [weak self] userType in
             self?.showWithdrawal(userType: userType)
         }
+        
+        myPage.onAlertButtonTap = { [weak self] url in
+            self?.showAlertSetting(url: url)
+        }
 
         router.push(myPage)
     }
@@ -73,5 +77,9 @@ final class MyPageCoordinator: DefaultMyPageCoordinator {
             self?.requestCoordinating?(.signInWithToast)
         }
         self.router.push(withdrawalVC)
+    }
+    
+    private func showAlertSetting(url: String) {
+        openExternalLink(urlStr: url)
     }
 }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -154,7 +154,7 @@ extension MainVC {
     
     private func updateUI(with model: UserMainInfoModel) {
         if let isAllConfirm = model.isAllConfirm {
-            self.naviBar.changeNoticeButtonStyle(isActive: isAllConfirm)
+            self.naviBar.changeNoticeButtonStyle(isActive: !isAllConfirm)
         }
         
         self.naviBar.hideNoticeButton(wantsToHide: self.viewModel.userType == .visitor)

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/VC/MainVC.swift
@@ -153,8 +153,8 @@ extension MainVC {
     }
     
     private func updateUI(with model: UserMainInfoModel) {
-        if let notificationExists = model.exists {
-            self.naviBar.changeNoticeButtonStyle(isActive: notificationExists)
+        if let isAllConfirm = model.isAllConfirm {
+            self.naviBar.changeNoticeButtonStyle(isActive: isAllConfirm)
         }
         
         self.naviBar.hideNoticeButton(wantsToHide: self.viewModel.userType == .visitor)

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Views/MainNavigationBar.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Views/MainNavigationBar.swift
@@ -27,7 +27,7 @@ final class MainNavigationBar: UIView {
     }
     
     private let noticeButton = UIButton(type: .custom).then {
-        $0.setImage(DSKitAsset.Assets.btnNoticeActive.image, for: .normal)
+        $0.setImage(DSKitAsset.Assets.btnNoticeInactive.image, for: .normal)
     }
     
     private let rightButton = UIButton(type: .custom).then {

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotifcationFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotifcationFeatureBuildable.swift
@@ -12,5 +12,5 @@ import Domain
 
 public protocol NotificationFeatureBuildable {
     func makeNotificationList() -> NotificationListPresentable
-    func makeNotificationDetailVC(notification: NotificationListModel) -> NotificationDetailViewControllable
+    func makeNotificationDetailVC(notificationId: Int) -> NotificationDetailViewControllable
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
@@ -13,7 +13,7 @@ import Domain
 public protocol NotificationListViewControllable: ViewControllable { }
 public protocol NotificationListCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
-    var onNotificationTap: ((NotificationListModel) -> Void)? { get set }
+    var onNotificationTap: ((Int) -> Void)? { get set }
 }
 public typealias NotificationListViewModelType = ViewModelType & NotificationListCoordinatable
 public typealias NotificationListPresentable = (vc: NotificationListViewControllable, vm: any NotificationListViewModelType)

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationBuilder.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationBuilder.swift
@@ -26,9 +26,9 @@ extension NotificationBuilder: NotificationFeatureBuildable {
         return (vc, vm)
     }
     
-    public func makeNotificationDetailVC(notification: NotificationListModel) -> NotificationDetailViewControllable {
+    public func makeNotificationDetailVC(notificationId: Int) -> NotificationDetailViewControllable {
         let useCase = DefaultNotificationDetailUseCase(repository: notificationDetailRepository)
-        let viewModel = NotificationDetailViewModel(useCase: useCase, notification: notification)
+        let viewModel = NotificationDetailViewModel(useCase: useCase, notificationId: notificationId)
         let notificationDetailVC = NotificationDetailVC(viewModel: viewModel)
         
         return notificationDetailVC

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
@@ -34,14 +34,14 @@ final class NotificationCoordinator: DefaultCoordinator {
             self?.router.popModule()
             self?.finishFlow?()
         }
-        notificiationList.vm.onNotificationTap = { [weak self] notification in
-            self?.showNotificationDetail(notification: notification)
+        notificiationList.vm.onNotificationTap = { [weak self] notificationId in
+            self?.showNotificationDetail(notificationId: notificationId)
         }
         router.push(notificiationList.vc)
     }
     
-    private func showNotificationDetail(notification: NotificationListModel) {
-        let notificationDetail = factory.makeNotificationDetailVC(notification: notification)
+    private func showNotificationDetail(notificationId: Int) {
+        let notificationDetail = factory.makeNotificationDetailVC(notificationId: notificationId)
         router.push(notificationDetail)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/VC/NotificationDetailVC.swift
@@ -194,7 +194,7 @@ extension NotificationDetailVC {
             }.store(in: cancelBag)
     }
     
-    private func setData(with notification: NotificationListModel) {
+    private func setData(with notification: NotificationDetailModel) {
         self.titleLabel.text = notification.title
         self.textView.text = notification.content
     }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -19,7 +19,7 @@ public class NotificationDetailViewModel: ViewModelType {
     private let useCase: NotificationDetailUseCase
     private var cancelBag = CancelBag()
     
-    private var notification: NotificationListModel
+    private var notificationId: Int
   
     // MARK: - Inputs
     
@@ -35,9 +35,9 @@ public class NotificationDetailViewModel: ViewModelType {
     
     // MARK: - init
   
-    public init(useCase: NotificationDetailUseCase, notification: NotificationListModel) {
+    public init(useCase: NotificationDetailUseCase, notificationId: Int) {
         self.useCase = useCase
-        self.notification = notification
+        self.notificationId = notificationId
     }
 }
 
@@ -51,10 +51,10 @@ extension NotificationDetailViewModel {
         input.viewDidLoad
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                output.notification.send(notification)
-                if notification.isRead == false {
-                    useCase.readNotification(notificationId: notification.notificationId)
-                }
+//                output.notification.send(notification)
+//                if notification.isRead == false {
+//                    useCase.readNotification(notificationId: notification.notificationId)
+//                }
             }.store(in: cancelBag)
     
         return output
@@ -65,9 +65,9 @@ extension NotificationDetailViewModel {
             .asDriver()
             .sink { [weak self] readSuccess in
                 print("읽음 처리: \(readSuccess)")
-                if readSuccess {
-                    self?.notification.isRead = true
-                }
+//                if readSuccess {
+//                    self?.notification.isRead = true
+//                }
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -53,7 +53,7 @@ extension NotificationDetailViewModel {
                 guard let self = self else { return }
                 output.notification.send(notification)
                 if notification.isRead == false {
-                    useCase.readNotification(notificationId: notification.id)
+                    useCase.readNotification(notificationId: notification.notificationId)
                 }
             }.store(in: cancelBag)
     

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -30,7 +30,7 @@ public class NotificationDetailViewModel: ViewModelType {
     // MARK: - Outputs
     
     public struct Output {
-        var notification = PassthroughSubject<NotificationListModel, Never>()
+        var notification = PassthroughSubject<NotificationDetailModel, Never>()
     }
     
     // MARK: - init
@@ -51,23 +51,24 @@ extension NotificationDetailViewModel {
         input.viewDidLoad
             .sink { [weak self] _ in
                 guard let self = self else { return }
-//                output.notification.send(notification)
-//                if notification.isRead == false {
-//                    useCase.readNotification(notificationId: notification.notificationId)
-//                }
+                useCase.getNotificationDetail(notificationId: notificationId)
             }.store(in: cancelBag)
     
         return output
     }
   
     private func bindOutput(output: Output, cancelBag: CancelBag) {
+        useCase.notificationDetail
+            .sink { [weak self] notificationDetail in
+                guard let self = self else { return }
+                output.notification.send(notificationDetail)
+                self.useCase.readNotification(notificationId: self.notificationId)
+            }.store(in: cancelBag)
+        
         useCase.readSuccess
             .asDriver()
-            .sink { [weak self] readSuccess in
+            .sink { readSuccess in
                 print("읽음 처리: \(readSuccess)")
-//                if readSuccess {
-//                    self?.notification.isRead = true
-//                }
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/Cells/NotificationListCVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/Cells/NotificationListCVC.swift
@@ -91,7 +91,7 @@ extension NotificationListCVC {
 // MARK: - Methods
 
 extension NotificationListCVC {
-    func initCell(title: String, time: String, description: String, isUnread: Bool) {
+    func initCell(title: String, time: String, description: String?, isUnread: Bool) {
         self.titleLabel.text = title
         self.timeLabel.text = time
         self.descriptionLabel.text = description

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -99,20 +99,14 @@ extension NotificationListVC {
     }
     
     private func setLayout() {
-        self.view.addSubviews(naviBar, notificationFilterCollectionView, notificationListCollectionView)
+        self.view.addSubviews(naviBar, notificationListCollectionView)
         
         naviBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
         }
         
-        notificationFilterCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            make.height.equalTo(46)
-        }
-        
         notificationListCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(notificationFilterCollectionView.snp.bottom)
+            make.top.equalTo(naviBar.snp.bottom)
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -43,7 +43,6 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
         cv.showsHorizontalScrollIndicator = false
         cv.showsVerticalScrollIndicator = false
         cv.backgroundColor = .clear
-        cv.isHidden = true
         return cv
     }()
     
@@ -99,20 +98,20 @@ extension NotificationListVC {
     }
     
     private func setLayout() {
-        self.view.addSubviews(naviBar, notificationListCollectionView)
+        self.view.addSubviews(naviBar, notificationFilterCollectionView, notificationListCollectionView)
         
         naviBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
         }
         
-//        notificationFilterCollectionView.snp.makeConstraints { make in
-//            make.top.equalTo(naviBar.snp.bottom)
-//            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-//            make.height.equalTo(46)
-//        }
+        notificationFilterCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(naviBar.snp.bottom)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(46)
+        }
         
         notificationListCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom)
+            make.top.equalTo(notificationFilterCollectionView.snp.bottom)
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         
@@ -232,7 +231,7 @@ extension NotificationListVC: UICollectionViewDelegate {
         let contentHeight = scrollView.contentSize.height
         let height = scrollView.frame.height
         
-        guard offsetY > 0 else { return }
+        guard offsetY > 0 , contentHeight > 0 else { return }
         
         if height > contentHeight - offsetY && !viewModel.isPaging {
             viewModel.startPaging()

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -25,6 +25,7 @@ public final class NotificationListVC: UIViewController, NotificationListViewCon
     private var cancelBag = CancelBag()
     private var cellTapped = PassthroughSubject<Int, Never>()
     private var requestNotifications = CurrentValueSubject<Void, Never>(())
+    private var categoryCellTapped = PassthroughSubject<Int, Never>()
     
     private lazy var notificationFilterDataSource: UICollectionViewDiffableDataSource<Int, NotificationFilterType>! = nil
     
@@ -194,10 +195,12 @@ extension NotificationListVC {
 extension NotificationListVC {
     private func bindViewModels() {
         let input = NotificationListViewModel.Input(
+            viewDidLoad: Just<Void>(()).asDriver(),
             requestNotifications: requestNotifications.asDriver(),
             naviBackButtonTapped: naviBar.leftButtonTapped,
             cellTapped: cellTapped.asDriver(),
-            readAllButtonTapped: naviBar.rightButtonTapped
+            readAllButtonTapped: naviBar.rightButtonTapped,
+            categoryCellTapped: categoryCellTapped.asDriver()
         )
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
@@ -220,6 +223,9 @@ extension NotificationListVC {
 
 extension NotificationListVC: UICollectionViewDelegate {
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if collectionView == notificationFilterCollectionView {
+            categoryCellTapped.send(indexPath.item)
+        }
         
         if collectionView == notificationListCollectionView {
             cellTapped.send(indexPath.item)

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationFilterType.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationFilterType.swift
@@ -9,8 +9,7 @@
 import Foundation
 
 enum NotificationFilterType: String {
-    case all = "모든 알림"
-    case entireTarget = "전체 알림"
-    case partTarget = "파트별 알림"
+    case all = "전체 알림"
+    case notice = "공지"
     case news = "소식"
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -46,7 +46,7 @@ public class NotificationListViewModel: NotificationListViewModelType {
     // MARK: - NotificationCoordinatable
     
     public var onNaviBackButtonTap: (() -> Void)?
-    public var onNotificationTap: ((NotificationListModel) -> Void)?
+    public var onNotificationTap: ((Int) -> Void)?
     
     // MARK: - init
     
@@ -78,7 +78,7 @@ extension NotificationListViewModel {
             .withUnretained(self)
             .sink { owner, index in
                 let notification = owner.notifications[index]
-                owner.onNotificationTap?(notification)
+                owner.onNotificationTap?(notification.notificationId)
                 owner.read(index: index)
                 output.notificationList.send(self.notifications)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -21,7 +21,7 @@ public class NotificationListViewModel: NotificationListViewModelType {
     private let useCase: NotificationListUseCase
     private var cancelBag = CancelBag()
     
-    let filterList: [NotificationFilterType] = [.all, .entireTarget, .partTarget, .news]
+    let filterList: [NotificationFilterType] = [.all, .notice, .news]
     var notifications: [NotificationListModel] = []
     
     var page = 0

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -30,10 +30,12 @@ public class NotificationListViewModel: NotificationListViewModelType {
     // MARK: - Inputs
     
     public struct Input {
+        let viewDidLoad: Driver<Void>
         let requestNotifications: Driver<Void>
         let naviBackButtonTapped: Driver<Void>
         let cellTapped: Driver<Int>
         let readAllButtonTapped: Driver<Void>
+        let categoryCellTapped: Driver<Int>
     }
     
     // MARK: - Outputs
@@ -61,6 +63,12 @@ extension NotificationListViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
+        
+        input.viewDidLoad
+            .withUnretained(self)
+            .sink { owner, _ in
+                output.filterList.send(owner.filterList)
+            }.store(in: cancelBag)
         
         input.requestNotifications
             .withUnretained(self)
@@ -90,6 +98,13 @@ extension NotificationListViewModel {
                 owner.useCase.readAllNotifications()
             }.store(in: cancelBag)
         
+        input.categoryCellTapped
+            .removeDuplicates()
+            .withUnretained(self)
+            .sink { owner, index in
+                print(index)
+            }.store(in: cancelBag)
+        
         return output
     }
     
@@ -99,7 +114,6 @@ extension NotificationListViewModel {
             .sink { [weak self] notificationList in
                 guard let self = self else { return }
                 self.notifications.append(contentsOf: notificationList)
-                output.filterList.send(filterList)
                 output.notificationList.send(notifications)
                 self.endPaging(isEmptyResponse: notificationList.isEmpty)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/NotificationAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/NotificationAPI.swift
@@ -13,7 +13,7 @@ import Moya
 
 public enum NotificationAPI {
     case getNotificationList(page: Int)
-    case readNotification(notificationId: Int)
+    case readNotification(notificationId: Int?)
 }
 
 extension NotificationAPI: BaseAPI {
@@ -22,6 +22,7 @@ extension NotificationAPI: BaseAPI {
     public var path: String {
         switch self {
         case .readNotification(let notificationId):
+            guard let notificationId = notificationId else { return "" }
             return "/\(notificationId)"
         default:
             return ""

--- a/SOPT-iOS/Projects/Modules/Network/Sources/API/NotificationAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/API/NotificationAPI.swift
@@ -14,6 +14,7 @@ import Moya
 public enum NotificationAPI {
     case getNotificationList(page: Int)
     case readNotification(notificationId: Int?)
+    case getNotificationDetail(notificationId: Int)
 }
 
 extension NotificationAPI: BaseAPI {
@@ -23,6 +24,8 @@ extension NotificationAPI: BaseAPI {
         switch self {
         case .readNotification(let notificationId):
             guard let notificationId = notificationId else { return "" }
+            return "/\(notificationId)"
+        case .getNotificationDetail(let notificationId):
             return "/\(notificationId)"
         default:
             return ""

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/MainEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/MainEntity.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct MainEntity: Codable {
     public let user: UserInfo?
     public let operation: OperationInfo?
-    public let exists: Bool?
+    public let isAllConfirm: Bool?
 }
 
 // MARK: - UserInfo

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationDetailEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationDetailEntity.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
-public struct NotificationDetailEntity {
-    
+public struct NotificationDetailEntity: Decodable {
+    public let notificationId: Int
+    public let userId: Int
+    public let title: String
+    public let content: String?
+    public let deepLink: String?
+    public let webLink: String?
+    public let createdAt: String
+    public let updatedAt: String?
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationListEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationListEntity.swift
@@ -12,7 +12,7 @@ public struct NotificationListEntity: Codable {
     public let notificationId: Int
     public let userId: Int
     public let title: String
-    public let content: String
+    public let content: String?
     public let category: String?
     public let isRead: Bool
     public let createdAt: String

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationListEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Entity/NotificationListEntity.swift
@@ -9,12 +9,11 @@
 import Foundation
 
 public struct NotificationListEntity: Codable {
-    public let id: Int
+    public let notificationId: Int
     public let userId: Int
     public let title: String
     public let content: String
-    public let type: String?
+    public let category: String?
     public let isRead: Bool
     public let createdAt: String
-    public let updatedAt: String?
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/NotificationService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/NotificationService.swift
@@ -16,6 +16,7 @@ public typealias DefaultNotificationService = BaseService<NotificationAPI>
 public protocol NotificationService {
     func getNotificationList(page: Int) -> AnyPublisher<[NotificationListEntity], Error>
     func readNotification(notificationId: Int?) -> AnyPublisher<Int, Error>
+    func getNotificationDetail(notificationId: Int) -> AnyPublisher<NotificationDetailEntity, Error>
 }
 
 extension DefaultNotificationService: NotificationService {
@@ -26,5 +27,9 @@ extension DefaultNotificationService: NotificationService {
     
     public func readNotification(notificationId: Int?) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.readNotification(notificationId: notificationId))
+    }
+    
+    public func getNotificationDetail(notificationId: Int) -> AnyPublisher<NotificationDetailEntity, Error> {
+        requestObjectInCombine(.getNotificationDetail(notificationId: notificationId))
     }
 }

--- a/SOPT-iOS/Projects/Modules/Network/Sources/Service/NotificationService.swift
+++ b/SOPT-iOS/Projects/Modules/Network/Sources/Service/NotificationService.swift
@@ -15,7 +15,7 @@ public typealias DefaultNotificationService = BaseService<NotificationAPI>
 
 public protocol NotificationService {
     func getNotificationList(page: Int) -> AnyPublisher<[NotificationListEntity], Error>
-    func readNotification(notificationId: Int) -> AnyPublisher<Int, Error>
+    func readNotification(notificationId: Int?) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultNotificationService: NotificationService {
@@ -24,7 +24,7 @@ extension DefaultNotificationService: NotificationService {
         requestObjectInCombine(.getNotificationList(page: page))
     }
     
-    public func readNotification(notificationId: Int) -> AnyPublisher<Int, Error> {
+    public func readNotification(notificationId: Int?) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.readNotification(notificationId: notificationId))
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#296

## 🌱 PR Point
- 푸시 알림 관련 API 명세들이 바뀐 것들을 반영했습니다.
- 알림 목록 조회 API와 알림 상세 조회 API가 분리되었습니다.
- 알림 필터의 종류가 바뀌어서 반영했습니다. (다음 스프린트에 배포될 예정이라 우선 해당 뷰는 숨김처리했습니다.)
- 마이페이지 뷰에서 알림 수신 여부를 사용자가 직접 앱팀 서버로 수정할 수 있던 기능의 요구 사항이 바껴서 알림 설정하기 버튼을 누르면 iOS의 환경설정 앱이 켜지도록 했습니다.

## 📌 참고 사항
마이페이지 부분은 승호형 @elesahich 담당인데 배포 일정이 어제까지 (근데 작업 후에 기간 늘어남...)라 PM 분들과 QA하다가 급하게 제가 반영했습니다.

히스토리를 남기자면
1. 원래 알림 카테고리 별로 알림 수신 여부를 켜고 끌 수 있도록 하는 요구 사항이 있었습니다.
2. 지난 전체 회의 때 해당 기능을 없애고 모든 알림의 수신 여부를 켜고 끄는 기능만 남도록 요구 사항이 바뀌었습니다.
3. 이러고 나니 사실상 휴대폰 환경 설정에서 푸시 알림 수신 여부를 사용자가 설정하는 것과 다름이 없어졌습니다.
4. 그리고 알림 수신 여부를 앱팀단에서 관리하면 백엔드에서 푸시 토큰을 관리하는 것이 어렵다는 이야기가 나와서 해당 기능을 전부 제거하고
5. 대신 알림 설정하기 버튼을 누르면 아이폰의 환경설정 앱이 켜져서 알림을 설정할 수 있도록 했습니다. (앱팀 PM들이 제시한 방법) 

## 📣 남은 작업들
- 지금은 푸시 알림이 도착해서 클릭하면 메인 뷰가 켜집니다.
- 이걸 우선 알림 디테일 뷰로 가지도록 바꿔야 합니다.
- 푸시 알림 페이로드로 딥링크/웹링크가 들어오면 해당 뷰로 이동할 수 있는 로직을 구현해야 합니다. (방금 기획분들에게 들은 바로는 푸시 알림 클릭 -> 알림 디테일뷰로 이동 -> 바로가기 버튼을 누르면 딥릉크/웹링크 뷰로 이동하는 플로우인 것 같습니다.)


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기존|<img width="281" alt="image" src="https://github.com/sopt-makers/SOPT-iOS/assets/77267404/e3017e77-7f75-4715-a285-da696d752862">|
|변경 후| ![Simulator Screen Recording - iPhone 14 - 2023-10-05 at 02 51 22](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/b9af3572-4638-4e0c-ad24-4c853e8d274e)|

## 📮 관련 이슈
- Resolved: #296 
