### PR TITLE
[Fix] #409 - 스프린트0 QA

### DIFF
--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
@@ -119,7 +119,8 @@ extension DailySoptuneResultVC {
         
         scrollView.snp.makeConstraints { make in
             make.top.equalTo(backButton.snp.bottom)
-            make.leading.trailing.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-100)
         }
         
         contentStackView.snp.makeConstraints { make in

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -110,9 +110,11 @@ extension DailySoptuneResultViewModel {
         
         useCase.randomUser
             .asDriver()
-            .sink(receiveValue: { values in
+            .withUnretained(self)
+            .sink { owner, values in
+                guard !values.isEmpty else { return }
                 output.randomUser.send(values[0])
-            }).store(in: cancelBag)
+            }.store(in: cancelBag)
 
         useCase.pokedResponse
             .sink { _ in

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -13,6 +13,7 @@ import Core
 import Domain
 
 import DailySoptuneFeatureInterface
+import BaseFeatureDependency
 
 public final class DailySoptuneResultViewModel: DailySoptuneResultViewModelType {
     
@@ -114,7 +115,9 @@ extension DailySoptuneResultViewModel {
             }).store(in: cancelBag)
 
         useCase.pokedResponse
-            .subscribe(output.pokeResponse)
+            .sink { _ in
+                ToastUtils.showMDSToast(type: .success, text: I18N.Poke.pokeSuccess)
+            }
             .store(in: cancelBag)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #409 

## 🌱 PR Point
스프린트0 QA 내용들을 반영했어요 후후
- 오늘의 솝마디 결과뷰 -> 콕찌르기 시 토스트바 노출
- 오늘의 솝마디 결과뷰 -> 콕찌르기 추천인이 없을 시의 예외 처리

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
> 오늘의 솝마디 결과뷰 -> 콕찌르기 추천인이 없을 시의 예외 처리

위의 상황은 이번에 QA하면서, **모든 멤버에게 콕찌르기를 진행할 경우** 추천인이 오지 않아 작동이 멈추는 버그였는데요.
이게 dev라 멤버 인원이 적어서 가능한 것이지, prod에서는 모든 멤버에게 콕찌르기 하는 것이 사실상 불가능한 완전완전 엣지 케이스이기 때문에 .. 
배포해도 큰 문제는 없을 것 같기도 하고, 추천인이 없을 경우 '모든 솝트인에게 찔렀어요' 엠티뷰 혹은 특별한 이스터에그를 기획적으로 진행하고 싶어 하셔서, 해당 내용은 다음 스프린트로 미뤘습니다. (그래도 예외처리는 해뒀습니다..)


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|(엣지 케이스) 추천인 없을 경우|<img src="https://github.com/user-attachments/assets/54150ded-3927-4741-93d0-ff33e1652221" width = 300>|
| 콕찌르기 시 토스트바 | <video src = "https://github.com/user-attachments/assets/b4e246e8-0a78-4067-9b6e-c605a729e833" width = 300> |




## 📮 관련 이슈
- Resolved: #409 
