### PR TITLE
[Feature] BottomSheetManager, Configuration 작성

### DIFF
--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetConfiguration.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetConfiguration.swift
@@ -1,0 +1,28 @@
+//
+//  BottomSheetConfiguration.swift
+//  BaseFeatureDependency
+//
+//  Created by Ian on 12/2/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+public struct BottomSheetConfiguration {
+    let prefersScrollingExpandsWhenScrolledToEdge: Bool
+    let preferredCornerRadius: CGFloat
+    let detents: [UISheetPresentationController.Detent]
+}
+
+extension BottomSheetConfiguration {
+    public static func `default`() -> Self {
+        .init(
+            prefersScrollingExpandsWhenScrolledToEdge: true,
+            preferredCornerRadius: 16.f,
+            detents: [
+                .custom { context in context.maximumDetentValue * 0.6 },
+                .large()
+            ]
+        )
+    }
+}

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetManager.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetManager.swift
@@ -1,0 +1,48 @@
+//
+//  BottomSheetManager.swift
+//  BaseFeatureDependency
+//
+//  Created by Ian on 12/2/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+public class BottomSheetManager {
+    private let configuration: BottomSheetConfiguration
+    
+    public init(
+        configuration: BottomSheetConfiguration = BottomSheetConfiguration.default(),
+        delegate: UISheetPresentationControllerDelegate? = nil
+    ) {
+        self.configuration = configuration
+    }
+}
+
+extension BottomSheetManager {
+    public static var `default`: BottomSheetManager {
+        .init(
+            configuration: .default(),
+            delegate: nil
+        )
+    }
+}
+
+extension BottomSheetManager {
+    public func present(toPresent viewController: UIViewController, on view: UIViewController?) {
+        guard let sheet = viewController.sheetPresentationController else {
+            return assertionFailure("Content ViewController는 modalPresent 방식으로 작업되어야 합니다.")
+        }
+
+        sheet.detents = self.configuration.detents
+        sheet.preferredCornerRadius = self.configuration.preferredCornerRadius
+        sheet.prefersScrollingExpandsWhenScrolledToEdge = self.configuration.prefersScrollingExpandsWhenScrolledToEdge
+        
+        sheet.prefersEdgeAttachedInCompactHeight = false
+        sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = false
+        sheet.largestUndimmedDetentIdentifier = .none
+        sheet.prefersGrabberVisible = true
+        
+        view?.present(viewController, animated: true)
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약
앱팀 새로운 피처에 필요한 BottomSheet을 작성했어요

🌱 작업한 브랜치
- feature/#make-custom-bottomsheet-어쩌구

## 🌱 PR Point
1. BottomSheet은 detent만 잘 작성해서 사용하면 되어요. detent는 bottomSheet의 height 입니다!
2. 배열로 받도록 했고, 기본 구현도 있어요. 기본 구현을 사용하는 경우 `BottomSheetManager.default.present(~)` 하면 돼요
3. 기본값은 구현하면서 디자이너와 맞추면서 변경하면 더 좋겠어요~

## 🌱 사용법 
1. 기본 바텀싯 (높이 height의 0.6 / 전체 풀 스크린)을 사용하고 싶나요? 그럼  **`BottomSheetManager.default.present(~)`**
2. 바텀싯 커스텀이 필요한가요? 그럼 이니셜라이저를 사용하기. **BottomSheetManager(configuration:delegate:)**

### Configuration : [날진님 블로그](https://sujinnaljin.medium.com/swift-uisheetpresentationcontroller-%EB%BF%8C%EC%8B%9C%EA%B8%B0-eb982a09b55f) 참고해요 아래에 설명을 적긴 하지만 여긴 사진도 있답니다??
- `detents` :  (만 알아도 사용하는데 문제 업서요)
  + BottomSheet의 height.
- `preferredCornerRadius` : 
  + BottomSheet의 topleft, topright cornerRadius. 기본값 16
- `prefersScrollingExpandsWhenScrolledToEdge` : 
  + 콘텐츠가 스크롤 되는 경우 스크롤이 누구먼저 될 것이냐! true인 경우 바텀싯이 먼저 커지고요, false인 경우 컨텐츠 스크롤이 모두 되고 바텀싯이 커집니다. 기본값은 true.
- `prefersEdgeAttachedInCompactHeight` : 
  + 이건 우린 세로모드만 지원하니까 상관 업습니다. compact-height인 가로모드에서 full Screen으로 나올지 여부. false면 풀스크린으로 나옴.
- `widthFollowsPreferredContentSizeWhenEdgeAttached`
   + content ViewController의 preferredContentSize를 바텀시트가 따라가냐는 말인거 같은데요? default는 false이고 container의 safeArea와 같게 간다고 합니다. 저희도 false에여
- `largestUndimmedDetentIdentifier` 
   + 여기엔 detent를 값으로 주는데요, (ex largestUndimmedDetentIdentifier = .medium) 그럼 medium부터는 바텀시트 뒤 컨텐츠랑 userInteraction을 할수 있고, dimm도 없어진대요.
- `prefersGrabberVisible`
   + top-center에 grabber라고 하는 바 모양을 노출하냐 하지 않느냐!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
## 📸 스크린샷
|            <center>동영상</center>             |    <center>설명</center>     |
| :-----------------------------------------: | :-------------------------: |
| <video src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/b7853439-2192-4f12-a176-a5f593824865">| detent 값이 각각 0.3, 0.6, large 입니다요  |
-->


## 📮 관련 이슈
- Resolved: #311
