### PR TITLE
[Feat] #392 - 솝마디 결과 뷰, 부적 화면 전환 및 데이터 바인딩

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UIColor+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UIColor+.swift
@@ -24,4 +24,18 @@ public extension UIColor {
            blue: rgb & 0xFF
        )
    }
+
+    convenience init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        
+        let r = CGFloat((rgb >> 16) & 0xFF) / 255.0
+        let g = CGFloat((rgb >> 8) & 0xFF) / 255.0
+        let b = CGFloat((rgb >> 0) & 0xFF) / 255.0
+        
+        self.init(red: r, green: g, blue: b, alpha: 1.0)
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/DailySoptuneCardTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/DailySoptuneCardTransform.swift
@@ -13,6 +13,6 @@ import Networks
 
 extension FortuneCardEntity {
     public func toDomain() -> DailySoptuneCardModel {
-        return DailySoptuneCardModel(name: name, description: description, imageURL: imageURL)
+        return DailySoptuneCardModel(name: name, description: description, imageURL: imageURL, imageColorCode: imageColorCode)
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/DailySoptuneCardModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/DailySoptuneCardModel.swift
@@ -12,10 +12,12 @@ public struct DailySoptuneCardModel: Codable {
     public let name: String
     public let description: String
     public let imageURL: String
+    public let imageColorCode: String
 
-    public init(name: String, description: String, imageURL: String) {
+    public init(name: String, description: String, imageURL: String, imageColorCode: String) {
         self.name = name
         self.description = description
         self.imageURL = imageURL
+        self.imageColorCode = imageColorCode
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
@@ -9,4 +9,12 @@
 import BaseFeatureDependency
 import Core
 
-public protocol DailySoptuneCardPresentable: ViewControllable { }
+public protocol DailySoptuneCardViewControllable: ViewControllable { }
+
+public protocol DailySoptuneCardCoordinatable {
+    var onGoToHomeButtonTapped: (() -> Void)? { get set }
+    var onBackButtonTapped: (() -> Void)? { get set }
+}
+
+public typealias DailySoptuneCardViewModelType = ViewModelType & DailySoptuneCardCoordinatable
+public typealias DailySoptuneCardPresentable = (vc: DailySoptuneCardViewControllable, vm: any DailySoptuneCardViewModelType)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
@@ -1,0 +1,12 @@
+//
+//  DailySoptuneCardPresentable.swift
+//  DailySoptuneFeatureInterface
+//
+//  Created by Jae Hyun Lee on 9/28/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import BaseFeatureDependency
+import Core
+
+public protocol DailySoptuneCardPresentable: ViewControllable { }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
@@ -14,4 +14,5 @@ import Domain
 public protocol DailySoptuneFeatureBuildable {
     func makeDailySoptuneResultVC() -> DailySoptuneResultPresentable
     func makeDailySoptuneMainVC() -> DailySoptuneMainPresentable
+    func makeDailySoptuneCardVC(cardModel: DailySoptuneCardModel) -> DailySoptuneCardPresentable
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
@@ -13,6 +13,5 @@ import Domain
 
 public protocol DailySoptuneFeatureBuildable {
     func makeDailySoptuneResultVC() -> DailySoptuneResultPresentable
-    func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
     func makeDailySoptuneMainVC() -> DailySoptuneMainPresentable
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneFeatureBuildable.swift
@@ -13,7 +13,6 @@ import Domain
 
 public protocol DailySoptuneFeatureBuildable {
     func makeDailySoptuneResultVC(resultModel: DailySoptuneResultModel) -> DailySoptuneResultPresentable
-    func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
     func makeDailySoptuneMainVC() -> DailySoptuneMainPresentable
     func makeDailySoptuneCardVC(cardModel: DailySoptuneCardModel) -> DailySoptuneCardPresentable
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
@@ -13,7 +13,7 @@ import Domain
 public protocol DailySoptuneResultViewControllable: ViewControllable { }
 
 public protocol DailySoptuneResultCoordinatable {
-    var onNaviBackButtonTap: (() -> Void)? { get set }
+    var onNaviBackButtonTapped: (() -> Void)? { get set }
     var onKokButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onReceiveTodaysFortuneCardButtonTapped: ((DailySoptuneCardModel) -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
@@ -14,6 +14,7 @@ public protocol DailySoptuneResultViewControllable: ViewControllable { }
 
 public protocol DailySoptuneResultCoordinatable {
     var onKokButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
+    var onReceiveTodaysFortuneCardButtonTapped: ((DailySoptuneCardModel) -> Void)? { get set }
 }
 
 public typealias DailySoptuneResultViewModelType = ViewModelType & DailySoptuneResultCoordinatable

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
@@ -13,6 +13,7 @@ import Domain
 public protocol DailySoptuneResultViewControllable: ViewControllable { }
 
 public protocol DailySoptuneResultCoordinatable {
+    var onNaviBackButtonTap: (() -> Void)? { get set }
     var onKokButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onReceiveTodaysFortuneCardButtonTapped: ((DailySoptuneCardModel) -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
@@ -9,7 +9,6 @@
 import Core
 import Domain
 @_exported import DailySoptuneFeatureInterface
-import PokeFeatureInterface
 
 public final class DailySoptuneBuilder {
     @Injected public var dailySoptuneRepository: DailySoptuneRepositoryInterface
@@ -35,8 +34,10 @@ extension DailySoptuneBuilder: DailySoptuneFeatureBuildable {
 	}
     
     public func makeDailySoptuneCardVC(cardModel: DailySoptuneCardModel) -> DailySoptuneCardPresentable {
-        let dailySoptuneCardVC = DailySoptuneCardVC(cardModel: cardModel)
-        return dailySoptuneCardVC
+        let useCase = DefaultDailySoptuneUseCase(repository: dailySoptuneRepository)
+        let viewModel = DailySoptuneCardViewModel(useCase: useCase)
+        let dailySoptuneCardVC = DailySoptuneCardVC(cardModel: cardModel, viewModel: viewModel)
+        return (dailySoptuneCardVC, viewModel)
     }
     
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
@@ -9,7 +9,6 @@
 import Core
 import Domain
 @_exported import DailySoptuneFeatureInterface
-import PokeFeature
 import PokeFeatureInterface
 
 public final class DailySoptuneBuilder {
@@ -26,13 +25,6 @@ extension DailySoptuneBuilder: DailySoptuneFeatureBuildable {
         let viewModel = DailySoptuneResultViewModel(useCase: useCase)
         let dailySoptuneResultVC = DailySoptuneResultVC(viewModel: viewModel)
         return (dailySoptuneResultVC, viewModel)
-    }
-    
-    public func makePokeMessageTemplateBottomSheet(messageType: Domain.PokeMessageType) -> PokeFeatureInterface.PokeMessageTemplatesPresentable {
-        let useCase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: useCase)
-        let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
-        return (viewController, viewModel)
     }
 	
 	public func makeDailySoptuneMainVC() -> DailySoptuneMainPresentable {

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneBuilder.swift
@@ -33,4 +33,10 @@ extension DailySoptuneBuilder: DailySoptuneFeatureBuildable {
 		let dailySoptuneMainVC = DailySoptuneMainVC(viewModel: viewModel)
 		return (dailySoptuneMainVC, viewModel)
 	}
+    
+    public func makeDailySoptuneCardVC(cardModel: DailySoptuneCardModel) -> DailySoptuneCardPresentable {
+        let dailySoptuneCardVC = DailySoptuneCardVC(cardModel: cardModel)
+        return dailySoptuneCardVC
+    }
+    
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
@@ -40,8 +40,9 @@ public final class DailySoptuneCardCoordinator: DefaultCoordinator {
         var dailySoptuneCard = factory.makeDailySoptuneCardVC(cardModel: cardModel)
         
         dailySoptuneCard.vm.onBackButtonTapped = { [weak self] in
-            self?.router.dismissModule(animated: true)
-            self?.finishFlow?()
+            guard let self = self else { return }
+            self.router.dismissModule(animated: true)
+            self.finishFlow?()
         }
         
         dailySoptuneCard.vm.onGoToHomeButtonTapped = { [weak self] in

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
@@ -16,6 +16,7 @@ import Domain
 
 public final class DailySoptuneCardCoordinator: DefaultCoordinator {
     
+    public var requestCoordinating: (() -> Void)?
     public var finishFlow: (() -> Void)?
         
     private let factory: DailySoptuneFeatureBuildable
@@ -41,6 +42,10 @@ public final class DailySoptuneCardCoordinator: DefaultCoordinator {
         dailySoptuneCard.vm.onBackButtonTapped = { [weak self] in
             self?.router.dismissModule(animated: true)
             self?.finishFlow?()
+        }
+        
+        dailySoptuneCard.vm.onGoToHomeButtonTapped = { [weak self] in
+            self?.requestCoordinating?()
         }
         
         self.rootController = dailySoptuneCard.vc.asNavigationController

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
@@ -1,0 +1,49 @@
+//
+//  DailySoptuneCardCoordinator.swift
+//  DailySoptuneFeature
+//
+//  Created by Jae Hyun Lee on 9/28/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import BaseFeatureDependency
+import DailySoptuneFeatureInterface
+import Domain
+
+public final class DailySoptuneCardCoordinator: DefaultCoordinator {
+    
+    public var finishFlow: (() -> Void)?
+        
+    private let factory: DailySoptuneFeatureBuildable
+    private let router: Router
+    
+    private let cardModel: DailySoptuneCardModel
+
+    private weak var rootController: UINavigationController?
+    
+    public init(router: Router, factory: DailySoptuneFeatureBuildable, cardModel: DailySoptuneCardModel) {
+        self.router = router
+        self.factory = factory
+        self.cardModel = cardModel
+    }
+    
+    public override func start() {
+        showDailySoptuneCard()
+    }
+    
+    private func showDailySoptuneCard() {
+        var dailySoptuneCard = factory.makeDailySoptuneCardVC(cardModel: cardModel)
+        
+        dailySoptuneCard.vm.onBackButtonTapped = { [weak self] in
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
+        }
+        
+        self.rootController = dailySoptuneCard.vc.asNavigationController
+        self.router.present(self.rootController, animated: true, modalPresentationSytle: .overFullScreen)
+    }
+}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -1,0 +1,83 @@
+//
+//  DailySoptuneCoordinator.swift
+//  DailySoptuneFeature
+//
+//  Created by Jae Hyun Lee on 9/21/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import BaseFeatureDependency
+import DailySoptuneFeatureInterface
+import Domain
+import PokeFeatureInterface
+
+public final class DailySoptuneCoordinator: DefaultCoordinator {
+    public var finishFlow: (() -> Void)?
+    
+    private let factory: DailySoptuneFeatureBuildable
+    private let pokeFactory: PokeFeatureBuildable
+    private let router: Router
+    
+    public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable) {
+        self.router = router
+        self.factory = factory
+        self.pokeFactory = pokeFactory
+    }
+    
+    public override func start() {
+        showDailySoptuneMain()
+    }
+    
+    private func showDailySoptuneMain() {
+        var dailySoptuneMain = factory.makeDailySoptuneMainVC()
+        
+        dailySoptuneMain.vm.onNaviBackTap = {
+            self.router.popModule()
+            self.finishFlow?()
+        }
+        
+        dailySoptuneMain.vm.onReciveTodayFortuneButtonTap = { [weak self] result in
+            guard let self else { return }
+            let resultVC = self.factory.makeDailySoptuneResultVC(resultModel: result)
+            self.router.push(resultVC.vc)
+        }
+        
+        router.push(dailySoptuneMain.vc)
+    }
+    
+    private func showDailySoptuneResult(resultModel: DailySoptuneResultModel) {
+        var dailySoptuneResult = factory.makeDailySoptuneResultVC(resultModel: resultModel)
+        
+        dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
+            guard let self else { return .empty() }
+            return self.showMessageBottomSheet(userModel: userModel, on: dailySoptuneResult.vc.viewController)
+        }
+        
+        router.push(dailySoptuneResult.vc)
+    }
+    
+    private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
+        let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
+        
+        guard let bottomSheet = self.pokeFactory
+            .makePokeMessageTemplateBottomSheet(messageType: messageType)
+            .vc
+            .viewController as? PokeMessageTemplatesViewControllable
+        else { return .empty() }
+        
+        let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: bottomSheet.minimumContentHeight))
+        
+        self.router.showBottomSheet(manager: bottomSheetManager,
+                                    toPresent: bottomSheet.viewController,
+                                    on: view)
+        
+        return bottomSheet
+            .signalForClick()
+            .map { (userModel, $0, $1)}
+            .asDriver()
+    }
+}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -35,6 +35,11 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     private func showDailySoptuneResult() {
         var dailySoptuneResult = factory.makeDailySoptuneResultVC()
         
+        dailySoptuneResult.vm.onNaviBackButtonTap = { [weak self] in
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
+        }
+        
         dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
             guard let self else { return .empty() }
             return self.showMessageBottomSheet(userModel: userModel, on: dailySoptuneResult.vc.viewController)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -40,9 +40,16 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
             return self.showMessageBottomSheet(userModel: userModel, on: dailySoptuneResult.vc.viewController)
         }
         
+        dailySoptuneResult.vm.onReceiveTodaysFortuneCardButtonTapped = { [weak self] cardModel in
+            guard let self else { return }
+            let dailySoptuneCardVC = self.factory.makeDailySoptuneCardVC(cardModel: cardModel).viewController
+            dailySoptuneCardVC.modalPresentationStyle = .overFullScreen
+            dailySoptuneResult.vc.viewController.present(dailySoptuneCardVC, animated: false)
+        }
+        
         router.push(dailySoptuneResult.vc)
     }
-    
+        
     private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
         let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
         

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  DailySoptuneCoordinator.swift
+//  DailySoptuneResultCoordinator.swift
 //  DailySoptuneFeature
 //
 //  Created by Jae Hyun Lee on 9/21/24.
@@ -15,7 +15,7 @@ import DailySoptuneFeatureInterface
 import Domain
 import PokeFeatureInterface
 
-public final class DailySoptuneCoordinator: DefaultCoordinator {
+public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: DailySoptuneFeatureBuildable

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -22,34 +22,19 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     
     private let factory: DailySoptuneFeatureBuildable
     private let pokeFactory: PokeFeatureBuildable
+    private let resultModel: DailySoptuneResultModel
     private let router: Router
     private weak var rootController: UINavigationController?
 
-    public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable) {
+    public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
         self.router = router
         self.factory = factory
         self.pokeFactory = pokeFactory
+        self.resultModel = resultModel
     }
     
     public override func start() {
-        showDailySoptuneMain()
-    }
-    
-    private func showDailySoptuneMain() {
-        var dailySoptuneMain = factory.makeDailySoptuneMainVC()
-        
-        dailySoptuneMain.vm.onNaviBackTap = {
-            self.router.popModule()
-            self.finishFlow?()
-        }
-        
-        dailySoptuneMain.vm.onReciveTodayFortuneButtonTap = { [weak self] result in
-            guard let self else { return }
-            let resultVC = self.factory.makeDailySoptuneResultVC(resultModel: result)
-            self.router.push(resultVC.vc)
-        }
-        
-        router.push(dailySoptuneMain.vc)
+        showDailySoptuneResult(resultModel: resultModel)
     }
     
     private func showDailySoptuneResult(resultModel: DailySoptuneResultModel) {
@@ -71,7 +56,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         }
         
         rootController = dailySoptuneResult.vc.asNavigationController
-        router.present(rootController, animated: false, modalPresentationSytle: .overFullScreen)
+        router.present(rootController, animated: true, modalPresentationSytle: .overFullScreen)
     }
     
     internal func runDailySoptuneCardFlow(cardModel: DailySoptuneCardModel) {

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -16,6 +16,8 @@ import Domain
 import PokeFeatureInterface
 
 public final class DailySoptuneResultCoordinator: DefaultCoordinator {
+    
+    public var requestCoordinating: (() -> Void)?
     public var finishFlow: (() -> Void)?
     
     private let factory: DailySoptuneFeatureBuildable
@@ -66,6 +68,10 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         dailySoptuneCardCoordinator.finishFlow = { [weak self, weak dailySoptuneCardCoordinator] in
             dailySoptuneCardCoordinator?.childCoordinators = []
             self?.removeDependency(dailySoptuneCardCoordinator)
+        }
+        
+        dailySoptuneCardCoordinator.requestCoordinating = { [weak self] in
+            self?.requestCoordinating?()
         }
         
         addDependency(dailySoptuneCardCoordinator)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 import Core
 import DSKit
@@ -14,11 +15,13 @@ import Domain
 
 import BaseFeatureDependency
 
-public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardPresentable {
+public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardViewControllable {
     
     // MARK: - Properties
 
+    public var viewModel: DailySoptuneCardViewModel
     private let cardModel: DailySoptuneCardModel
+    private var cancelBag = CancelBag()
 
 	// MARK: - UI Components
 	
@@ -44,8 +47,9 @@ public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardPresent
     
     // MARK: - initialization
     
-    init(cardModel: DailySoptuneCardModel) {
+    init(cardModel: DailySoptuneCardModel, viewModel: DailySoptuneCardViewModel) {
         self.cardModel = cardModel
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -60,6 +64,7 @@ public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardPresent
 		setUI()
 		setLayout()
         setData()
+        bindViewModels()
 	}
 }
 
@@ -113,5 +118,14 @@ private extension DailySoptuneCardVC {
         self.cardLabel.text = "\(cardModel.name)이 왔솝"
         self.cardLabel.partColorChange(targetString: "\(cardModel.name)", textColor: UIColor(hex: "\(cardModel.imageColorCode)"))
         self.cardImage.setImage(with: cardModel.imageURL)
+    }
+    
+    private func bindViewModels() {
+        let input = DailySoptuneCardViewModel.Input(
+            goToHomeButtonTap: self.goToHomeButton.publisher(for: .touchUpInside).mapVoid().asDriver(),
+            backButtonTap: self.backButton.publisher(for: .touchUpInside).mapVoid().asDriver()
+        )
+        
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
@@ -21,7 +21,7 @@ public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardViewCon
 
     public var viewModel: DailySoptuneCardViewModel
     private let cardModel: DailySoptuneCardModel
-    private var cancelBag = CancelBag()
+    private let cancelBag = CancelBag()
 
 	// MARK: - UI Components
 	

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
@@ -10,8 +10,15 @@ import UIKit
 
 import Core
 import DSKit
+import Domain
 
-public final class DailySoptuneCardVC: UIViewController {
+import BaseFeatureDependency
+
+public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardPresentable {
+    
+    // MARK: - Properties
+
+    private let cardModel: DailySoptuneCardModel
 
 	// MARK: - UI Components
 	
@@ -22,11 +29,9 @@ public final class DailySoptuneCardVC: UIViewController {
 	private let subCardLabel = UILabel().then {
 		$0.textColor = DSKitAsset.Colors.gray300.color
 		$0.font = DSKitFontFamily.Suit.semiBold.font(size: 16)
-		$0.text = "어려움을 전부 극복할"
 	}
 	
 	private let cardLabel = UILabel().then {
-		$0.text = "OO부적이 왔솝"
 		$0.textColor = DSKitAsset.Colors.white100.color
 		$0.font = DSKitFontFamily.Suit.bold.font(size: 28)
 	}
@@ -36,12 +41,25 @@ public final class DailySoptuneCardVC: UIViewController {
 	}
 	
 	private let goToHomeButton = AppOutlinedButton(title: I18N.DailySoptune.goHome)
+    
+    // MARK: - initialization
+    
+    init(cardModel: DailySoptuneCardModel) {
+        self.cardModel = cardModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Life Cycle
 	
 	public override func viewDidLoad() {
 		super.viewDidLoad()
-		
 		setUI()
 		setLayout()
+        setData()
 	}
 }
 
@@ -85,4 +103,15 @@ private extension DailySoptuneCardVC {
 			make.bottom.equalTo(goToHomeButton.snp.top).offset(-36.adjustedH)
 		}
 	}
+}
+
+// MARK: - Methods
+
+private extension DailySoptuneCardVC {
+    func setData() {
+        self.subCardLabel.text = cardModel.description
+        self.cardLabel.text = "\(cardModel.name)이 왔솝"
+        self.cardLabel.partColorChange(targetString: "\(cardModel.name)", textColor: UIColor(hex: "\(cardModel.imageColorCode)"))
+        self.cardImage.setImage(with: cardModel.imageURL)
+    }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneCardViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneCardViewModel.swift
@@ -1,0 +1,67 @@
+//
+//  DailySoptuneCardViewModel.swift
+//  DailySoptuneFeature
+//
+//  Created by Jae Hyun Lee on 9/28/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Core
+import Domain
+
+import DailySoptuneFeatureInterface
+
+public final class DailySoptuneCardViewModel: DailySoptuneCardViewModelType {
+    
+    public var onGoToHomeButtonTapped: (() -> Void)?
+    public var onBackButtonTapped: (() -> Void)?
+
+    // MARK: - Properties
+    
+    private let useCase: DailySoptuneUseCase
+    private var cancelBag = CancelBag()
+    
+    // MARK: - Inputs
+    
+    public struct Input {
+        let goToHomeButtonTap: Driver<Void>
+        let backButtonTap: Driver<Void>
+    }
+    
+    // MARK: - Outpust
+    
+    public struct Output {
+        
+    }
+    
+    // MARK: - initialization
+    
+    public init(useCase: DailySoptuneUseCase) {
+        self.useCase = useCase
+    }
+}
+
+extension DailySoptuneCardViewModel {
+    
+    public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        
+        input.goToHomeButtonTap
+            .withUnretained(self)
+            .sink { _ in
+                self.onGoToHomeButtonTapped?()
+            }.store(in: cancelBag)
+        
+        input.backButtonTap
+            .withUnretained(self)
+            .sink { _ in
+                self.onBackButtonTapped?()
+            }.store(in: cancelBag)
+        
+        return output
+    }
+    
+}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneCardViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneCardViewModel.swift
@@ -50,15 +50,13 @@ extension DailySoptuneCardViewModel {
         let output = Output()
         
         input.goToHomeButtonTap
-            .withUnretained(self)
-            .sink { _ in
-                self.onGoToHomeButtonTapped?()
+            .sink { [weak self] _ in
+                self?.onGoToHomeButtonTapped?()
             }.store(in: cancelBag)
         
         input.backButtonTap
-            .withUnretained(self)
-            .sink { _ in
-                self.onBackButtonTapped?()
+            .sink { [weak self] _ in
+                self?.onBackButtonTapped?()
             }.store(in: cancelBag)
         
         return output

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneMainViewModel.swift
@@ -50,15 +50,13 @@ extension DailySoptuneMainViewModel {
         self.bindOutput(output: output, cancelBag: cancelBag)
         
         input.viewDidLoad
-            .withUnretained(self)
-            .sink {_ in
-                self.onNaviBackTap?()
+            .sink { [weak self] _ in
+                self?.onNaviBackTap?()
             }.store(in: cancelBag)
         
         input.receiveTodayFortuneButtonTap
-            .withUnretained(self)
-            .sink { _ in
-                self.useCase.getDailySoptuneResult(date: setDateFormat(to: "yyyy-MM-dd"))
+            .sink { [weak self] _ in
+                self?.useCase.getDailySoptuneResult(date: setDateFormat(to: "yyyy-MM-dd"))
             }.store(in: cancelBag)
         
 		return output
@@ -66,9 +64,8 @@ extension DailySoptuneMainViewModel {
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.dailySoptuneResult
-            .withUnretained(self)
-            .sink { _, resultModel in
-                self.onReciveTodayFortuneButtonTap?(resultModel)
+            .sink { [weak self] resultModel in
+                self?.onReciveTodayFortuneButtonTap?(resultModel)
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -15,9 +15,9 @@ import Domain
 import DailySoptuneFeatureInterface
 
 public class DailySoptuneResultViewModel: DailySoptuneResultViewModelType {
-
-    public var onNaviBackTap: (() -> Void)?
-    public var onReceiveTodaysFortuneCardTap: ((DailySoptuneCardModel) -> Void)?
+    
+    public var onNaviBackButtonTap: (() -> Void)?
+        public var onReceiveTodaysFortuneCardTap: ((DailySoptuneCardModel) -> Void)?
     public var onKokButtonTapped: ((Domain.PokeUserModel) -> Core.Driver<(Domain.PokeUserModel, Domain.PokeMessageModel, isAnonymous: Bool)>)?
     public var onReceiveTodaysFortuneCardButtonTapped: ((Domain.DailySoptuneCardModel) -> Void)?
     
@@ -59,8 +59,14 @@ extension DailySoptuneResultViewModel {
         input.viewWillAppear
             .withUnretained(self)
             .sink {  _ in
-                self.onNaviBackTap?()
+                self.onNaviBackButtonTap?()
                 self.useCase.getRandomUser()
+            }.store(in: cancelBag)
+        
+        input.naviBackButtonTap
+            .withUnretained(self)
+            .sink { _ in
+                self.onNaviBackButtonTap?()
             }.store(in: cancelBag)
         
         input.receiveTodaysFortuneCardTap

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -38,7 +38,7 @@ public final class DailySoptuneResultViewModel: DailySoptuneResultViewModelType 
     // MARK: - Outputs
     
     public struct Output {
-        let todaysFortuneCard = PassthroughSubject<DailySoptuneCardModel, Never>()
+//        let todaysFortuneCard = PassthroughSubject<DailySoptuneCardModel, Never>()
         let randomUser = PassthroughSubject<PokeRandomUserInfoModel, Never>()
         let messageTemplates = PassthroughSubject<PokeMessagesModel, Never>()
         let pokeResponse = PassthroughSubject<PokeUserModel, Never>()
@@ -57,21 +57,18 @@ extension DailySoptuneResultViewModel {
         self.bindOutput(output: output, cancelBag: cancelBag)
         
         input.viewWillAppear
-            .withUnretained(self)
-            .sink {  _ in
-                self.useCase.getRandomUser()
+            .sink { [weak self] _ in
+                self?.useCase.getRandomUser()
             }.store(in: cancelBag)
         
         input.naviBackButtonTap
-            .withUnretained(self)
-            .sink { _ in
-                self.onNaviBackButtonTapped?()
+            .sink { [weak self] _ in
+                self?.onNaviBackButtonTapped?()
             }.store(in: cancelBag)
         
         input.receiveTodaysFortuneCardTap
-            .withUnretained(self)
-            .sink { _ in
-                self.useCase.getTodaysFortuneCard()
+            .sink { [weak self] _ in
+                self?.useCase.getTodaysFortuneCard()
             }.store(in: cancelBag)
         
         input.kokButtonTap
@@ -89,13 +86,10 @@ extension DailySoptuneResultViewModel {
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.todaysFortuneCard
-            .withUnretained(self)
-            .sink { _, cardModel in
-                self.onReceiveTodaysFortuneCardButtonTapped?(cardModel)
-                output.todaysFortuneCard.send(cardModel)
+            .sink { [weak self] cardModel in
+                self?.onReceiveTodaysFortuneCardButtonTapped?(cardModel)
             }
             .store(in: cancelBag)
-        
         useCase.randomUser
             .asDriver()
             .sink(receiveValue: { values in

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -14,10 +14,10 @@ import Domain
 
 import DailySoptuneFeatureInterface
 
-public class DailySoptuneResultViewModel: DailySoptuneResultViewModelType {
+public final class DailySoptuneResultViewModel: DailySoptuneResultViewModelType {
     
-    public var onNaviBackButtonTap: (() -> Void)?
-        public var onReceiveTodaysFortuneCardTap: ((DailySoptuneCardModel) -> Void)?
+    public var onNaviBackButtonTapped: (() -> Void)?
+    public var onReceiveTodaysFortuneCardTap: ((DailySoptuneCardModel) -> Void)?
     public var onKokButtonTapped: ((Domain.PokeUserModel) -> Core.Driver<(Domain.PokeUserModel, Domain.PokeMessageModel, isAnonymous: Bool)>)?
     public var onReceiveTodaysFortuneCardButtonTapped: ((Domain.DailySoptuneCardModel) -> Void)?
     
@@ -65,7 +65,7 @@ extension DailySoptuneResultViewModel {
         input.naviBackButtonTap
             .withUnretained(self)
             .sink { _ in
-                self.onNaviBackButtonTap?()
+                self.onNaviBackButtonTapped?()
             }.store(in: cancelBag)
         
         input.receiveTodaysFortuneCardTap

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -59,7 +59,6 @@ extension DailySoptuneResultViewModel {
         input.viewWillAppear
             .withUnretained(self)
             .sink {  _ in
-                self.onNaviBackButtonTap?()
                 self.useCase.getRandomUser()
             }.store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
@@ -41,11 +41,12 @@ public final class DailySoptuneResultPokeView: UIView {
     
     private let profileImageView = UIImageView().then {
         $0.layer.cornerRadius = 36
-        $0.backgroundColor = DSKitAsset.Colors.white.color
+        $0.backgroundColor = DSKitAsset.Colors.gray700.color
         $0.clipsToBounds = true
         $0.contentMode = .scaleAspectFill
         $0.layer.borderColor = DSKitAsset.Colors.success.color.cgColor
         $0.layer.borderWidth = 2
+        $0.image = DSKitAsset.Assets.iconDefaultProfile.image
     }
     
     private let nameLabel = UILabel().then {
@@ -149,7 +150,7 @@ extension DailySoptuneResultPokeView {
         self.user = model
         self.nameLabel.text = model.name
         self.partLabel.text = "\(model.generation)기 \(model.part)"
-        self.profileImageView.setImage(with: model.isAnonymous ? model.anonymousImage : model.profileImage)
+        self.profileImageView.setImage(with: model.profileImage, placeholder: DSKitAsset.Assets.iconDefaultProfile.image)
     }
     
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -18,6 +18,7 @@ import NotificationFeature
 import StampFeature
 import PokeFeature
 import AttendanceFeature
+import DailySoptuneFeature
 
 public
 final class ApplicationCoordinator: BaseCoordinator {
@@ -342,6 +343,31 @@ extension ApplicationCoordinator {
         coordinator.finishFlow = { [weak self, weak coordinator] in
             self?.removeDependency(coordinator)
         }
+        addDependency(coordinator)
+        coordinator.start()
+        
+        return coordinator
+    }
+    
+    @discardableResult
+    internal func runDailySoptuneResultFlow() -> DailySoptuneResultCoordinator {
+        let coordinator = DailySoptuneResultCoordinator(
+            router: router,
+            factory: DailySoptuneBuilder(),
+            pokeFactory: PokeBuilder()
+        )
+        
+        coordinator.finishFlow = { [weak self, weak coordinator] in
+            coordinator?.childCoordinators = []
+            self?.removeDependency(coordinator)
+        }
+        
+        coordinator.requestCoordinating = { [weak self] in
+            self?.notificationHandler.receive(deepLink: "home")
+            guard let deepLinkComponent = self?.notificationHandler.deepLink.value else { return }
+            self?.handleDeepLink(deepLink: deepLinkComponent)
+        }
+        
         addDependency(coordinator)
         coordinator.start()
         

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/FortuneCardEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/FortuneCardEntity.swift
@@ -11,11 +11,11 @@ import Foundation
 // MARK: - Entity
 
 public struct FortuneCardEntity: Codable {
-    public let name, description: String
+    public let name, description, imageColorCode: String
     public let imageURL: String
 
     enum CodingKeys: String, CodingKey {
-        case name, description
+        case name, description, imageColorCode
         case imageURL = "imageUrl"
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -173,7 +173,8 @@ extension AppDelegate {
             interface: DailySoptuneRepositoryInterface.self,
             implement: {
                 DailySoptuneRepository(
-                    fortuneService: DefaultFortuneService()
+                    fortuneService: DefaultFortuneService(), 
+                    pokeService: DefaultPokeService()
                 )
             }
         )


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #392 

## 🌱 PR Point
- 솝마디 결과 뷰 -> 부적 화면 -> 홈 화면 전환을 구현했습니다.
- 홈 화면 전환은 딥링크로 구현했습니다. 
- 부적 화면 데이터 바인딩을 진행했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- 기존에는 `PokeFeature`의 **BottomSheet**을 `DailySoptuneFeature` 모듈에서 사용하면서, `DailySoptuneBuilder`에 `PokeFeature`를 import해 직접 생성하고 있었습니다. 따라서 모듈 간의 강한 결합이 이루어졌던 부분을 제거하고, `ApplicationCoordinator`에서 PokeBuilder()를 주입하여 인터페이스를 통해 `PokeBuilder`에서 **BottomSheet**를 생성하도록 수정했습니다. (이 부분에 대해 잘못된 부분이 있다면 리뷰 부탁드립니다..!) 
```swift
@discardableResult
    internal func runDailySoptuneResultFlow() -> DailySoptuneResultCoordinator {
        let coordinator = DailySoptuneResultCoordinator(
            router: router,
            factory: DailySoptuneBuilder(),
            pokeFactory: PokeBuilder()
        )
        
        coordinator.finishFlow = { [weak self, weak coordinator] in
            coordinator?.childCoordinators = []
            self?.removeDependency(coordinator)
        }
        
        coordinator.requestCoordinating = { [weak self] in
            self?.notificationHandler.receive(deepLink: "home")
            guard let deepLinkComponent = self?.notificationHandler.deepLink.value else { return }
            self?.handleDeepLink(deepLink: deepLinkComponent)
        }
        
        addDependency(coordinator)
        coordinator.start()
        
        return coordinator
    }
```
- 아직 ProfileImageView 눌렀을 때 플그 프로필로 넘어가는 부분이 안 되어있습니다..~ 다음 이슈에서 할게요 ! @yungu0010 


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 솝마디 결과 -> 부적화면 |<img src = "https://github.com/user-attachments/assets/1d51fc02-f07b-419f-8a68-e097544e3123" width = 400> |

## 📮 관련 이슈
- Resolved: #392 
