### PR TITLE
[Fix] Stamp 이슈 수정 

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
@@ -13,61 +13,68 @@ import Domain
 import Networks
 
 public class MissionListRepository {
-    
-    private let missionService: MissionService
-    private let rankService: RankService
-    private let userService: UserService
-    private let cancelBag = CancelBag()
-    
-    public init(
-        missionService: MissionService,
-        rankService: RankService,
-        userService: UserService
-    ) {
-        self.missionService = missionService
-        self.rankService = rankService
-        self.userService = userService
-    }
+  
+  private let missionService: MissionService
+  private let rankService: RankService
+  private let userService: UserService
+  private let cancelBag = CancelBag()
+  
+  public init(
+    missionService: MissionService,
+    rankService: RankService,
+    userService: UserService
+  ) {
+    self.missionService = missionService
+    self.rankService = rankService
+    self.userService = userService
+  }
 }
 
 extension MissionListRepository: MissionListRepositoryInterface {
-    public func fetchMissionList(type: MissionListFetchType, userName: String?) -> AnyPublisher<[MissionListModel], Error> {
-        guard let userName else {
-            return fetchMissionList(type: type)
-        }
-        
-        return fetchRankDetail(userName: userName)
+  public func fetchMissionList(type: MissionListFetchType, userName: String?) -> AnyPublisher<[MissionListModel], Error> {
+    guard let userName else {
+      return fetchMissionList(type: type)
     }
     
-    public func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error> {
-        self.userService
-            .fetchActiveGenerationStatus()
-            .map { $0.toDomain() }
-            .eraseToAnyPublisher()
-    }
+    return fetchRankDetail(userName: userName)
+  }
+  
+  public func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error> {
+    self.userService
+      .fetchActiveGenerationStatus()
+      .map { $0.toDomain() }
+      .eraseToAnyPublisher()
+  }
+  
+  public func fetchCurrentSoptampInfo() -> AnyPublisher<SoptampUserModel, Error> {
+    self.userService
+      .fetchSoptampUser()
+      .map { $0.toDomain() }
+      .eraseToAnyPublisher()
+  }
 }
 
 extension MissionListRepository {
-    private func fetchMissionList(type: MissionListFetchType) -> AnyPublisher<[MissionListModel], Error> {
-        switch type {
-        case .all:
-            return missionService.fetchAllMissionList()
-                .map { $0.toDomain() }
-                .eraseToAnyPublisher()
-        case .complete:
-            return missionService.fetchCompleteMissionList()
-                .map { $0.toDomain() }
-                .eraseToAnyPublisher()
-        case .incomplete:
-            return missionService.fetchIncompleteMissionList()
-                .map { $0.toDomain() }
-                .eraseToAnyPublisher()
-        }
+  private func fetchMissionList(type: MissionListFetchType) -> AnyPublisher<[MissionListModel], Error> {
+    switch type {
+    case .all:
+      return missionService.fetchAllMissionList()
+        .map { $0.toDomain() }
+        .eraseToAnyPublisher()
+    case .complete:
+      return missionService.fetchCompleteMissionList()
+        .map { $0.toDomain() }
+        .eraseToAnyPublisher()
+    case .incomplete:
+      return missionService.fetchIncompleteMissionList()
+        .map { $0.toDomain() }
+        .eraseToAnyPublisher()
     }
-    
-    private func fetchRankDetail(userName: String) -> AnyPublisher<[MissionListModel], Error> {
-        rankService.fetchRankDetail(userName: userName)
-            .map { $0.toDomain() }
-            .eraseToAnyPublisher()
-    }
+  }
+  
+  private func fetchRankDetail(userName: String) -> AnyPublisher<[MissionListModel], Error> {
+    rankService.fetchRankDetail(userName: userName)
+      .map { $0.toDomain() }
+      .eraseToAnyPublisher()
+  }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptampUserTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptampUserTransform.swift
@@ -1,0 +1,22 @@
+//
+//  SoptampUserTransform.swift
+//  Data
+//
+//  Created by Ian on 4/20/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension SoptampUserEntity {
+  public func toDomain() -> SoptampUserModel {
+    return SoptampUserModel(
+      nickname: self.nickname,
+      profileMessage: self.profileMessage,
+      points: self.points
+    )
+  }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/RankingModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/RankingModel.swift
@@ -8,29 +8,39 @@
 
 import Foundation
 
-public struct RankingModel: Hashable {
-    public let username: String
-    public let score: Int
-    public let sentence: String
-    
-    public var isMyRanking: Bool = false
-    
-    public init(username: String, score: Int, sentence: String) {
-        self.username = username
-        self.score = score
-        self.sentence = sentence
-    }
-    
-    public
-    mutating func setMyRanking(_ isMyRanking: Bool) {
-        self.isMyRanking = isMyRanking
-    }
+// MARK: - RankingModel
+public struct RankingModel {
+  public let username: String
+  public let score: Int
+  public let sentence: String
+  
+  public var isMyRanking: Bool = false
+  
+  public init(username: String, score: Int, sentence: String) {
+    self.username = username
+    self.score = score
+    self.sentence = sentence
+  }
+  
+  public
+  mutating func setMyRanking(_ isMyRanking: Bool) {
+    self.isMyRanking = isMyRanking
+  }
 }
 
-public struct RankingChartModel: Hashable {
-    public let ranking: [RankingModel]
-    
-    public init(ranking: [RankingModel]) {
-        self.ranking = ranking
-    }
+extension RankingModel: Hashable, Identifiable {
+  public var id: String { UUID().uuidString }
+}
+
+// MARK: - RankingChartModel
+public struct RankingChartModel {
+  public let ranking: [RankingModel]
+  
+  public init(ranking: [RankingModel]) {
+    self.ranking = ranking
+  }
+}
+
+extension RankingChartModel: Hashable, Identifiable {
+  public var id: String { UUID().uuidString }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptampUserModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptampUserModel.swift
@@ -1,0 +1,21 @@
+//
+//  SoptampUserModel.swift
+//  Domain
+//
+//  Created by Ian on 4/20/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct SoptampUserModel {
+  public let nickname: String
+  public let profileMessage: String?
+  public let points: Int
+  
+  public init(nickname: String, profileMessage: String?, points: Int) {
+    self.nickname = nickname
+    self.profileMessage = profileMessage
+    self.points = points
+  }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MissionListRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/MissionListRepositoryInterface.swift
@@ -11,6 +11,7 @@ import Combine
 import Core
 
 public protocol MissionListRepositoryInterface {
-    func fetchMissionList(type: MissionListFetchType, userName: String?) -> AnyPublisher<[MissionListModel], Error>
-    func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error>
+  func fetchMissionList(type: MissionListFetchType, userName: String?) -> AnyPublisher<[MissionListModel], Error>
+  func fetchIsActiveGenerationUser() -> AnyPublisher<UsersActiveGenerationStatusViewResponse, Error>
+  func fetchCurrentSoptampInfo() -> AnyPublisher<SoptampUserModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
@@ -11,54 +11,65 @@ import Combine
 import Core
 
 public protocol MissionListUseCase {
-    func fetchMissionList(type: MissionListFetchType)
-    func fetchOtherUserMissionList(userName: String)
-    func fetchIsActiveGenerationUser()
-
-    var missionListModelsFetched: PassthroughSubject<[MissionListModel], Error> { get set }
-    var usersActiveGenerationInfo: PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error> { get set }
+  func fetchMissionList(type: MissionListFetchType)
+  func fetchOtherUserMissionList(userName: String)
+  func fetchIsActiveGenerationUser()
+  func updateCurrentSoptampUserInfo()
+  
+  var missionListModelsFetched: PassthroughSubject<[MissionListModel], Error> { get set }
+  var usersActiveGenerationInfo: PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error> { get set }
 }
 
 public class DefaultMissionListUseCase {
   
-    private let repository: MissionListRepositoryInterface
-    private var cancelBag = CancelBag()
-    public var missionListModelsFetched = PassthroughSubject<[MissionListModel], Error>()
-    public var usersActiveGenerationInfo = PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error>()
-    
-    public init(repository: MissionListRepositoryInterface) {
-        self.repository = repository
-    }
+  private let repository: MissionListRepositoryInterface
+  private var cancelBag = CancelBag()
+  public var missionListModelsFetched = PassthroughSubject<[MissionListModel], Error>()
+  public var usersActiveGenerationInfo = PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error>()
+  
+  public init(repository: MissionListRepositoryInterface) {
+    self.repository = repository
+  }
 }
 
 extension DefaultMissionListUseCase: MissionListUseCase {
-    public func fetchMissionList(type: MissionListFetchType) {
-        repository.fetchMissionList(type: type, userName: nil)
-            .sink(receiveCompletion: { event in
-                print("completion: \(event)")
-            }, receiveValue: { model in
-                self.missionListModelsFetched.send(model)
-            })
-            .store(in: cancelBag)
-    }
-    
-    public func fetchIsActiveGenerationUser() {
-        self.repository
-            .fetchIsActiveGenerationUser()
-            .sink(receiveCompletion: { event in
-                print("completion: \(event)")
-            }, receiveValue: { usersActiveGenerationStatus in
-                self.usersActiveGenerationInfo.send(usersActiveGenerationStatus)
-            }).store(in: self.cancelBag)
-    }
-    
-    public func fetchOtherUserMissionList(userName: String) {
-        repository.fetchMissionList(type: .complete, userName: userName)
-            .sink(receiveCompletion: { event in
-                print("completion: \(event)")
-            }, receiveValue: { model in
-                self.missionListModelsFetched.send(model)
-            })
-            .store(in: cancelBag)
-    }
+  public func fetchMissionList(type: MissionListFetchType) {
+    repository.fetchMissionList(type: type, userName: nil)
+      .sink(receiveCompletion: { event in
+        print("completion: \(event)")
+      }, receiveValue: { model in
+        self.missionListModelsFetched.send(model)
+      })
+      .store(in: cancelBag)
+  }
+  
+  public func fetchIsActiveGenerationUser() {
+    self.repository
+      .fetchIsActiveGenerationUser()
+      .sink(receiveCompletion: { event in
+        print("completion: \(event)")
+      }, receiveValue: { usersActiveGenerationStatus in
+        self.usersActiveGenerationInfo.send(usersActiveGenerationStatus)
+      }).store(in: self.cancelBag)
+  }
+  
+  public func fetchOtherUserMissionList(userName: String) {
+    repository.fetchMissionList(type: .complete, userName: userName)
+      .sink(receiveCompletion: { event in
+        print("completion: \(event)")
+      }, receiveValue: { model in
+        self.missionListModelsFetched.send(model)
+      })
+      .store(in: cancelBag)
+  }
+  
+  public func updateCurrentSoptampUserInfo() {
+    repository.fetchCurrentSoptampInfo()
+      .sink(receiveCompletion: {
+        print("completion: \($0)")
+      }, receiveValue: { info in
+        UserDefaultKeyList.User.soptampName = info.nickname
+        UserDefaultKeyList.User.sentence = info.profileMessage
+      }).store(in: self.cancelBag)
+  }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -267,8 +267,11 @@ extension MissionListVC {
   }
 
   private func bindViewModels() {
-    let input = MissionListViewModel.Input(viewWillAppear: viewWillAppear.asDriver(),
-                                           missionTypeSelected: missionTypeMenuSelected)
+    let input = MissionListViewModel.Input(
+      viewDidLoad: Driver<Void>.just(()),
+      viewWillAppear: viewWillAppear.asDriver(),
+      missionTypeSelected: missionTypeMenuSelected
+    )
     let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
 
     output.$missionListModel

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -13,85 +13,92 @@ import Core
 import Domain
 
 public class MissionListViewModel: ViewModelType {
-    
-    private let useCase: MissionListUseCase
-    private var cancelBag = CancelBag()
-    public var missionListsceneType: MissionListSceneType!
-    
-    // MARK: - Inputs
-    
-    public struct Input {
-        let viewWillAppear: Driver<Void>
-        let missionTypeSelected: CurrentValueSubject<MissionListFetchType, Never>
-    }
-    
-    // MARK: - Outputs
-    
-    public class Output: NSObject {
-        @Published var missionListModel: [MissionListModel]?
-        @Published var usersActivateGenerationStatus: UsersActiveGenerationStatusViewResponse?
-    }
-    
-    // MARK: - init
-    
-    public init(useCase: MissionListUseCase, sceneType: MissionListSceneType) {
-        self.useCase = useCase
-        self.missionListsceneType = sceneType
-    }
+  
+  private let useCase: MissionListUseCase
+  private var cancelBag = CancelBag()
+  public var missionListsceneType: MissionListSceneType!
+  
+  // MARK: - Inputs
+  
+  public struct Input {
+    let viewDidLoad: Driver<Void>
+    let viewWillAppear: Driver<Void>
+    let missionTypeSelected: CurrentValueSubject<MissionListFetchType, Never>
+  }
+  
+  // MARK: - Outputs
+  
+  public class Output: NSObject {
+    @Published var missionListModel: [MissionListModel]?
+    @Published var usersActivateGenerationStatus: UsersActiveGenerationStatusViewResponse?
+  }
+  
+  // MARK: - init
+  
+  public init(useCase: MissionListUseCase, sceneType: MissionListSceneType) {
+    self.useCase = useCase
+    self.missionListsceneType = sceneType
+  }
 }
 
 extension MissionListViewModel {
-    public func transform(from input: Input, cancelBag: CancelBag) -> Output {
-        let output = Output()
-        self.bindOutput(output: output, cancelBag: cancelBag)
-        
-        input.viewWillAppear
-            .withUnretained(self)
-            .sink { owner, _ in
-                owner.fetchMissionList(type: input.missionTypeSelected.value)
-                owner.useCase.fetchIsActiveGenerationUser()
-            }.store(in: cancelBag)
-        
-        input.missionTypeSelected
-            .dropFirst()
-            .withUnretained(self)
-            .sink { owner, fetchType in
-                owner.useCase.fetchMissionList(type: fetchType)
-            }.store(in: cancelBag)
-        
-        return output
-    }
+  public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+    let output = Output()
+    self.bindOutput(output: output, cancelBag: cancelBag)
     
-    private func fetchMissionList(type: MissionListFetchType) {
-        switch self.missionListsceneType {
-        case .ranking(let userName, _):
-            self.useCase.fetchOtherUserMissionList(userName: userName)
-        default:
-            self.useCase.fetchMissionList(type: type)
-            
-        }
-    }
+    input.viewDidLoad
+      .withUnretained(self)
+      .sink { owner, _ in
+        owner.useCase.updateCurrentSoptampUserInfo()
+      }.store(in: cancelBag)
     
-    private func fetchIsActiveGerationUser(type: MissionListFetchType) {
-        guard case .default = self.missionListsceneType else { return }
-        
-        self.useCase.fetchIsActiveGenerationUser()
-    }
+    input.viewWillAppear
+      .withUnretained(self)
+      .sink { owner, _ in
+        owner.fetchMissionList(type: input.missionTypeSelected.value)
+        owner.useCase.fetchIsActiveGenerationUser()
+      }.store(in: cancelBag)
     
-    private func bindOutput(output: Output, cancelBag: CancelBag) {
-        let fetchedMissionList = self.useCase.missionListModelsFetched
-        
-        fetchedMissionList.asDriver()
-            .sink(receiveValue: { model in
-                output.missionListModel = model
-            })
-            .store(in: self.cancelBag)
-        
-        self.useCase
-            .usersActiveGenerationInfo
-            .asDriver()
-            .sink { usersActivateGenerationStatus in
-                output.usersActivateGenerationStatus = usersActivateGenerationStatus
-            }.store(in: self.cancelBag)
+    input.missionTypeSelected
+      .dropFirst()
+      .withUnretained(self)
+      .sink { owner, fetchType in
+        owner.useCase.fetchMissionList(type: fetchType)
+      }.store(in: cancelBag)
+    
+    return output
+  }
+  
+  private func fetchMissionList(type: MissionListFetchType) {
+    switch self.missionListsceneType {
+    case .ranking(let userName, _):
+      self.useCase.fetchOtherUserMissionList(userName: userName)
+    default:
+      self.useCase.fetchMissionList(type: type)
+      
     }
+  }
+  
+  private func fetchIsActiveGerationUser(type: MissionListFetchType) {
+    guard case .default = self.missionListsceneType else { return }
+    
+    self.useCase.fetchIsActiveGenerationUser()
+  }
+  
+  private func bindOutput(output: Output, cancelBag: CancelBag) {
+    let fetchedMissionList = self.useCase.missionListModelsFetched
+    
+    fetchedMissionList.asDriver()
+      .sink(receiveValue: { model in
+        output.missionListModel = model
+      })
+      .store(in: self.cancelBag)
+    
+    self.useCase
+      .usersActiveGenerationInfo
+      .asDriver()
+      .sink { usersActivateGenerationStatus in
+        output.usersActivateGenerationStatus = usersActivateGenerationStatus
+      }.store(in: self.cancelBag)
+  }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -20,242 +20,262 @@ import StampFeatureInterface
 import BaseFeatureDependency
 
 public class RankingVC: UIViewController, RankingViewControllable {
+  
+  // MARK: - Properties
+  
+  public var viewModel: RankingViewModel!
+  private var cancelBag = CancelBag()
+  
+  lazy var dataSource: UICollectionViewDiffableDataSource<RankingSection, AnyHashable>! = nil
+  
+  // MARK: - RankingCoordinatable
+  
+  public var onCellTap: ((String, String) -> Void)?
+  public var onNaviBackTap: (() -> Void)?
+  
+  // MARK: - UI Components
+  
+  lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton, ignorePopAction: true)
+    .setTitleTypoStyle(.SoptampFont.h2)
+    .setTitle("랭킹")
+    .setRightButton(.none)
+  
+  private lazy var rankingCollectionView: UICollectionView = {
+    let cv = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
+    cv.showsVerticalScrollIndicator = true
+    cv.backgroundColor = .white
+    cv.refreshControl = refresher
+    return cv
+  }()
+  
+  private let refresher: UIRefreshControl = {
+    let rf = UIRefreshControl()
+    return rf
+  }()
+  
+  private lazy var showMyRankingFloatingButton: UIButton = {
+    let bt = UIButton()
+    bt.layer.cornerRadius = 27.adjustedH
+    bt.backgroundColor = DSKitAsset.Colors.soptampPurple300.color
+    bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
+    let attributedStr = NSMutableAttributedString(string: "내 랭킹 보기")
+    let style = NSMutableParagraphStyle()
+    attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+    attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
+    bt.setAttributedTitle(attributedStr, for: .normal)
+    bt.isHidden = true
+    return bt
+  }()
+  
+  // MARK: - View Life Cycle
+  private let rankingViewType: RankingViewType
+  
+  init(rankingViewType: RankingViewType) {
+    self.rankingViewType = rankingViewType
     
-    // MARK: - Properties
+    super.init(nibName: nil, bundle: nil)
     
-    public var viewModel: RankingViewModel!
-    private var cancelBag = CancelBag()
-    
-    lazy var dataSource: UICollectionViewDiffableDataSource<RankingSection, AnyHashable>! = nil
-    
-    // MARK: - RankingCoordinatable
-    
-    public var onCellTap: ((String, String) -> Void)?
-    public var onNaviBackTap: (() -> Void)?
-    
-    // MARK: - UI Components
-    
-    lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton, ignorePopAction: true)
-        .setTitleTypoStyle(.SoptampFont.h2)
-        .setTitle("랭킹")
-        .setRightButton(.none)
-    
-    private lazy var rankingCollectionView: UICollectionView = {
-        let cv = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
-        cv.showsVerticalScrollIndicator = true
-        cv.backgroundColor = .white
-        cv.refreshControl = refresher
-        return cv
-    }()
-    
-    private let refresher: UIRefreshControl = {
-        let rf = UIRefreshControl()
-        return rf
-    }()
-    
-    private lazy var showMyRankingFloatingButton: UIButton = {
-        let bt = UIButton()
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.backgroundColor = DSKitAsset.Colors.soptampPurple300.color
-        bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
-        let attributedStr = NSMutableAttributedString(string: "내 랭킹 보기")
-        let style = NSMutableParagraphStyle()
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
-        bt.setAttributedTitle(attributedStr, for: .normal)
-        bt.isHidden = true
-        return bt
-    }()
-    
-    // MARK: - View Life Cycle
-    private let rankingViewType: RankingViewType
-    
-    init(rankingViewType: RankingViewType) {
-        self.rankingViewType = rankingViewType
-
-        super.init(nibName: nil, bundle: nil)
-
-      if case .currentGeneration(let info) = rankingViewType {
-        let navigationTitle = String(describing: info.currentGeneration) + "기 랭킹"
-        self.naviBar.setTitle(navigationTitle)
-      }
-      
-      if case .individualRankingInPart(let part) = rankingViewType {
-        let navigationTitle = String(describing: part.rawValue) + " 랭킹"
-        self.naviBar.setTitle(navigationTitle)
-      }
+    if case .currentGeneration(let info) = rankingViewType {
+      let navigationTitle = String(describing: info.currentGeneration) + "기 랭킹"
+      self.naviBar.setTitle(navigationTitle)
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    if case .individualRankingInPart(let part) = rankingViewType {
+      let navigationTitle = String(describing: part.rawValue) + " 랭킹"
+      self.naviBar.setTitle(navigationTitle)
     }
-    
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-        self.setUI()
-        self.setLayout()
-        self.setDelegate()
-        self.registerCells()
-        self.bindViews()
-        self.bindViewModels()
-        self.setDataSource()
-    }
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setUI()
+    self.setLayout()
+    self.setDelegate()
+    self.registerCells()
+    self.bindViews()
+    self.bindViewModels()
+    self.setDataSource()
+  }
 }
 
 // MARK: - UI & Layouts
 
 extension RankingVC {
+  
+  private func setUI() {
+    self.view.backgroundColor = .white
+    self.navigationController?.isNavigationBarHidden = true
+  }
+  
+  private func setLayout() {
+    self.view.addSubviews(naviBar, rankingCollectionView, showMyRankingFloatingButton)
     
-    private func setUI() {
-        self.view.backgroundColor = .white
-        self.navigationController?.isNavigationBarHidden = true
+    naviBar.snp.makeConstraints { make in
+      make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
     }
     
-    private func setLayout() {
-        self.view.addSubviews(naviBar, rankingCollectionView, showMyRankingFloatingButton)
-        
-        naviBar.snp.makeConstraints { make in
-            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-        rankingCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom).offset(4)
-            make.leading.trailing.equalToSuperview()
-            make.bottom.equalToSuperview()
-        }
-        
-        showMyRankingFloatingButton.snp.makeConstraints { make in
-            make.width.equalTo(143.adjusted)
-            make.height.equalTo(54.adjustedH)
-            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
-            make.centerX.equalToSuperview()
-        }
+    rankingCollectionView.snp.makeConstraints { make in
+      make.top.equalTo(naviBar.snp.bottom).offset(4)
+      make.leading.trailing.equalToSuperview()
+      make.bottom.equalToSuperview()
     }
+    
+    showMyRankingFloatingButton.snp.makeConstraints { make in
+      make.width.equalTo(143.adjusted)
+      make.height.equalTo(54.adjustedH)
+      make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+      make.centerX.equalToSuperview()
+    }
+  }
 }
 
 // MARK: - Methods
 
 extension RankingVC {
+  
+  private func bindViews() {
+    naviBar.leftButtonTapped
+      .withUnretained(self)
+      .sink { owner, _ in
+        owner.onNaviBackTap?()
+      }.store(in: cancelBag)
+  }
+  
+  private func bindViewModels() {
+    let refreshStarted = refresher.publisher(for: .valueChanged)
+      .mapVoid()
+      .asDriver()
     
-    private func bindViews() {
-        naviBar.leftButtonTapped
-            .withUnretained(self)
-            .sink { owner, _ in
-                owner.onNaviBackTap?()
-            }.store(in: cancelBag)
-    }
+    let showRankingButtonTapped = self.showMyRankingFloatingButton
+      .publisher(for: .touchUpInside)
+      .filter { _ in self.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
+      .mapVoid()
+      .asDriver()
     
-    private func bindViewModels() {
-        let refreshStarted = refresher.publisher(for: .valueChanged)
-            .mapVoid()
-            .asDriver()
+    let input = RankingViewModel.Input(
+      viewDidLoad: Driver.just(()),
+      refreshStarted: refreshStarted,
+      showMyRankingButtonTapped: showRankingButtonTapped
+    )
+    
+    let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+    
+    output.$rankingListModel
+      .sink { [weak self] model in
+        guard
+          let self,
+          let name = UserDefaultKeyList.User.soptampName,
+          model.contains(where: { $0.username == name })
+        else { return }
         
-        let showRankingButtonTapped = self.showMyRankingFloatingButton
-            .publisher(for: .touchUpInside)
-            .filter { _ in self.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
-            .mapVoid()
-            .asDriver()
-        
-        let input = RankingViewModel.Input(
-            viewDidLoad: Driver.just(()),
-            refreshStarted: refreshStarted,
-            showMyRankingButtonTapped: showRankingButtonTapped
-        )
-        
-        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
-      
-        output.$rankingListModel
-          .sink { [weak self] model in
-            guard
-              let self,
-              let name = UserDefaultKeyList.User.soptampName,
-              model.contains(where: { $0.username == name })
-            else { return }
+        self.showMyRankingFloatingButton.isHidden = false
+      }.store(in: self.cancelBag)
+    
+    output.$rankingListModel
+      .dropFirst(2)
+      .withUnretained(self)
+      .sink { owner, model in
+        owner.applySnapshot(model: model)
+        owner.endRefresh()
+      }.store(in: self.cancelBag)
+    
+    output.$myRanking
+      .dropFirst()
+      .map { IndexPath(item: $0.item, section: $0.section)}
+      .withUnretained(self)
+      .sink { owner, indexPath in
+        owner.rankingCollectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: true)
+      }.store(in: self.cancelBag)
+  }
+  
+  private func setDelegate() {
+    rankingCollectionView.delegate = self
+  }
+  
+  private func registerCells() {
+    RankingChartCVC.register(target: rankingCollectionView)
+    RankingListCVC.register(target: rankingCollectionView)
+  }
+  
+  private func setDataSource() {
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: rankingCollectionView,
+      cellProvider: { collectionView, indexPath, itemIdentifier in
+        switch RankingSection.type(indexPath.section) {
+        case .chart:
+          guard 
+            let chartCell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: RankingChartCVC.className, 
+                for: indexPath
+            ) as? RankingChartCVC,
+            let chartCellModel = itemIdentifier as? RankingChartModel
+          else { return UICollectionViewCell() }
+
+          chartCell.setData(model: chartCellModel)
+          chartCell.usernameTapped = { [weak self] balloonModel in
+            guard let self = self else { return }
+            
+            let item = balloonModel.toRankingListTapItem()
+            self.onCellTap?(item.username, item.sentence)
+          }
+          return chartCell
           
-            self.showMyRankingFloatingButton.isHidden = false
-        }.store(in: self.cancelBag)
-        
-        output.$rankingListModel
-            .dropFirst(2)
-            .withUnretained(self)
-            .sink { owner, model in
-                owner.applySnapshot(model: model)
-                owner.endRefresh()
-            }.store(in: self.cancelBag)
-        
-        output.$myRanking
-            .dropFirst()
-            .map { IndexPath(item: $0.item, section: $0.section)}
-            .withUnretained(self)
-            .sink { owner, indexPath in
-                owner.rankingCollectionView.scrollToItem(at: indexPath, at: .centeredVertically, animated: true)
-            }.store(in: self.cancelBag)
-    }
+        case .list:
+          guard
+            let rankingListCell = collectionView.dequeueReusableCell(
+              withReuseIdentifier: RankingListCVC.className,
+              for: indexPath
+            ) as? RankingListCVC,
+            let rankingListCellModel = itemIdentifier as? RankingModel 
+          else { return UICollectionViewCell() }
+          
+          rankingListCell.setData(model: rankingListCellModel, rank: indexPath.row + 1 + 3)
+          
+          return rankingListCell
+        }
+      }
+    )
+  }
+  
+  func applySnapshot(model: [RankingModel]) {
+    var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
+    snapshot.appendSections([.chart, .list])
     
-    private func setDelegate() {
-        rankingCollectionView.delegate = self
-    }
+    guard model.count >= 4 else { return }
     
-    private func registerCells() {
-        RankingChartCVC.register(target: rankingCollectionView)
-        RankingListCVC.register(target: rankingCollectionView)
-    }
+    guard
+      let chartCellModels = Array(model[0...2]) as? [RankingModel],
+      let rankingListModel = Array(model[3...model.count - 1]) as? [RankingModel]
+    else { return }
     
-    private func setDataSource() {
-        dataSource = UICollectionViewDiffableDataSource(collectionView: rankingCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
-            switch RankingSection.type(indexPath.section) {
-            case .chart:
-                guard let chartCell = collectionView.dequeueReusableCell(withReuseIdentifier: RankingChartCVC.className, for: indexPath) as? RankingChartCVC,
-                      let chartCellModel = itemIdentifier as? RankingChartModel else { return UICollectionViewCell() }
-                chartCell.setData(model: chartCellModel)
-                chartCell.usernameTapped = { [weak self] balloonModel in
-                    guard let self = self else { return }
-                    let item = balloonModel.toRankingListTapItem()
-                    self.onCellTap?(item.username, item.sentence)
-                }
-                return chartCell
-                
-            case .list:
-                guard let rankingListCell = collectionView.dequeueReusableCell(withReuseIdentifier: RankingListCVC.className, for: indexPath) as? RankingListCVC,
-                      let rankingListCellModel = itemIdentifier as? RankingModel else { return UICollectionViewCell() }
-                rankingListCell.setData(model: rankingListCellModel,
-                                        rank: indexPath.row + 1 + 3)
-                
-                return rankingListCell
-            }
-        })
-    }
-    
-    func applySnapshot(model: [RankingModel]) {
-        var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
-        snapshot.appendSections([.chart, .list])
-        guard model.count >= 4 else { return }
-        guard let chartCellModels = Array(model[0...2]) as? [RankingModel],
-              let rankingListModel = Array(model[3...model.count-1]) as? [RankingModel] else { return }
-        let chartCellModel = RankingChartModel.init(ranking: chartCellModels)
-        snapshot.appendItems([chartCellModel], toSection: .chart)
-        snapshot.appendItems(rankingListModel, toSection: .list)
-        dataSource.apply(snapshot, animatingDifferences: false)
-        self.view.setNeedsLayout()
-    }
-    
-    private func endRefresh() {
-        self.refresher.endRefreshing()
-    }
+    let chartCellModel = RankingChartModel.init(ranking: chartCellModels)
+    snapshot.appendItems([chartCellModel], toSection: .chart)
+    snapshot.appendItems(rankingListModel, toSection: .list)
+    dataSource.apply(snapshot, animatingDifferences: false)
+    self.view.setNeedsLayout()
+  }
+  
+  private func endRefresh() {
+    self.refresher.endRefreshing()
+  }
 }
 
 extension RankingVC: UICollectionViewDelegate {
-    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard indexPath.section >= 1 else { return }
-        
-        guard let tappedCell = collectionView.cellForItem(at: indexPath) as? RankingListTappable,
-              let item = tappedCell.getModelItem() else { return }
-        self.onCellTap?(item.username, item.sentence)
-    }
+  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard indexPath.section >= 1 else { return }
+    
+    guard let tappedCell = collectionView.cellForItem(at: indexPath) as? RankingListTappable,
+          let item = tappedCell.getModelItem() else { return }
+    self.onCellTap?(item.username, item.sentence)
+  }
 }
 
 extension RankingVC: UIGestureRecognizerDelegate {
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        true
-    }
+  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    true
+  }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
@@ -80,7 +80,7 @@ extension RankingViewModel {
         
         fetchedRankingList.asDriver()
             .sink(receiveValue: { model in
-                output.rankingListModel = model
+                output.rankingListModel = model.uniqued()
             })
             .store(in: self.cancelBag)
         


### PR DESCRIPTION
## 🌴 PR 요약
스탬프 프로덕션에서 발생한 이슈를 수정했어요

🌱 작업한 브랜치
- fix/stamp-issue

## 🌱 PR Point
### 1. RankingVC 
- 앱이 터지는 이슈가 있었는데 그건 Hashable 하다고 해놓고서 중복 데이터를 줘서 그랬어요 
- [Sentry](https://sopt-1a.sentry.io/issues/5226600274/events/ea82b21e6b364544b99475d757a5266f/?project=4505090751332352&query=is:unresolved&stream_index=1)
- 실제로 닉네임이 같아서 (이게 오류 포인트) 아요김민성씨가 두개였고
- 서버에서 변경했고 unique하도록 바꿔주었어요 
- 클라이언트에서도 대응합니다

<img width="1368" alt="image" src="https://github.com/sopt-makers/SOPT-iOS/assets/16400721/037888a1-2cb8-40b5-acef-f9e4c78adbae">

### 2. 솝탬프 닉네임
- 솝탬프 닉네임은 로그인때 저장하는데요 이번에 솝탬프 릴리즈 때 닉네임을 일괄 변경했어요 (아요이승호~ 어쩌구~)
- 그래서 로그아웃을 안 한 유저는 최신화가 안 될거에요 
- 그럼 내 미션을 조회할 때 query로 닉네임을 넘기는데 이상한 닉네임으로 조회해서 안 나오게 돼요
- 이걸 MissionList에서 땡겨서 갱신하도록 했어요


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #
