### PR TITLE
[Feat] #391 - 솝마디 메인 뷰 화면 전환 및 데이터 바인딩

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
@@ -8,27 +8,33 @@
 
 import Foundation
 
-extension String {
-    
-    /**
 
-      - Description:
-          "yyyy-MM-dd'T'HH:mm:ss" 형태로 주어진 날짜를 원하는 format으로 변경하는 메서드
+/**
 
-      - parameters:
-        - dateString: 변경하고자 하는 dateformat을 입력합니다. ex. "HH:mm"
-     
-    */
+  - Description:
+      주어진 날짜를 원하는 format으로 변경하는 메서드
+      주어진 날짜가 없는 경우 오늘 날짜 반환
 
-    public func setDateFormat(dateString: String) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-        dateFormatter.locale = Locale(identifier: "ko_KR")
-        dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+  - parameters:
+    - dateString: 변경하고자 하는 dateformat을 입력합니다. ex. "HH:mm"
+ 
+*/
+
+public func setDateFormat(date: String? = nil, from before: String? = nil, to after: String) -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "ko_KR")
+    dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+    if let dateString = date,
+        let inputFormat = before {
         
-        guard let date = dateFormatter.date(from: self) else { return "00:00" }
+        dateFormatter.dateFormat = before
+        guard let date = dateFormatter.date(from: dateString) else { return "00:00" }
+        dateFormatter.dateFormat = after
         
-        dateFormatter.dateFormat = dateString
         return dateFormatter.string(from: date)
+    } else {
+        dateFormatter.dateFormat = after
+        return dateFormatter.string(from: Date())
     }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setDateFormat.swift
@@ -26,7 +26,7 @@ public func setDateFormat(date: String? = nil, from before: String? = nil, to af
     dateFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
 
     if let dateString = date,
-        let inputFormat = before {
+        let before = before {
         
         dateFormatter.dateFormat = before
         guard let date = dateFormatter.date(from: dateString) else { return "00:00" }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AttendanceScheduleTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AttendanceScheduleTransform.swift
@@ -30,6 +30,9 @@ extension TodayAttendance {
     
     public func toDomain() -> TodayAttendanceModel {
         return .init(status: self.status,
-                     attendedAt: self.attendedAt.setDateFormat(dateString: "HH:mm"))
+                     attendedAt: setDateFormat(
+                        date: self.attendedAt,
+                        from:  "yyyy-MM-dd'T'HH:mm:ss",
+                        to: "HH:mm"))
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
@@ -12,7 +12,7 @@ import Domain
 @_exported import PokeFeatureInterface
 
 public protocol DailySoptuneFeatureBuildable {
-    func makeDailySoptuneResultVC() -> DailySoptuneResultPresentable
+    func makeDailySoptuneResultVC(resultModel: DailySoptuneResultModel) -> DailySoptuneResultPresentable
     func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
     func makeDailySoptuneMainVC() -> DailySoptuneMainPresentable
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneMainPresentable.swift
@@ -8,10 +8,14 @@
 
 import BaseFeatureDependency
 import Core
+import Domain
 
 public protocol DailySoptuneMainViewControllable: ViewControllable {}
 
-public protocol DailySoptuneMainCoordinatable {}
+public protocol DailySoptuneMainCoordinatable {
+    var onNaviBackTap: (() -> Void)? { get set }
+    var onReciveTodayFortuneButtonTap: ((DailySoptuneResultModel) -> Void)? { get set }
+}
 
 public typealias DailySoptuneMainViewModelType = ViewModelType & DailySoptuneMainCoordinatable
 public typealias DailySoptuneMainPresentable = (vc: DailySoptuneMainViewControllable, vm: any DailySoptuneMainViewModelType)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
@@ -21,10 +21,12 @@ public final class DailySoptuneBuilder {
 
 extension DailySoptuneBuilder: DailySoptuneFeatureBuildable {
     
-    public func makeDailySoptuneResultVC() -> DailySoptuneFeatureInterface.DailySoptuneResultPresentable {
+    public func makeDailySoptuneResultVC(resultModel: DailySoptuneResultModel) -> DailySoptuneFeatureInterface.DailySoptuneResultPresentable {
         let useCase = DefaultDailySoptuneUseCase(repository: dailySoptuneRepository)
         let viewModel = DailySoptuneResultViewModel(useCase: useCase)
-        let dailySoptuneResultVC = DailySoptuneResultVC(viewModel: viewModel)
+        let dailySoptuneResultVC = DailySoptuneResultVC(
+            viewModel: viewModel,
+            resultModel: resultModel)
         return (dailySoptuneResultVC, viewModel)
     }
     

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -29,11 +29,28 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     }
     
     public override func start() {
-        showDailySoptuneResult()
+        showDailySoptuneMain()
     }
     
-    private func showDailySoptuneResult() {
-        var dailySoptuneResult = factory.makeDailySoptuneResultVC()
+    private func showDailySoptuneMain() {
+        var dailySoptuneMain = factory.makeDailySoptuneMainVC()
+        
+        dailySoptuneMain.vm.onNaviBackTap = {
+            self.router.popModule()
+            self.finishFlow?()
+        }
+        
+        dailySoptuneMain.vm.onReciveTodayFortuneButtonTap = { [weak self] result in
+            guard let self else { return }
+            let resultVC = self.factory.makeDailySoptuneResultVC(resultModel: result)
+            self.router.push(resultVC.vc)
+        }
+        
+        router.push(dailySoptuneMain.vc)
+    }
+    
+    private func showDailySoptuneResult(resultModel: DailySoptuneResultModel) {
+        var dailySoptuneResult = factory.makeDailySoptuneResultVC(resultModel: resultModel)
         
         dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
             guard let self else { return .empty() }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DeepLinks/DailySoptuneWordDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DeepLinks/DailySoptuneWordDeepLink.swift
@@ -1,0 +1,34 @@
+//
+//  DailySoptuneWordDeepLink.swift
+//  DailySoptuneFeatureDemo
+//
+//  Created by 강윤서 on 9/28/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import BaseFeatureDependency
+
+public struct DailySoptuneWordDeepLink: DeepLinkExecutable {
+    public var name = "word"
+    public var children: [DeepLinkExecutable] = []
+    public var isDestination = true
+    
+    public init() {}
+    
+    public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
+        guard let coordinator = coordinator as? DailySoptuneCoordinator else { return nil }
+        
+        coordinator.start()
+        
+        return nil
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DeepLinks/DailySoptuneWordDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DeepLinks/DailySoptuneWordDeepLink.swift
@@ -19,7 +19,9 @@ public struct DailySoptuneWordDeepLink: DeepLinkExecutable {
     public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
         guard let coordinator = coordinator as? DailySoptuneCoordinator else { return nil }
         
-        coordinator.start()
+        if self.isDestination == true {
+            coordinator.start()
+        }
         
         return nil
     }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
@@ -127,7 +127,7 @@ private extension DailySoptuneMainVC {
     func bindViewModels() {
         let input = DailySoptuneMainViewModel
             .Input(
-                viewDidLoad: viewDidLoaded,
+                viewDidLoad: viewDidLoaded.asDriver(),
                 naviBackButtonTap: backButtonTapped,
                 receiveTodayFortuneButtonTap: todayFortuneButtonTapped
             )

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
@@ -37,7 +37,7 @@ public final class DailySoptuneMainVC: UIViewController, DailySoptuneMainViewCon
 	private let dateLabel = UILabel().then {
 		$0.textColor = DSKitAsset.Colors.gray100.color
 		$0.font = DSKitFontFamily.Suit.medium.font(size: 16)
-		$0.text = "9월 17일 화요일"
+		$0.text = setDateFormat(to: "M월 d일 EEEE")
 	}
 	
 	private let recieveFortune = UILabel().then {

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
@@ -22,6 +22,7 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
     
     public var viewModel: DailySoptuneResultViewModel
     private var cancelBag = CancelBag()
+    private let resultModel: DailySoptuneResultModel
     
     private lazy var receiveTodaysFortuneButtonTap: Driver<Void> = receiveTodaysFortuneCardButton.publisher(for: .touchUpInside).mapVoid().asDriver()
     private let viewWillAppear = PassthroughSubject<Void, Never>()
@@ -51,7 +52,7 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
     
     // 오늘의 솝마디 부분
     
-    private lazy var dailySoptuneResultContentView = DailySoptuneResultContentView(name: "이재현", description: "단순하게 생각하면\n일이 술술 풀리겠솝!", date: viewModel.setCurrentDateString())
+    private lazy var dailySoptuneResultContentView = DailySoptuneResultContentView()
     
     // 콕 찌르기 부분
     
@@ -65,8 +66,9 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
     
     // MARK: - Initialization
     
-    public init(viewModel: DailySoptuneResultViewModel) {
+    public init(viewModel: DailySoptuneResultViewModel, resultModel: DailySoptuneResultModel) {
         self.viewModel = viewModel
+        self.resultModel = resultModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -95,6 +97,7 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
 extension DailySoptuneResultVC {
     private func setUI() {
         view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
+        dailySoptuneResultContentView.setData(model: resultModel)
     }
     
     private func setStackView() {
@@ -143,8 +146,8 @@ extension DailySoptuneResultVC {
 
 // MARK: - Methods
 
-extension DailySoptuneResultVC {
-    private func bindViewModels() {
+private extension DailySoptuneResultVC {
+    func bindViewModels() {
         let input = DailySoptuneResultViewModel
             .Input(
                 viewWillAppear: viewWillAppear.asDriver(),
@@ -164,3 +167,4 @@ extension DailySoptuneResultVC {
             }.store(in: self.cancelBag)
     }
 }
+

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
@@ -16,8 +16,8 @@ import DailySoptuneFeatureInterface
 
 public final class DailySoptuneMainViewModel: DailySoptuneMainViewModelType {
     
-    public var onNavibackTap: (() -> Void)?
-    public var onReciveTodayFortuneButtonTap: (() -> Void)?
+    public var onNaviBackTap: (() -> Void)?
+    public var onReciveTodayFortuneButtonTap: ((DailySoptuneResultModel) -> Void)?
 	
 	// MARK: - Properties
 
@@ -35,7 +35,6 @@ public final class DailySoptuneMainViewModel: DailySoptuneMainViewModelType {
 	// MARK: - Outputs
 	
 	public struct Output {
-        let todayFortuneResult = PassthroughSubject<DailySoptuneResultModel, Never>()
 	}
 	
 	// MARK: - Initialization
@@ -53,13 +52,12 @@ extension DailySoptuneMainViewModel {
         input.viewDidLoad
             .withUnretained(self)
             .sink {_ in
-                self.onNavibackTap?()
+                self.onNaviBackTap?()
             }.store(in: cancelBag)
         
         input.receiveTodayFortuneButtonTap
             .withUnretained(self)
             .sink { _ in
-                self.onReciveTodayFortuneButtonTap?()
                 self.useCase.getDailySoptuneResult(date: setDateFormat(to: "yyyy-MM-dd"))
             }.store(in: cancelBag)
         
@@ -68,8 +66,10 @@ extension DailySoptuneMainViewModel {
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.dailySoptuneResult
-            .asDriver()
-            .subscribe(output.todayFortuneResult)
+            .withUnretained(self)
+            .sink { _, resultModel in
+                self.onReciveTodayFortuneButtonTap?(resultModel)
+            }
             .store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
@@ -60,7 +60,7 @@ extension DailySoptuneMainViewModel {
             .withUnretained(self)
             .sink { _ in
                 self.onReciveTodayFortuneButtonTap?()
-                self.useCase.getDailySoptuneResult(date: "2024-09-19")
+                self.useCase.getDailySoptuneResult(date: setDateFormat(to: "yyyy-MM-dd"))
             }.store(in: cancelBag)
         
 		return output

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultContentView.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultContentView.swift
@@ -11,6 +11,7 @@ import Combine
 
 import DSKit
 import Core
+import Domain
 
 public final class DailySoptuneResultContentView: UIView {
     
@@ -28,18 +29,18 @@ public final class DailySoptuneResultContentView: UIView {
     private lazy var contentLabel = UILabel().then {
         $0.font = UIFont.MDS.title3.font
         $0.textColor = DSKitAsset.Colors.gray30.color
-        $0.numberOfLines = 3
+        $0.numberOfLines = 0
     }
     
     // MARK: - initialization
     
-    init(name: String, description: String, date: String) {
-        super.init(frame: .zero)
-        self.contentLabel.text = "\(name)님,\n\(description)"
-        self.dateLabel.text = date
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        
         self.setUI()
         self.setLayout()
     }
+    
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -70,24 +71,32 @@ extension DailySoptuneResultContentView {
         self.addSubviews(soptuneLogoImage, dateLabel, contentLabel)
         
         soptuneLogoImage.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(32)
+            make.top.equalToSuperview().inset(32.adjustedH)
             make.width.equalTo(Metric.soptuneLogoWidth)
             make.height.equalTo(Metric.soptuneLogoWidth * Metric.soptuneLogoRatio)
             make.centerX.equalToSuperview()
         }
         
         dateLabel.snp.makeConstraints { make in
-            make.top.equalTo(soptuneLogoImage.snp.bottom).offset(12)
+            make.top.equalTo(soptuneLogoImage.snp.bottom).offset(12.adjusted)
             make.centerX.equalToSuperview()
         }
         
         contentLabel.snp.makeConstraints { make in
-            make.top.equalTo(dateLabel.snp.bottom).offset(20)
+            make.top.equalTo(dateLabel.snp.bottom).offset(20.adjustedH)
             make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(76.adjusted)
         }
         
         self.snp.makeConstraints { make in
-            make.bottom.equalTo(contentLabel.snp.bottom).offset(34)
+            make.bottom.equalTo(contentLabel.snp.bottom).offset(34.adjustedH)
         }
+    }
+}
+
+extension DailySoptuneResultContentView {
+    public func setData(model: DailySoptuneResultModel) {
+        self.dateLabel.text = setDateFormat(to: "MM월 dd일 EEEE")
+        self.contentLabel.text = "\(model.userName)님,\n\(model.title)"
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -18,6 +18,7 @@ import NotificationFeature
 import StampFeature
 import PokeFeature
 import AttendanceFeature
+import DailySoptuneFeature
 
 public
 final class ApplicationCoordinator: BaseCoordinator {
@@ -341,6 +342,26 @@ extension ApplicationCoordinator {
         coordinator.finishFlow = { [weak self, weak coordinator] in
             self?.removeDependency(coordinator)
         }
+        addDependency(coordinator)
+        coordinator.start()
+        
+        return coordinator
+    }
+    
+    @discardableResult
+    internal func runDailySoptuneFlow() -> DailySoptuneCoordinator {
+        let coordinator = DailySoptuneCoordinator(
+            router: Router(
+                rootController: UIWindow.getRootNavigationController
+            ),
+            factory: DailySoptuneBuilder(), 
+            pokeFactory: PokeBuilder()
+        )
+        coordinator.finishFlow = { [weak self, weak coordinator] in
+            coordinator?.childCoordinators = []
+            self?.removeDependency(coordinator)
+        }
+        
         addDependency(coordinator)
         coordinator.start()
         

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -22,7 +22,6 @@ import AttendanceFeature
 public
 final class ApplicationCoordinator: BaseCoordinator {
     
-    //  private let coordinatorFactory: CoordinatorFactory
     private let router: Router
     private var cancelBag = CancelBag()
     private let notificationHandler: NotificationHandler

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/DailySoptuneDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/DailySoptuneDeepLink.swift
@@ -18,6 +18,10 @@ public struct DailySoptuneDeepLink: DeepLinkExecutable {
     public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
         guard let coordinator = coordinator as? DailySoptuneCoordinator else { return nil }
         
+        if self.isDestination == true {
+            coordinator.start()
+        }
+        
         return nil
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/DailySoptuneDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/DailySoptuneDeepLink.swift
@@ -1,0 +1,23 @@
+//
+//  DailySoptuneDeepLink.swift
+//  RootFeature
+//
+//  Created by 강윤서 on 9/28/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import BaseFeatureDependency
+import DailySoptuneFeature
+
+public struct DailySoptuneDeepLink: DeepLinkExecutable {
+    public var name = "fortune"
+    public var children: [DeepLinkExecutable] = [DailySoptuneWordDeepLink()]
+    public var isDestination = false
+    
+    public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
+        guard let coordinator = coordinator as? DailySoptuneCoordinator else { return nil }
+        
+        return nil
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#391

## 🌱 PR Point
- 솝마디 메인뷰 -> 결과뷰 화면 전환
- 알림 상세 -> 솝마디 메인뷰 딥링크 바인딩
- 푸시알림 -> 솝마디 메인뷰 딥링크 바인딩
- 기존 dateFormat 메소드 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### setDateFormat 메소드 수정
- 수정 전: String 타입을 확장하여 서버에서 내려준 dateString을 원하는 포맷으로 변경하는 메소드
- 수정 후: String 타입 확장을 없애고 바꾸고자 하는 `dateString`, `기존 포맷`, `변경 포맷`을 인자로 받음.
바꾸고자 하는 dateString이 없는 경우 오늘 날짜를 사용함.
- #389 에서 setDateFormat을 수정하면 DailySoptuneResultViewModel도 수정해주신다고 했는데 데이터 바인딩 과정에서 필요해 제가 수정해두었습니다 ! 
- 기존 방식보다 함수가 지저분해진 것 같기도 해서,, 의견 부탁드립니다 ! 

### 데이터 바인딩
- DailySoptuneMainViewModel에서 usecase output을 클로저에 전달
- 전달된 output을 vc 생성자 주입
- vc 내부의 view에서 setData로 데이터 바인딩

### 딥링크
- 아직 서버에서 딥링크가 수정되지 않아 확인해보지 못했습니다,, (테스트 코드의 필요성을 한 번 더 느낌,,)
- #298 딥링크 설계 과정은 해당 PR을 참고해주세요 !
- 현재 딥링크는 fortune/word로 되어있어 설계 규칙에 따라 home/fortune로 수정 제안을 해둔 상태입니다.
- 푸시 알림 클릭 시, 알림 상세 클릭 시 모두 home/fortune을 파싱하여 `DailySoptuneDeepLink`에서 dailySoptuneCoordinator.start()를 실행하게 됩니다.

## 📸 스크린샷
- 토큰 재발급 이슈로 서버측에 확인 요청 드렸습니다 . .. ! 확인 후 첨부하겠습니다 !_!

## 📮 관련 이슈
- Resolved: #391
