### PR TITLE
[Fix] #320 - Dev 앱의 Playground 관련 링크들 분기처리

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/ServiceType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/ServiceType.swift
@@ -22,16 +22,16 @@ public enum ServiceType {
     
     public var serviceDomainLink: String {
         switch self {
-        case .officialHomepage: return "https://sopt.org"
-        case .review: return "https://sopt.org/review"
-        case .project: return "https://playground.sopt.org/projects"
-        case .faq: return "https://sopt.org/FAQ"
-        case .youtube: return "https://m.youtube.com/@SOPTMEDIA"
+        case .officialHomepage: return ExternalURL.SOPT.officialHomepage
+        case .review: return ExternalURL.SOPT.review
+        case .project: return ExternalURL.Playground.project
+        case .faq: return ExternalURL.SOPT.faq
+        case .youtube: return ExternalURL.SNS.youtube
         case .attendance: return ""
-        case .member: return "https://playground.sopt.org/members"
-        case .group: return "https://playground.sopt.org/group?utm_source=playground_group&utm_medium=app_button&utm_campaign=app"
-        case .instagram: return "https://www.instagram.com/sopt_official"
-        case .playgroundCommunity: return "https://playground.sopt.org"
+        case .member: return ExternalURL.Playground.member
+        case .group: return ExternalURL.Playground.group
+        case .instagram: return ExternalURL.SNS.instagram
+        case .playgroundCommunity: return ExternalURL.Playground.playgroundCommunity
         }
     }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
@@ -21,6 +21,15 @@ public struct ExternalURL {
     
     public struct SOPT {
         public static let project = "https://sopt.org/project"
+        public static let officialHomepage = "https://sopt.org"
+        public static let review = "https://sopt.org/review"
+        public static let faq = "https://sopt.org/FAQ"
+    }
+    
+    public struct SNS {
+        public static let youtube = "https://m.youtube.com/@SOPTMEDIA"
+        public static let instagram = "https://www.instagram.com/sopt_official"
+        
     }
     
     public struct Playground {
@@ -33,5 +42,10 @@ public struct ExternalURL {
         public static func login(state: String = "") -> String {
             return "\(main)/auth/oauth?redirect_uri=sopt-makers://org.sopt.makers.iOS/oauth2redirect&state=\(state)"
         }
+        
+        public static let project = "\(main)/projects"
+        public static let member = "\(main)/members"
+        public static let group = "\(main)/group?utm_source=playground_group&utm_medium=app_button&utm_campaign=app"
+        public static let playgroundCommunity = main
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#320

## 🌱 PR Point
- 최근 웹 뷰로 플그 토큰을 주입해주는 로직을 추가했는데 여기서 발생한 한 가지 이슈가 있었습니다.
- 이전까지는 Dev 앱에서 메인 뷰의 플그 관련 버튼을 클릭하면 플그 웹뷰가 열리는데 이 때 로드하는 URL이 플그 Prod URL이었습니다.
- 따라서 Dev앱 로그인할 때는 플그 Dev에서 토큰 받아오고 정작 메인 뷰에서는 플그 Prod를 열었기 때문에 토큰이 일치하지 않아 로그인이 되지 않는 문제가 새롭게 발생한 것입니다.
- 따라서 Dev 앱에서는 Dev Playground가 열리도록 메인 뷰와 연결된 웹 URL들을 수정했습니다.


## 📮 관련 이슈
- Resolved: #320 
