### PR TITLE
[Feat] #231 - 기존 결석 케이스 지각으로 수정

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -155,15 +155,24 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
         }
         /// 2차 출석 후
         else {
-            /// 2차 출석 안한 경우, 결석
+            /// 2차 결석인 경우
             if attendances[safe: 1]?.type == AttendanceStepType.unCheck {
-                attendances.append(AttendanceStepModel(type: .absent, title: I18N.Attendance.absent))
-            } else {
-                /// 1차 출석 안하고, 2차 출석한 경우 지각
+                /// 1차 출석일 때, 지각
+                if attendances[safe:0]?.type == AttendanceStepType.check {
+                    attendances.append(AttendanceStepModel(type: .tardy, title: I18N.Attendance.tardy))
+                }
+                /// 1차 결석일 때, 결석
+                else if attendances[safe:0]?.type == AttendanceStepType.unCheck {
+                    attendances.append(AttendanceStepModel(type: .absent, title: I18N.Attendance.absent))
+                }
+            } 
+            /// 2차 출석인 경우
+            else {
+                /// 1차 결석일 때, 지각
                 if attendances[safe: 0]?.type == AttendanceStepType.unCheck {
                     attendances.append(AttendanceStepModel(type: .tardy, title: I18N.Attendance.tardy))
                 }
-                /// 1차 출석, 2차 출석 모두 한 경우 출석완료
+                /// 1차 출석일 때, 출석
                 else {
                     attendances.append(AttendanceStepModel(type: .done, title: I18N.Attendance.completeAttendance))
                 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/SampleData/Attendance/AttendanceSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/SampleData/Attendance/AttendanceSampleData.swift
@@ -23,9 +23,10 @@ extension AttendanceAPI {
 //            return SampleData.Lecture.noAttendanceSession
             let lectureCases = [SampleData.Lecture.noSession, SampleData.Lecture.noAttendanceSession,
                                 SampleData.Lecture.beforeAttendance, SampleData.Lecture.absentCaseOne, SampleData.Lecture.absenctCaseTwo,
-                                SampleData.Lecture.tardy, SampleData.Lecture.eventSession, SampleData.Lecture.firstAbsentCaseOne]
+                                SampleData.Lecture.tardyCaseOne, SampleData.Lecture.tardyCaseTwo, SampleData.Lecture.eventSession, SampleData.Lecture.firstAbsentCaseOne]
             let randomIndex = Int.random(in: 0..<lectureCases.count)
-            return lectureCases[randomIndex]
+//            return lectureCases[randomIndex]
+            return SampleData.Lecture.absenctCaseTwo
 //            return SampleData.Lecture.attendanceComplete
 //            return SampleData.Lecture.errorSession
         case .total:

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/SampleData/Attendance/Data/ATLectureSampleData.swift
@@ -171,7 +171,7 @@ enum SampleData {
         """.utf8
         )
         
-        static let tardy = Data(
+        static let tardyCaseOne = Data(
         """
         {
           "success": true,
@@ -191,6 +191,34 @@ enum SampleData {
               },
               {
                 "status": "ATTENDANCE",
+                "attendedAt": "2023-04-13T14:10:04"
+              }
+            ]
+          }
+        }
+        """.utf8
+        )
+        
+        static let tardyCaseTwo = Data(
+        """
+        {
+          "success": true,
+          "message": "세션 조회 성공",
+          "data": {
+            "type": "HAS_ATTENDANCE",
+                "id": 1,
+            "location": "아름교육관",
+            "name": "서버 1차 세미나",
+            "startDate": "2023-04-13T14:00:00",
+            "endDate": "2023-04-13T18:00:00",
+            "message": "",
+            "attendances": [
+              {
+                "status": "ATTENDANCE",
+                "attendedAt": "2023-04-13T14:12:09"
+              },
+              {
+                "status": "ABSENT",
                 "attendedAt": "2023-04-13T14:10:04"
               }
             ]


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#231

## 🌱 PR Point
기존 결석 케이스를 지각 케이스로 수정했습니다.

AS-IS
[출석, 결석] -> 결석

TO-BE
[출석, 결석] -> 지각

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

이번 기수에서 기존 결석 케이스를 지각으로 가져간다고 해서 대응했습니다.

현재 서버에서 내려오는 [1차 출석, 2차 출석] 상태에 따라 [최종 출석]을 클라이언트 측에서 계산해주고 있는데요.
이에 따라서 나올 수 있는 경우의 수는 아래와 같습니다.

|1차 출석|2차 출석|최종 출석|
|:--:|:--:|:--:|
|출석|결석|지각|
|결석|결석|결석|
|결석|출석|지각|
|출석|출석|출석|

이에 맞게 ShowAttendanceUseCase 쪽 로직 수정 및 주석 추가해뒀습니다.
아무래도 빠르게 대응해야 하는 건이라 실례일수 있는데 제가 진행하는 점 죄송합니다. (꾸벅)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|지각 케이스|<img src="https://github.com/sopt-makers/SOPT-iOS/assets/74968390/82881fed-9fcf-4e5f-b880-dfe3f138fb6e" width=300>|


## 📮 관련 이슈
- Resolved: #231 
