### PR TITLE
[Fix] #363 - 무한로딩 해결 로직 수정

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/ShowAttendanceRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ShowAttendanceRepository.swift
@@ -39,7 +39,7 @@ extension ShowAttendanceRepository: ShowAttendanceRepositoryInterface {
     public func fetchLectureRound(lectureId: Int) -> AnyPublisher<AttendanceRoundModel?, Error> {
         return self.attendanceService
             .fetchAttendanceRound(lectureId: lectureId)
-            .compactMap { $0.data?.toDomain() }
+            .map { $0.data?.toDomain() }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ShowAttendanceUseCase.swift
@@ -112,7 +112,6 @@ extension DefaultShowAttendanceUseCase: ShowAttendanceUseCase {
             })
             .sink(receiveCompletion: { event in
                 print("completion: fetchLectureRound \(event)")
-                self.lectureRound.send(.EMPTY)
             }, receiveValue: { result in
                 /// 출석 진행중인데 이미 출석 완료한 경우
                 if self.takenAttendance.rawValue == result?.round {

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -130,13 +130,12 @@ extension ShowAttendanceViewModel {
             .store(in: self.cancelBag)
         
         lectureRound
-            .compactMap { $0 }
             .withUnretained(self)
             .sink { owner, lectureRound in
-                if lectureRound == .EMPTY {
-                    output.isLoading.send(false)
-                    let buttonInfo = AttendanceButtonInfo(title: I18N.Attendance.takeNthAttendance(2), isEnalbed: false)
+                guard let lectureRound else {
+                    let buttonInfo = AttendanceButtonInfo(title: I18N.Attendance.takeNthAttendance(1), isEnalbed: false)
                     output.attendanceButtonInfo.send(buttonInfo)
+                    output.isLoading.send(false)
                     return
                 }
                 owner.lectureRound = lectureRound


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/ #363 

## 🌱 PR Point
### 문제 원인
```swift
// 출석 체크 시작 전
{ "success": false,"message":"출석 체크 시작 전입니다","data": null }

// 출석 체크 시작 후
{"success":true,"message":"출석 차수 조회 성공","data":{"id":529,"round":2}}
```
출석체크를 시작하기 전에는 이런 응답값이 오고 있습니다. data의 타입이 nil입니다.

```swift
/// ShowAttendanceRepository

// Before
public func fetchLectureRound(lectureId: Int) -> AnyPublisher<AttendanceRoundModel?, Error> {
    return self.attendanceService
        .fetchAttendanceRound(lectureId: lectureId)
        .compactMap { $0.data?.toDomain() }
        .eraseToAnyPublisher()
}

// After
public func fetchLectureRound(lectureId: Int) -> AnyPublisher<AttendanceRoundModel?, Error> {
    return self.attendanceService
        .fetchAttendanceRound(lectureId: lectureId)
        .map { $0.data?.toDomain() } // <---✅ 바뀐 부분 ✅
        .eraseToAnyPublisher()
}
```
기존 로직의 경우 Repository에서 Service에서 받은 응답값의 data가 nil일 경우 `compactMap`에 의해서 필터링되어 이후 ViewModel에서 로딩뷰를 stop하는 로직이 트리거될 일이 없던 것이 원인이였습니다.

따라서 `compactMap`을 `map`으로 바꾸고 nil일 경우에도 로딩뷰를 stop하게끔 재수정했습니다. 

## 📮 관련 이슈
- Resolved: #363 
- Link T-10824