### PR TITLE
[Fix] #352 콕찌르기 이미지 뷰 조정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/Foundation+/String+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/Foundation+/String+.swift
@@ -75,3 +75,30 @@ public extension String {
         return map({String($0)}).last
     }
 }
+
+public extension String {
+    func isPercentEncoded() -> Bool {
+        guard let decodedString = self.removingPercentEncoding,
+              let decodedData = decodedString.data(using: .utf8)
+        else { return false }
+        
+        let encodedData = self.data(using: .utf8)
+        
+        return encodedData != decodedData
+    }
+    
+    func removePercentEncodingIfNeeded() -> String {
+        func removePercentEncodingRecursively(with string: String, attempts: Int) -> String {
+            guard attempts > 0 else { return string }
+
+            let decodedString = string.removingPercentEncoding ?? string
+            return decodedString.isPercentEncoded() ? removePercentEncodingRecursively(with: decodedString, attempts: attempts - 1) : decodedString
+        }
+        
+        guard isPercentEncoded(),
+              let decodedString = self.removingPercentEncoding
+        else { return self }
+        
+        return removePercentEncodingRecursively(with: decodedString, attempts: 2)
+    }
+}

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -10,6 +10,11 @@ import Kingfisher
 
 public extension UIImageView {
     func setImage(with urlString: String, placeholder: UIImage? = nil, completion: ((UIImage?) -> Void)? = nil) {
+        guard let urlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            print("URL 인코딩 실패")
+            return
+        }
+
         let cache = ImageCache.default
         if urlString == "" {
             self.image = placeholder

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -10,7 +10,10 @@ import Kingfisher
 
 public extension UIImageView {
     func setImage(with urlString: String, placeholder: UIImage? = nil, completion: ((UIImage?) -> Void)? = nil) {
-        guard let urlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+        guard let urlString = urlString
+            .removePercentEncodingIfNeeded()
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) 
+        else {
             print("URL 인코딩 실패")
             return
         }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileCardView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileCardView.swift
@@ -30,6 +30,7 @@ public final class PokeProfileCardView: UIView, PokeCompatible {
         imageView.backgroundColor = DSKitAsset.Colors.gray700.color
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
+        imageView.image = DSKitAsset.Assets.iconDefaultProfile.image
         return imageView
     }()
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileImageView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileImageView.swift
@@ -29,6 +29,7 @@ public final class PokeProfileImageView: UIImageView {
     
     private func setUI() {
         self.backgroundColor = DSKitAsset.Colors.gray700.color
+        self.image = DSKitAsset.Assets.iconDefaultProfile.image
         self.clipsToBounds = true
         self.layer.borderWidth = 2
         self.contentMode = .scaleAspectFill

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/Views/ProfileCardGroupView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/Views/ProfileCardGroupView.swift
@@ -37,9 +37,11 @@ public final class ProfileCardGroupView: UIView, PokeCompatible {
     // MARK: - UI Components
     
     private let friendProfileImageView = UIImageView().then {
+        $0.image = DSKitAsset.Assets.iconDefaultProfile.image
         $0.layer.cornerRadius = 15
         $0.backgroundColor = DSKitAsset.Colors.gray700.color
         $0.clipsToBounds = true
+        $0.contentMode = .scaleAspectFill
     }
     
     private let friendNameLabel = UILabel().then {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#352

## 🌱 PR Point
- 콕 찌르기 피쳐의 프로필 이미지 뷰들에 기본 사람 아이콘을 넣어서 네트워크 통신 실패 시에도 어색하지 않도록 수정했습니다.
- 프로필 이미지 URL에 한글이 섞여 있는 경우 특정 기기들에서는 제대로 이미지를 불러오지 못하는 이슈가 있었습니다.
- 이 문제를 해결하기 위해 URL을 PercentEncoding 하여 한글을 제거하고 이미지를 불러오도록 수정했습니다.


## 📮 관련 이슈
- Resolved: #352 
