### PR TITLE
[Fix] #361 - 타이머 실행 전 출석하기 진입시 무한로딩 이슈 해결

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/Model/AttendanceRoundModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/AttendanceRoundModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct AttendanceRoundModel {
+public struct AttendanceRoundModel: Equatable {
     public let subLectureId: Int
     public let round: Int
     

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -112,6 +112,7 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
             })
             .sink(receiveCompletion: { event in
                 print("completion: fetchLectureRound \(event)")
+                self.lectureRound.send(.EMPTY)
             }, receiveValue: { result in
                 /// 출석 진행중인데 이미 출석 완료한 경우
                 if self.takenAttendance.rawValue == result?.round {

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -133,6 +133,12 @@ extension ShowAttendanceViewModel {
             .compactMap { $0 }
             .withUnretained(self)
             .sink { owner, lectureRound in
+                if lectureRound == .EMPTY {
+                    output.isLoading.send(false)
+                    let buttonInfo = AttendanceButtonInfo(title: I18N.Attendance.takeNthAttendance(2), isEnalbed: false)
+                    output.attendanceButtonInfo.send(buttonInfo)
+                    return
+                }
                 owner.lectureRound = lectureRound
                 let buttonInfo = AttendanceButtonInfo(title: I18N.Attendance.takeNthAttendance(lectureRound.round), isEnalbed: true)
                 output.attendanceButtonInfo.send(buttonInfo)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/ #361 

## 🌱 PR Point
- [ 세미나 당일 ]  + [ 2차 출석 완료 ] 상태에 버튼이 어떤 상태로 있는지 명확하지 않아서 아래 스크린샷 처럼 해두었습니다.
- Service Future의 completion시에도 로딩이 멈춰지게끔 로직을 추가했습니다.

## 📌 참고 사항
- [ 출석 + 결석 ], [ 결석 + 출석 ]은 이제 모두 '지각' 입니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 출석하기 | <img src=https://github.com/sopt-makers/SOPT-iOS/assets/60292150/c0e9cb55-2b3a-4738-8424-23cca1cb6a70 width="300"/> |




## 📮 관련 이슈
- Resolved: #361 
- Closes T-10824
