### PR TITLE
[Fix] LifecycleAdapter 위치 이동 : SOPT-iOS 모듈로 이동

### DIFF
--- a/SOPT-iOS/Projects/Demo/Sources/AppLifecycleAdapter/AppLifecycleAdapter.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/AppLifecycleAdapter/AppLifecycleAdapter.swift
@@ -1,0 +1,47 @@
+//
+//  AppLifecycleAdapter.swift
+//  SOPT-iOS-Demo
+//
+//  Created by Ian on 12/3/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Core
+import Networks
+
+import UIKit
+
+final public class AppLifecycleAdapter {
+    private let cancelBag = CancelBag()
+    private let authService = DefaultAuthService()
+}
+
+// MARK: - Private functions
+extension AppLifecycleAdapter {
+    public func prepare() {
+        self.onWillEnterForeground()
+        self.onWillEnterBackground()
+    }
+
+    //MARK: - Usecases
+    private func onWillEnterForeground() {
+        NotificationCenter.default
+            .publisher(for: UIApplication.willEnterForegroundNotification)
+            .subscribe(on: DispatchQueue.global())
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                self?.reissureTokens()
+            }).store(in: self.cancelBag)
+    }
+    
+    private func onWillEnterBackground() { }
+}
+
+// MARK: - Private functions
+extension AppLifecycleAdapter {
+    private func reissureTokens() {
+        guard UserDefaultKeyList.Auth.appAccessToken != nil else { return }
+        
+        self.authService.reissuance { _  in }
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/AppDelegate.swift
@@ -17,13 +17,13 @@ import BaseFeatureDependency
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private var appLifecycleAdapter = AppLifecycleAdapter()
-    
+
     func application( _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         configureSentry()
+        configureAppLifecycleAdapter()
         registerDependencies()
         application.registerForRemoteNotifications()
         
-        appLifecycleAdapter.prepare()
         return true
     }
     
@@ -63,6 +63,10 @@ extension AppDelegate {
         }
     }
     
+    private func configureAppLifecycleAdapter() {
+        self.appLifecycleAdapter.prepare()
+    }
+
     /// APNs 등록 실패할 경우 호출되는 메서드
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("APNs Failed to register for notifications: \(error.localizedDescription)")

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/AppLifecycleAdapter/AppLifecycleAdapter.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/AppLifecycleAdapter/AppLifecycleAdapter.swift
@@ -1,8 +1,8 @@
 //
 //  AppLifecycleAdapter.swift
-//  BaseFeatureDependency
+//  SOPT-iOS
 //
-//  Created by Ian on 12/2/23.
+//  Created by Ian on 12/3/23.
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
@@ -12,24 +12,18 @@ import Networks
 import UIKit
 
 final public class AppLifecycleAdapter {
-    private let authService: AuthService
     private let cancelBag = CancelBag()
-
-    public init() {
-        self.authService = DefaultAuthService()
-    }
+    private let authService = DefaultAuthService()
 }
 
-// MARK: - Public functions
+// MARK: - Private functions
 extension AppLifecycleAdapter {
     public func prepare() {
         self.onWillEnterForeground()
         self.onWillEnterBackground()
     }
-}
 
-// MARK: - Lifecycle Usecases
-extension AppLifecycleAdapter {
+    //MARK: - Usecases
     private func onWillEnterForeground() {
         NotificationCenter.default
             .publisher(for: UIApplication.willEnterForegroundNotification)
@@ -39,7 +33,7 @@ extension AppLifecycleAdapter {
                 self?.reissureTokens()
             }).store(in: self.cancelBag)
     }
-
+    
     private func onWillEnterBackground() { }
 }
 
@@ -47,8 +41,7 @@ extension AppLifecycleAdapter {
 extension AppLifecycleAdapter {
     private func reissureTokens() {
         guard UserDefaultKeyList.Auth.appAccessToken != nil else { return }
-
+        
         self.authService.reissuance { _  in }
     }
 }
-

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -20,9 +20,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application( _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         configureSentry()
+        configureAppLifecycleAdapter()
         registerDependencies()
-
-        appLifecycleAdapter.prepare()
         
         application.registerForRemoteNotifications()
         return true
@@ -62,6 +61,10 @@ extension AppDelegate {
             options.failedRequestStatusCodes = [ httpStatusCodeRange ]
             options.enableAutoBreadcrumbTracking = true
         }
+    }
+    
+    private func configureAppLifecycleAdapter() {
+        self.appLifecycleAdapter.prepare()
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약
#309 의 후속 작업이여요, LifecycleAdapter의 위치 변경 PR이에요

🌱 작업한 브랜치
- fix/relocate-adapter

## 🌱 PR Point
1. 이게 가용한 옵션은 SOPT-iOS 메인 모듈밖에 없겠더라고요!
2. 그렇답니다. 나머지는 안 되고, 나중을 고려했을때도 이 장소가 맞을 것 같아요~ (e.g. 소켓 유실, 인터넷 유실 처리 등)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #
