### PR TITLE
[Setting] 앱 계정 이전

### DIFF
--- a/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
+++ b/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
@@ -50,7 +50,7 @@ public extension Project {
       "CFBundleShortVersionString": "1.0.0",
       "CFBundleDevelopmentRegion": "ko",
       "CFBundleVersion": "1",
-      "CFBundleIdentifier": "com.sopt-stamp-iOS.test",
+      "CFBundleIdentifier": "com.sopt-stamp-iOS.alpha",
       "CFBundleDisplayName": "SOPT-Test",
       "UILaunchStoryboardName": "LaunchScreen",
       "UIApplicationSceneManifest": [

--- a/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -60,7 +60,7 @@ public extension SettingsDictionary {
     
     func setCodeSignManual() -> SettingsDictionary {
         merging(["CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual")])
-            .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "9K86FQHDLU")])
+            .merging(["DEVELOPMENT_TEAM": SettingValue(stringLiteral: "95YWTT5L8K")])
             .merging(["CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "$(CODE_SIGN_IDENTITY)")])
     }
     

--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.sopt-stamp-iOS</string>
-	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
+++ b/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.sopt-stamp-iOS</string>
-	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/fastlane/Appfile
+++ b/SOPT-iOS/fastlane/Appfile
@@ -1,8 +1,8 @@
 app_identifier("com.sopt-stamp-iOS.release") # The bundle identifier of your app
 apple_id(ENV["APPLE_ID"]) # Your Apple Developer Portal username
 
-itc_team_id("125287287") # App Store Connect Team ID
-team_id("9K86FQHDLU") # Developer Portal Team ID
+itc_team_id("127177793") # App Store Connect Team ID
+team_id("95YWTT5L8K") # Developer Portal Team ID
 
 # app_identifier 설정
 for_platform :ios do

--- a/SOPT-iOS/fastlane/Appfile
+++ b/SOPT-iOS/fastlane/Appfile
@@ -9,16 +9,16 @@ for_platform :ios do
 
     # demo
     for_lane :set_version_demo do
-      app_identifier 'com.sopt-stamp-iOS.test'
+      app_identifier 'com.sopt-stamp-iOS.alpha'
     end
 
-    for_lane :upload_testflight_demo do
-        app_identifier 'com.sopt-stamp-iOS.test'
+    for_lane :upload_alphaflight_demo do
+        app_identifier 'com.sopt-stamp-iOS.alpha'
     end
   
     # release
 
-    for_lane :upload_testflight do
+    for_lane :upload_alphaflight do
         app_identifier 'com.sopt-stamp-iOS.release'
     end
 

--- a/SOPT-iOS/fastlane/Fastfile
+++ b/SOPT-iOS/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :ios do
 
     match(
       type: "appstore",
-      app_identifier: 'com.sopt-stamp-iOS.test',
+      app_identifier: 'com.sopt-stamp-iOS.alpha',
       readonly: true
     )
 
@@ -227,13 +227,13 @@ platform :ios do
   lane :match_read_only do
     match(
       type: "appstore",
-      app_identifier: ['com.sopt-stamp-iOS.test', 'com.sopt-stamp-iOS.release', 'com.sopt-stamp-iOS.release.WidgetExtension'],
+      app_identifier: ['com.sopt-stamp-iOS.alpha', 'com.sopt-stamp-iOS.release', 'com.sopt-stamp-iOS.release.WidgetExtension'],
       readonly: true
     )
 
     match(
       type: "development",
-      app_identifier: ['com.sopt-stamp-iOS.test', 'com.sopt-stamp-iOS.release', 'com.sopt-stamp-iOS.release.WidgetExtension'],
+      app_identifier: ['com.sopt-stamp-iOS.alpha', 'com.sopt-stamp-iOS.release', 'com.sopt-stamp-iOS.release.WidgetExtension'],
       readonly: true
     )
   end

--- a/SOPT-iOS/fastlane/Matchfile
+++ b/SOPT-iOS/fastlane/Matchfile
@@ -1,11 +1,11 @@
 git_url("git@github.com:sopt-makers/SOPT-iOS-Fastlane.git")
-git_branch("main")
+git_branch("master")
 
 storage_mode("git")
 
 type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
 
-app_identifier(["com.sopt-stamp-iOS.release", "com.sopt-stamp-iOS.alpha", "com.sopt-stamp-iOS.release.WidgetExtension"])
+app_identifier(["com.sopt-stamp-iOS.release", "com.sopt-stamp-iOS.alpha"])
 # username("user@fastlane.tools") # Your Apple Developer Portal username
 
 # For all available options run `fastlane match --help`

--- a/SOPT-iOS/fastlane/Matchfile
+++ b/SOPT-iOS/fastlane/Matchfile
@@ -1,5 +1,5 @@
-git_url("git@github.com:lsj8706/fastlane-match.git")
-git_branch("master")
+git_url("git@github.com:sopt-makers/SOPT-iOS-Fastlane.git")
+git_branch("main")
 
 storage_mode("git")
 

--- a/SOPT-iOS/fastlane/Matchfile
+++ b/SOPT-iOS/fastlane/Matchfile
@@ -5,7 +5,7 @@ storage_mode("git")
 
 type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
 
-app_identifier(["com.sopt-stamp-iOS.release", "com.sopt-stamp-iOS.test", "com.sopt-stamp-iOS.release.WidgetExtension"])
+app_identifier(["com.sopt-stamp-iOS.release", "com.sopt-stamp-iOS.alpha", "com.sopt-stamp-iOS.release.WidgetExtension"])
 # username("user@fastlane.tools") # Your Apple Developer Portal username
 
 # For all available options run `fastlane match --help`


### PR DESCRIPTION
## 🌴 PR 요약
- 큼직한 일을 끝냈습니다. (메이커스를 떠나기 전에 마지막으로 불태우기..)
- SOPT 앱이 원래 제 개인 애플 계정으로 올라가 있었는데 이걸 메이커스 계정으로 전환하면서 앱 이전을 진행했어요.
- 이 과정에서 대응한 것들
  - 기존 테스트 플라이트 빌드들, 초대된 유저들 전부 삭제 (다시 초대 필요함)
  - 기존에 사용하던 인증서 사용 불가 -> fastlane match 다시 세팅했고 메이커스 organization에 private로 레포 파서 거기에 인증서 올렸어요.
  - SOPT 앱은 앱 이전으로 번들 아이디가 유지되었지만 SOPT-Test 앱은 앱스토어에 안 올라갔기 때문에 앱 이전 불가 -> 번들 아이디 유지 불가 -> 원래 `com.sopt-stamp-iOS.test` 였는데 `com.sopt-stamp-iOS.alpha`로 변경해서 다시 세팅
  - 앱 그룹, 위젯 익스텐션 지금 사용하고 있지 않기 때문에 삭제
  - [프라이빗 파일 저장소](https://github.com/sopt-makers/SOPT-iOS-Private)에 있는 정보들 최신화
- 이전처럼 `fastlane match_read_only` 실행하고 원하는 시점에 `fastlane upload_testflight version:X.X.X` 하면 테스트플라이트 업로드 될거에요.
- 푸시 알림, 애플 로그인 등 애플 계정과 연관되어 있는 피쳐들이 이전처럼 잘 동작할지에 대해서는 확신이 없어요. 천천히 해결해야 할 것 같아요.