### PR TITLE
[Fix] Poke 3차 QA 리스트 반영

### DIFF
--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
@@ -96,6 +96,7 @@ final public class PokeNotificationListContentView: UIView, PokeCompatible {
         frame: CGRect
     ) {
         self.isDetailView = isDetailView
+      
         super.init(frame: frame)
 
         self.initializeViews()

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/PokeNotificationViewController.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/PokeNotificationViewController.swift
@@ -52,7 +52,7 @@ public final class PokeNotificationViewController: UIViewController, PokeNotific
     
     // MARK: TableViews
     private lazy var tableView = UITableView().then {
-        $0.separatorStyle = .singleLine
+        $0.separatorStyle = .none
         $0.showsVerticalScrollIndicator = false
         $0.delegate = self
         $0.dataSource = self

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/SubViews/PokeNotificationContentCell.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/SubViews/PokeNotificationContentCell.swift
@@ -18,10 +18,15 @@ public final class PokeNotificationContentCell: UITableViewCell {
     private enum Metric {
         static let contentTopBottom = 10.f
         static let contentLeadingTrailing = 20.f
+      
+        static let bottomSeperatorHeight = 1.f
     }
     
     private lazy var notificationListContentView = PokeNotificationListContentView(frame: self.frame)
-    
+  
+    private lazy var dividerView = UIView().then {
+      $0.backgroundColor = DSKitAsset.Colors.gray700.color
+    }
     
     // MARK: - View LifeCycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -40,7 +45,6 @@ public final class PokeNotificationContentCell: UITableViewCell {
     
     private(set) var cancelBag = CancelBag()
     
-    
     public override func prepareForReuse() {
         self.cancelBag = CancelBag()
     }
@@ -48,13 +52,18 @@ public final class PokeNotificationContentCell: UITableViewCell {
 
 extension PokeNotificationContentCell {
     private func initializeViews() {
-        self.contentView.addSubview(self.notificationListContentView)
+      self.contentView.addSubviews(self.notificationListContentView, self.dividerView)
     }
     
     private func setupConstraints() {
         self.notificationListContentView.snp.makeConstraints {
             $0.top.bottom.equalToSuperview().inset(Metric.contentTopBottom)
             $0.leading.trailing.equalToSuperview().inset(Metric.contentLeadingTrailing)
+        }
+      
+        self.dividerView.snp.makeConstraints {
+          $0.height.equalTo(Metric.bottomSeperatorHeight)
+          $0.leading.trailing.bottom.equalToSuperview()
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
3차 QA 리스트를 반영했어요 

🌱 작업한 브랜치
- feature/#qa-list-3

## 🌱 PR Point
### **[팀-앱 Slack : 잔여 업무 정리](https://sopt-makers.slack.com/archives/C041WU3BMD4/p1704802417029899)**

- 찌르기 다썼을 경우, 토스트 문구가 달라요 : 정황상 에러메시지에 해당 메시지를 담아줄 것으로 보이는데 그렇지 않음. [확인 및 수정 요청](https://sopt-makers.slack.com/archives/C05SU81B7K5/p1704814737931289) 했어요
- 찌르기 알림뷰에 선 부분 디자인이 달라요 : 해냈어요 
- 온보딩 바텀시트 버튼이 너무 작고 text와 영역이 너무 멀어요 : 규격을 잘 맞춰 주었어요

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
| TO - BE | 설명 |
|:--:|:--:|
| <img width ="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/513d7de4-0e5f-4003-bccb-1c6fb1eb3451"> | 잘 맞추어 주었어요  |
| <img width ="375" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/90c6c06f-7953-4a01-8578-20650ae5195d"> | separator를 잘 그려 주었어요 |

## 📮 관련 이슈
- Resolved: #