### PR TITLE
[Fix] #356 - 토큰 변수에 강제 언래핑 제거

### DIFF
--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/SOPTWebView.swift
@@ -106,11 +106,13 @@ extension SOPTWebView {
 
 extension SOPTWebView: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        guard !self.barrier else { return }
+        guard !self.barrier, let playgroundToken = UserDefaultKeyList.Auth.playgroundToken else {
+          return
+        }
         
         self.barrier = true
         self.wkwebView.evaluateJavaScript(
-            "localStorage.setItem(\"serviceAccessToken\", \"\(UserDefaultKeyList.Auth.playgroundToken!)\")"
+            "localStorage.setItem(\"serviceAccessToken\", \"\(playgroundToken)\")"
         )
         self.wkwebView.reload()
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#356

## 🌱 PR Point
- 비회원일 때 웹 뷰에 토큰 주입시 강제 언래핑으로 인해 앱이 크래시 나는 문제를 해결했습니다.

## 📸 스크린샷
- 생략

## 📮 관련 이슈
- Resolved: #356 
