### PR TITLE
[Feat] #339 콕 찌르기 피쳐 진입 플로우

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
@@ -22,7 +22,7 @@ public struct UserDefaultKeyList {
         @UserDefaultWrapper<String>(key: "sentence") public static var sentence
         @UserDefaultWrapper<String>(key: "soptampName") public static var soptampName
         @UserDefaultWrapper<String>(key: "pushToken") public static var pushToken
-        @UserDefaultWrapper<Bool>(key: "isFirstVisitToPokeView") public static var isFirstVisitToPokeView
+        @UserDefaultWrapper<Bool>(key: "isFirstVisitToPokeView") public static var isFirstVisitToPokeOnboardingView
     }
     
     public struct AppNotice {

--- a/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
@@ -17,12 +17,15 @@ public class MainRepository {
     private let userService: UserService
     private let configService: ConfigService
     private let descriptionService: DescriptionService
+    private let pokeService: PokeService
+    
     private let cancelBag = CancelBag()
     
-    public init(userService: UserService, configService: ConfigService, descriptionService: DescriptionService) {
+    public init(userService: UserService, configService: ConfigService, descriptionService: DescriptionService, pokeService: PokeService) {
         self.userService = userService
         self.configService = configService
         self.descriptionService = descriptionService
+        self.pokeService = pokeService
     }
 }
 

--- a/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MainRepository.swift
@@ -80,4 +80,10 @@ extension MainRepository: MainRepositoryInterface {
             }
             .eraseToAnyPublisher()
     }
+    
+    public func checkPokeNewUser() -> AnyPublisher<Bool, Error> {
+        pokeService.isNewUser()
+            .map { $0.isNew }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -39,7 +39,8 @@ extension AppDelegate {
                 MainRepository(
                     userService: DefaultUserService(),
                     configService: DefaultConfigService(),
-                    descriptionService: DefaultDescriptionService()
+                    descriptionService: DefaultDescriptionService(),
+                    pokeService: DefaultPokeService()
                 )
             }
         )

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MainRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MainRepositoryInterface.swift
@@ -15,4 +15,5 @@ public protocol MainRepositoryInterface {
     func getServiceState() -> AnyPublisher<ServiceStateModel, MainError>
     func getMainViewDescription() -> AnyPublisher<MainDescriptionModel, MainError>
     func registerPushToken(with token: String) -> AnyPublisher<Bool, Error>
+    func checkPokeNewUser() -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -180,6 +180,11 @@ extension MainViewModel {
                     self.onNeedSignIn?()
                 }
             }.store(in: self.cancelBag)
+        
+        useCase.isPokeNewUser
+            .sink { [weak self] isNewUser in
+                self?.onPoke?(isNewUser)
+            }.store(in: cancelBag)
     }
     
     private func handleMainServiceSectionTap(with service: ServiceType) {
@@ -209,8 +214,7 @@ extension MainViewModel {
         switch service {
         case .soptamp: onSoptamp?()
         case .poke:
-            // 온보딩 유저 분기
-            onPoke?(true)
+            useCase.checkPokeNewUser()
         }
     }
     

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/ViewModel/MainViewModel.swift
@@ -253,12 +253,15 @@ extension MainViewModel {
         case .visitor:
             self.mainServiceList = [.officialHomepage, .review, .project]
             self.otherServiceList = [.instagram, .youtube, .faq]
+            self.appServiceList = [.poke, .soptamp]
         case .active:
             self.mainServiceList = [.attendance, .group, .playgroundCommunity]
             self.otherServiceList = [.member, .project, .officialHomepage]
+            self.appServiceList = [.poke, .soptamp]
         case .inactive:
             self.mainServiceList = [.playgroundCommunity, .group, .member]
             self.otherServiceList = [.project, .officialHomepage, .instagram, .youtube]
+            self.appServiceList = [.soptamp]
         }
     }
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -104,6 +104,7 @@ public final class PokeMainVC: UIViewController, PokeMainViewControllable {
     public override func viewDidLoad() {
         super.viewDidLoad()
         self.setUI()
+        self.setDelegate()
         self.setStackView()
         self.setLayout()
         self.bindViewModel()
@@ -116,6 +117,10 @@ extension PokeMainVC {
     private func setUI() {
         self.navigationController?.isNavigationBarHidden = true
         view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
+    }
+    
+    private func setDelegate() {
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     private func setStackView() {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
@@ -26,7 +26,7 @@ public final class PokeOnboardingViewModel: PokeOnboardingViewModelType {
         let randomAcquaintance = PassthroughSubject<[PokeUserModel], Never>()
         let pokedResult = PassthroughSubject<PokeUserModel, Never>()
     }
-
+    
     public var onNaviBackTapped: (() -> Void)?
     public var onFirstVisitInOnboarding: (() -> Void)?
     public var onAvartarTapped: ((_ playgroundId: String) -> Void)?
@@ -57,10 +57,8 @@ extension PokeOnboardingViewModel {
             .map { _ in UserDefaultKeyList.User.isFirstVisitToPokeView ?? true }
             .sink(receiveValue: { [weak self] isFirstVisit in
                 guard isFirstVisit else { return }
-                
-//                UserDefaultKeyList.User.isFirstVisitToPokeView = false
-//                self?.onFirstVisitInOnboarding?()
-                 self?.onFirstVisitInOnboarding?()
+                UserDefaultKeyList.User.isFirstVisitToPokeView = false
+                self?.onFirstVisitInOnboarding?()
             }).store(in: cancelBag)
         
         input.pokeButtonTapped
@@ -77,7 +75,7 @@ extension PokeOnboardingViewModel {
             .sink(receiveValue: { [weak self] userModel in
                 self?.onAvartarTapped?(String(describing: userModel.playgroundId))
             }).store(in: cancelBag)
-
+        
         input.pullToRefreshTriggered
             .withUnretained(self)
             .sink(receiveValue: { [weak self] _ in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
@@ -54,10 +54,10 @@ extension PokeOnboardingViewModel {
             }).store(in: cancelBag)
         
         input.viewDidLoaded
-            .map { _ in UserDefaultKeyList.User.isFirstVisitToPokeView ?? true }
+            .map { _ in UserDefaultKeyList.User.isFirstVisitToPokeOnboardingView ?? true }
             .sink(receiveValue: { [weak self] isFirstVisit in
                 guard isFirstVisit else { return }
-                UserDefaultKeyList.User.isFirstVisitToPokeView = false
+                UserDefaultKeyList.User.isFirstVisitToPokeOnboardingView = false
                 self?.onFirstVisitInOnboarding?()
             }).store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/PokeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/PokeAPI.swift
@@ -13,6 +13,7 @@ import Moya
 import Core
 
 public enum PokeAPI {
+    case isNewUser
     case getWhoPokedToMe
     case getWhoPokedToMeList(pageIndex: String)
     case getFriend
@@ -29,6 +30,8 @@ extension PokeAPI: BaseAPI {
     
     public var path: String {
         switch self {
+        case .isNewUser:
+            return "/new"
         case .getWhoPokedToMe:
             return "/to/me"
         case .getWhoPokedToMeList:
@@ -50,7 +53,7 @@ extension PokeAPI: BaseAPI {
     
     public var method: Moya.Method {
         switch self {
-        case .getWhoPokedToMe, .getWhoPokedToMeList, .getFriend, .getFriendListWithRelation, .getFriendRandomUser,
+        case .isNewUser, .getWhoPokedToMe, .getWhoPokedToMeList, .getFriend, .getFriendListWithRelation, .getFriendRandomUser,
                 .getFriendList, .getRandomUsers, .getPokeMessages:
             return .get
         case .poke:

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PokeIsNewUserEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PokeIsNewUserEntity.swift
@@ -1,0 +1,13 @@
+//
+//  PokeIsNewUserEntity.swift
+//  Networks
+//
+//  Created by sejin on 12/27/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct PokeIsNewUserEntity: Decodable {
+    public let isNew: Bool
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/PokeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/PokeService.swift
@@ -14,6 +14,7 @@ import Moya
 public typealias DefaultPokeService = BaseService<PokeAPI>
 
 public protocol PokeService {
+    func isNewUser() -> AnyPublisher<PokeIsNewUserEntity, Error>
     func getWhoPokedToMe() -> AnyPublisher<PokeUserEntity?, Error>
     func getWhoPokedToMeList(pageIndex: String)  -> AnyPublisher<PokedToMeHistoryListEntity, Error>
     func getFriend() -> AnyPublisher<[PokeUserEntity], Error>
@@ -26,6 +27,10 @@ public protocol PokeService {
 }
 
 extension DefaultPokeService: PokeService {
+    public func isNewUser() -> AnyPublisher<PokeIsNewUserEntity, Error> {
+        requestObjectInCombine(.isNewUser)
+    }
+    
     public func getWhoPokedToMe() -> AnyPublisher<PokeUserEntity?, Error> {
         requestObjectInCombine(.getWhoPokedToMe)
     }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -39,7 +39,8 @@ extension AppDelegate {
                 MainRepository(
                     userService: DefaultUserService(),
                     configService: DefaultConfigService(),
-                    descriptionService: DefaultDescriptionService()
+                    descriptionService: DefaultDescriptionService(),
+                    pokeService: DefaultPokeService()
                 )
             }
         )


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#339

## 🌱 PR Point
- 앱의 메인 화면(홈 화면)에서 콕 찌르기 피쳐로 진입하는 플로우를 구현했습니다.
- 우선 비활동 회원의 경우 아직 콕 찌르기 피쳐 사용 대상자가 아니기 때문에 메인 화면에서 콕 찌르기로 이동할 수 있는 버튼을 숨겼습니다.
- 활동 회원은 콕 찌르기 피쳐의 이용이 가능합니다.
- 메인 화면에서 콕 찌르기 피쳐로 이동하는 버튼(Cell) 클릭 시 서버와 통신하여 해당 유저가 콕 찌르기 온보딩 대상 유저인지 확인합니다.
- 맞다면 온보딩 뷰로 아니라면 콕 찌르기 메인 뷰로 이동합니다.
- 이 과정에서 서버 통신 시간이 길어질 수 있기 때문에 Loading Indicator가 나오도록 했습니다.

## 📌 참고 사항
- MainViewModel에서 cell 터치 이벤트를 받는 로직의 코드가 깔끔하지 않은 것 같아서 이 부분 코드 다듬는 작업도 수행했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|콕 찌르기로 이동(온보딩)| ![Simulator Screen Recording - iPhone 14 - 2023-12-27 at 18 23 59](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/7adcd1a3-2f27-4254-8176-8d06369a365c) |
|콕 찌르기로 이동(메인)| ![Simulator Screen Recording - iPhone 14 - 2023-12-27 at 18 25 00](https://github.com/sopt-makers/SOPT-iOS/assets/77267404/2da77f3f-da11-4ace-8d77-e29016fef86c) |

## 📮 관련 이슈
- Resolved: #339 
