### PR TITLE
[Feature] NotificationList: 디테일 액션 챙기기 완료

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeNotificationRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeNotificationRepository.swift
@@ -27,4 +27,11 @@ extension PokeNotificationRepository: PokeNotificationRepositoryInterface {
             .map { (users: $0.history.map { $0.toDomain() }, page: $0.pageNum) }
             .eraseToAnyPublisher()
     }
+    
+    public func poke(userId: Int, message: String) -> AnyPublisher<PokeUserModel, Error> {
+        self.pokeService
+            .poke(userId: userId, message: message)
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeNotificationRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeNotificationRepository.swift
@@ -28,9 +28,10 @@ extension PokeNotificationRepository: PokeNotificationRepositoryInterface {
             .eraseToAnyPublisher()
     }
     
-    public func poke(userId: Int, message: String) -> AnyPublisher<PokeUserModel, Error> {
+    public func poke(userId: Int, message: String) -> AnyPublisher<PokeUserModel, PokeError> {
         self.pokeService
             .poke(userId: userId, message: message)
+            .mapErrorToPokeError()
             .map { $0.toDomain() }
             .eraseToAnyPublisher()
     }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeOnboardingRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeOnboardingRepository.swift
@@ -30,8 +30,8 @@ extension PokeOnboardingRepository: PokeOnboardingRepositoryInterface {
     
     public func getMesseageTemplates(type: PokeMessageType) -> AnyPublisher<PokeMessagesModel, Error> {
         self.pokeService
-            .getPokeMessages(messageType: type.rawValue) // messageType domain화
-            .map { $0.toDomain() }
+            .getPokeMessages(messageType: type.rawValue)
+            .map { $0.messages.map { $0.toDomain() } }
             .eraseToAnyPublisher()
     }
 

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeNotificationRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeNotificationRepositoryInterface.swift
@@ -8,6 +8,6 @@
 
 import Combine
 
-public protocol PokeNotificationRepositoryInterface {
+public protocol PokeNotificationRepositoryInterface: PokeRepositoryInterface {
     func getWhoPokedMeList(page: Int) -> AnyPublisher<(users: [PokeUserModel], page: Int), Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeNotificationUsecase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeNotificationUsecase.swift
@@ -12,17 +12,21 @@ import Core
 
 public protocol PokeNotificationUsecase {
     func getWhoPokedMeList()
+    func poke(userId: Int, message: PokeMessageModel)
     
     var pokedMeList: PassthroughSubject<[PokeUserModel], Never> { get }
+    var pokedResponse: PassthroughSubject<PokeUserModel, Never> { get }
 }
 
 public final class DefaultPokeNotificationUsecase {
     private let repository: PokeNotificationRepositoryInterface
     private let cancelBag = CancelBag()
     private var pageIndex: Int = 0
+    private var reachedToPageLimit = false
 
     // MARK: UsecaseProtocol
     public let pokedMeList = PassthroughSubject<[PokeUserModel], Never>()
+    public let pokedResponse = PassthroughSubject<PokeUserModel, Never>()
 
     public init(repository: PokeNotificationRepositoryInterface) {
         self.repository = repository
@@ -31,13 +35,28 @@ public final class DefaultPokeNotificationUsecase {
 
 extension DefaultPokeNotificationUsecase: PokeNotificationUsecase {
     public func getWhoPokedMeList() {
+        guard !self.reachedToPageLimit else { return }
+        
         self.repository
             .getWhoPokedMeList(page: self.pageIndex)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { [weak self] userModels, pageIndex in
+                    // TBD: paging endindex를 주세요
+                    
                     self?.pageIndex = pageIndex + 1
                     self?.pokedMeList.send(userModels)
                 }).store(in: self.cancelBag)
+    }
+    
+    public func poke(userId: Int, message: PokeMessageModel) {
+        self.repository
+            .poke(userId: userId, message: message.content)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] value in
+                    self?.pokedResponse.send(value)
+                }
+            ).store(in: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetManager.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/BottomSheetManager/BottomSheetManager.swift
@@ -43,6 +43,8 @@ extension BottomSheetManager {
         sheet.largestUndimmedDetentIdentifier = .none
         sheet.prefersGrabberVisible = true
         
-        view?.present(viewController, animated: true)
+        view?.present(viewController, animated: true) ?? UIApplication
+            .getMostTopViewController()?
+            .present(viewController, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
@@ -14,6 +14,7 @@ public protocol PokeNotificationViewControllable: ViewControllable { }
 
 public protocol PokeNotificationCoordinatable {
     var onNaviBackTapped: (() -> Void)? { get set }
+    var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel)>)? { get set }
 }
 
 public typealias PokeNotificationViewModelType = ViewModelType & PokeNotificationCoordinatable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
@@ -15,6 +15,7 @@ public protocol PokeNotificationViewControllable: ViewControllable { }
 public protocol PokeNotificationCoordinatable {
     var onNaviBackTapped: (() -> Void)? { get set }
     var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel)>)? { get set }
+    var onNewFriendAdded: ((_ friendName: String) -> Void)? { get set }
 }
 
 public typealias PokeNotificationViewModelType = ViewModelType & PokeNotificationCoordinatable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
@@ -149,17 +149,8 @@ extension PokeNotificationListContentView {
 }
 
 extension PokeNotificationListContentView {
-    public func configure(with model: NotificationListContentModel) {
-        self.userId = model.userId
-        self.profileImageView.setImage(with: model.avatarUrl, relation: model.pokeRelation)
-        self.nameLabel.text = model.name
-        self.partInfoLabel.text = model.partInfomation
-        self.descriptionLabel.attributedText = model.description.applyMDSFont()
-        self.pokeChipView.configure(with: model.chipInfo)
-        self.pokeKokButton.isEnabled = !model.isPoked
-    }
-    
     public func configure(with model: PokeUserModel) {
+        self.user = model
         self.user = model
         self.userId = model.userId
         self.profileImageView.setImage(with: model.profileImage, relation: PokeRelation(rawValue: model.relationName) ?? .newFriend)
@@ -180,13 +171,13 @@ extension PokeNotificationListContentView {
         self.setData(with: newUserModel)
     }
     
-    public func poked() {
-        // TBD
+    public func signalForPokeButtonClicked() -> Driver<PokeUserModel> {
+        self.pokeKokButton
+            .tap
+            .compactMap { [weak self] _ in self?.user }
+            .asDriver()
     }
-    
-    public func signalForPokeButtonClicked() -> Driver<Int?> {
-        self.pokeKokButton.tap.map { self.userId }.asDriver()
-    }
+
 }
 
 // NOTE(@승호): MDSFont 적용하고 DSKit으로 옮기고 적용하기.

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
@@ -151,7 +151,6 @@ extension PokeNotificationListContentView {
 extension PokeNotificationListContentView {
     public func configure(with model: PokeUserModel) {
         self.user = model
-        self.user = model
         self.userId = model.userId
         self.profileImageView.setImage(with: model.profileImage, relation: PokeRelation(rawValue: model.relationName) ?? .newFriend)
         self.nameLabel.text = model.name

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -32,8 +32,24 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
 
 extension PokeNotificationListCoordinator {
     private func showPokeNotificationListView() {
-        let viewController = self.factory.makePokeNotificationList()
-     
+        var viewController = self.factory.makePokeNotificationList()
+                    
+        viewController.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let bottomSheet = self?.factory
+                .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone)
+                    .vc
+                    .viewController as? PokeMessageTemplateBottomSheet
+            else { return .empty() }
+            
+            let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate())
+            bottomSheetManager.present(toPresent: bottomSheet, on: self?.rootController)
+            
+            return bottomSheet
+                .signalForClick()
+                .map { (userModel, $0) }
+                .asDriver()
+        }
+        
         self.rootController = viewController.vc.asNavigationController
         self.router.push(viewController.vc)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -50,6 +50,14 @@ extension PokeNotificationListCoordinator {
                 .asDriver()
         }
         
+        viewController.vm.onNewFriendAdded = { [weak self] friendName in
+            guard let self else { return }
+            
+            let pokeMakingFriendCompletedVC = self.factory.makePokeMakingFriendCompleted(friendName: friendName).viewController
+            pokeMakingFriendCompletedVC.modalPresentationStyle = .overFullScreen
+            viewController.vc.viewController.present(pokeMakingFriendCompletedVC, animated: false)
+        }
+
         self.rootController = viewController.vc.asNavigationController
         self.router.push(viewController.vc)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -49,7 +49,7 @@ public final class PokeMessageTemplateBottomSheet: UIViewController, PokeMessage
     private let viewModel: PokeMessageTemplateViewModel
     
     // MARK: Combine
-    private let viewWillAppear = PassthroughSubject<Void, Never>()
+    private let viewDidLoaded = PassthroughSubject<Void, Never>()
     private let messageModelSubject = PassthroughSubject<PokeMessageModel, Error>()
     private var cancelBag = CancelBag()
     
@@ -63,6 +63,8 @@ public final class PokeMessageTemplateBottomSheet: UIViewController, PokeMessage
         self.initializeViews()
         self.setupConstraints()
         self.bindViewModels()
+        
+        self.viewDidLoaded.send(())
     }
     
     required init?(coder: NSCoder) {
@@ -72,7 +74,6 @@ public final class PokeMessageTemplateBottomSheet: UIViewController, PokeMessage
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.viewWillAppear.send(())
     }
 }
 
@@ -127,7 +128,7 @@ extension PokeMessageTemplateBottomSheet {
 // MARK: - ViewModel Methods
 extension PokeMessageTemplateBottomSheet {
     private func bindViewModels() {
-        let input = PokeMessageTemplateViewModel.Input(viewWillAppear: self.viewWillAppear.asDriver())
+        let input = PokeMessageTemplateViewModel.Input(viewDidLoaded: self.viewDidLoaded.asDriver())
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
         output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateViewModel.swift
@@ -18,7 +18,7 @@ public final class PokeMessageTemplateViewModel: PokeMessageTemplatesViewModelTy
     public var messageType: PokeMessageType
     
     public struct Input {
-        let viewWillAppear: Driver<Void>
+        let viewDidLoaded: Driver<Void>
     }
     
     public struct Output {
@@ -38,7 +38,7 @@ extension PokeMessageTemplateViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
             
-        input.viewWillAppear
+        input.viewDidLoaded
             .sink(receiveValue: { [weak self] _ in
                 guard let self = self else { return }
                 self.usecase.getPokeMessageTemplates(type: self.messageType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/PokeNotificationViewController.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/PokeNotificationViewController.swift
@@ -27,7 +27,11 @@ public final class PokeNotificationViewController: UIViewController, PokeNotific
     }
     
     // MARK: - Views
-    private lazy var navigationBar = OPNavigationBar(self, type: .oneLeftButton)
+    private lazy var navigationBar = OPNavigationBar(
+        self,
+        type: .oneLeftButton,
+        backgroundColor: DSKitAsset.Colors.gray950.color
+    )
         .addMiddleLabel(title: "찌르기 알림", font: UIFont.MDS.body2)
         .setLeftButtonImage(DSKitAsset.Assets.chevronLeft.image.withTintColor(DSKitAsset.Colors.gray30.color))
     
@@ -56,6 +60,7 @@ public final class PokeNotificationViewController: UIViewController, PokeNotific
             PokeNotificationContentCell.self,
             forCellReuseIdentifier: PokeNotificationContentCell.className
         )
+        $0.backgroundColor = DSKitAsset.Colors.gray950.color
         $0.estimatedRowHeight = 88.f
     }
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/SubViews/PokeNotificationContentCell.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/SubViews/PokeNotificationContentCell.swift
@@ -12,6 +12,7 @@ import UIKit
 
 import Core
 import DSKit
+import Domain
 
 public final class PokeNotificationContentCell: UITableViewCell {
     private enum Metric {
@@ -59,11 +60,11 @@ extension PokeNotificationContentCell {
 }
 
 extension PokeNotificationContentCell {
-    public func configure(with model: NotificationListContentModel) {
+    public func configure(with model: PokeUserModel) {
         self.notificationListContentView.configure(with: model)
     }
     
-    public func signalForClick() -> Driver<Int?> {
+    public func signalForClick() -> Driver<PokeUserModel> {
         self.notificationListContentView.signalForPokeButtonClicked()
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
@@ -22,11 +22,14 @@ public final class PokeNotificationViewModel: PokeNotificationViewModelType {
     
     public struct Output {
         let pokeToMeHistoryList = PassthroughSubject<[PokeUserModel], Never>()
+        let pokedResult = PassthroughSubject<PokeUserModel, Never>()
     }
     
+    public var onNaviBackTapped: (() -> Void)?
+    public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel)>)?
+
     private let usecase: PokeNotificationUsecase
     private let cancelBag = CancelBag()
-    public var onNaviBackTapped: (() -> Void)?
     
     init(usecase: PokeNotificationUsecase) {
         self.usecase = usecase
@@ -43,7 +46,17 @@ extension PokeNotificationViewModel {
             .sink(receiveValue: { [weak self] _ in
                 self?.usecase.getWhoPokedMeList()
             }).store(in: self.cancelBag)
-
+        
+        input.pokedAction
+            .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel)> in
+                guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
+                
+                return value
+            }
+            .sink(receiveValue: { [weak self] userModel, messageModel in
+                self?.usecase.poke(userId: userModel.userId, message: messageModel)
+            }).store(in: cancelBag)
+        
         return output
     }
     
@@ -53,6 +66,13 @@ extension PokeNotificationViewModel {
             .asDriver()
             .sink(receiveValue: { values in
                 output.pokeToMeHistoryList.send(values)
+            }).store(in: cancelBag)
+        
+        self.usecase
+            .pokedResponse
+            .asDriver()
+            .sink(receiveValue: { value in
+                output.pokedResult.send(value)
             }).store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
@@ -79,5 +79,12 @@ extension PokeNotificationViewModel {
                 
                 self?.onNewFriendAdded?(userModel.name)
             }).store(in: cancelBag)
+        
+        self.usecase
+            .errorMessage
+            .compactMap { $0 }
+            .sink { message in
+                ToastUtils.showMDSToast(type: .alert, text: message)
+            }.store(in: cancelBag)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
Poke NotificationList 미비된 작업을 마무리 합니다 : 대상은 아래와 같아요 
- Poke 연결 
- GET poke/to/me/list paginated query 적용
- 새로운 친구 : Lottie 노출
- PUT /poke : API fail인 경우 toast를 노출

(잠수함 패치) bottomSheet의 api 호출 타이밍 : viewWillAppear > viewDidLoaded.

🌱 작업한 브랜치
- feature/#finishes-notification-list-detail

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
## 📸 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2023-12-27 at 20 34 04](https://github.com/sopt-makers/SOPT-iOS/assets/16400721/1f94adfb-cc2d-4d72-bb5b-122b47f74a32)


## 📮 관련 이슈
- Resolved: #
