### PR TITLE
[Fix] #410 - SE기기대응, 솝마디 토스트 메세지 추가

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -375,6 +375,7 @@ public struct I18N {
 		public static let recieveTodayFortune = "오늘의 운세가 도착했어요!"
 		public static let checkTodayFortune = "오늘의 운세 확인하기"
 		public static let goHome = "홈으로 돌아가기"
+        public static let dateErrorToastMessage = "앗, 오늘의 솝마디만 볼 수 있어요."
     }
 }
 

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
@@ -80,26 +80,26 @@ private extension DailySoptuneCardVC {
 		self.view.addSubviews(backButton, subCardLabel, cardLabel, cardImage, goToHomeButton)
 		
 		backButton.snp.makeConstraints { make in
-			make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
-			make.leading.equalToSuperview().inset(8)
-			make.size.equalTo(40)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
+            make.leading.equalToSuperview().inset(8.adjusted)
+            make.size.equalTo(40.adjusted)
 		}
 		
 		subCardLabel.snp.makeConstraints { make in
-			make.top.equalTo(view.safeAreaLayoutGuide).offset(48)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(48.adjustedH)
 			make.centerX.equalToSuperview()
-			make.height.equalTo(24)
+            make.height.equalTo(24.adjustedH)
 		}
 		
 		cardLabel.snp.makeConstraints { make in
-			make.top.equalTo(subCardLabel.snp.bottom).offset(2)
+            make.top.equalTo(subCardLabel.snp.bottom).offset(2.adjustedH)
 			make.centerX.equalToSuperview()
 			make.height.equalTo(42.adjustedH)
 		}
 		
 		goToHomeButton.snp.makeConstraints { make in
-			make.bottom.equalTo(view.safeAreaLayoutGuide).inset(49)
-			make.leading.trailing.equalToSuperview().inset(124)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(49.adjustedH)
+            make.leading.trailing.equalToSuperview().inset(124.adjusted)
 			make.height.equalTo(42.adjustedH)
 		}
 		

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneCardVC.swift
@@ -24,6 +24,11 @@ public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardViewCon
     private let cancelBag = CancelBag()
 
 	// MARK: - UI Components
+    
+    private let scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+        $0.showsHorizontalScrollIndicator = false
+    }
 	
 	private let backButton = UIButton().then {
 		$0.setImage(DSKitAsset.Assets.xMark.image.withTintColor(DSKitAsset.Colors.gray30.color), for: .normal)
@@ -71,42 +76,55 @@ public final class DailySoptuneCardVC: UIViewController, DailySoptuneCardViewCon
 // MARK: UI & Layout
 
 private extension DailySoptuneCardVC {
+    private enum Metric {
+        static let cardWidth = 295.adjusted
+        static let cardRatio = 450.0 / 295.0
+    }
 	func setUI() {
 		view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
         self.navigationController?.isNavigationBarHidden = true
 	}
 	
 	func setLayout() {
-		self.view.addSubviews(backButton, subCardLabel, cardLabel, cardImage, goToHomeButton)
+        self.view.addSubviews(backButton, scrollView)
+        scrollView.addSubviews(subCardLabel, cardLabel, cardImage, goToHomeButton)
 		
 		backButton.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
-            make.leading.equalToSuperview().inset(8.adjusted)
-            make.size.equalTo(40.adjusted)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
+            make.leading.equalToSuperview().inset(8)
+            make.size.equalTo(40)
 		}
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(backButton.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
 		
 		subCardLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(48.adjustedH)
+            make.top.equalToSuperview().offset(48)
 			make.centerX.equalToSuperview()
-            make.height.equalTo(24.adjustedH)
+            make.height.equalTo(24)
 		}
 		
 		cardLabel.snp.makeConstraints { make in
-            make.top.equalTo(subCardLabel.snp.bottom).offset(2.adjustedH)
+            make.top.equalTo(subCardLabel.snp.bottom).offset(2)
 			make.centerX.equalToSuperview()
-			make.height.equalTo(42.adjustedH)
+			make.height.equalTo(42)
 		}
 		
+        cardImage.snp.makeConstraints { make in
+            make.top.equalTo(cardLabel.snp.bottom).offset(41.adjustedH)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(Metric.cardWidth)
+            make.height.equalTo(Metric.cardRatio * Metric.cardWidth)
+        }
+        
 		goToHomeButton.snp.makeConstraints { make in
-            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(49.adjustedH)
-            make.leading.trailing.equalToSuperview().inset(124.adjusted)
-			make.height.equalTo(42.adjustedH)
-		}
-		
-		cardImage.snp.makeConstraints { make in
-			make.top.equalTo(cardLabel.snp.bottom).offset(41.adjustedH)
-			make.leading.trailing.equalToSuperview().inset(40.adjusted)
-			make.bottom.equalTo(goToHomeButton.snp.top).offset(-36.adjustedH)
+            make.top.equalTo(cardImage.snp.bottom).offset(36)
+            make.bottom.equalToSuperview().inset(49)
+            make.centerX.equalToSuperview()
+			make.height.equalTo(42)
 		}
 	}
 }
@@ -128,6 +146,6 @@ private extension DailySoptuneCardVC {
             backButtonTap: self.backButton.publisher(for: .touchUpInside).mapVoid().asDriver()
         )
         
-        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        let _ = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
@@ -29,6 +29,11 @@ public final class DailySoptuneMainVC: UIViewController, DailySoptuneMainViewCon
     private lazy var backButtonTapped: Driver<Void> = backButton.publisher(for: .touchUpInside).mapVoid().asDriver()
 	
 	// MARK: - UI Components
+    
+    private lazy var scrollView = UIScrollView().then {
+        $0.showsVerticalScrollIndicator = false
+        $0.showsHorizontalScrollIndicator = false
+    }
 	
 	private let backButton = UIButton().then {
 		$0.setImage(DSKitAsset.Assets.xMark.image.withTintColor(DSKitAsset.Colors.gray30.color), for: .normal)
@@ -82,34 +87,50 @@ public final class DailySoptuneMainVC: UIViewController, DailySoptuneMainViewCon
 // MARK: UI & Layout
 
 private extension DailySoptuneMainVC {
+    private enum Metric {
+        static let soptuneLogoWidth = 269.adjusted
+        static let soptuneLogoRatio = 208.0 / 269.0
+        
+        static let cardWidth = 307.adjusted
+        static let cardRatio = 270.0 / 307.0
+    }
+    
 	func setUI() {
 		view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
         navigationController?.navigationBar.isHidden = true
 	}
 	
 	func setLayout() {
-		self.view.addSubviews(backButton, dateLabel, recieveFortune, todayFortuneImage, titleCardsImage, checkTodayFortuneButton)
-		
+        self.view.addSubviews(scrollView, backButton, checkTodayFortuneButton)
+        scrollView.addSubviews(dateLabel, recieveFortune, todayFortuneImage, titleCardsImage)
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-100)
+            make.leading.trailing.equalToSuperview()
+        }
+        
 		backButton.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
-            make.leading.equalToSuperview().inset(8.adjusted)
-            make.size.equalTo(40.adjusted)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
+            make.leading.equalToSuperview().inset(8)
+            make.size.equalTo(40)
 		}
 		
 		dateLabel.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(40.adjustedH)
+            make.top.equalToSuperview().offset(40)
 			make.centerX.equalToSuperview()
 		}
 		
 		recieveFortune.snp.makeConstraints { make in
-            make.top.equalTo(dateLabel.snp.bottom).offset(2.adjustedH)
+            make.top.equalTo(dateLabel.snp.bottom).offset(2)
 			make.centerX.equalToSuperview()
 		}
 		
 		todayFortuneImage.snp.makeConstraints { make in
 			make.top.equalTo(recieveFortune.snp.bottom).offset(9.adjustedH)
-			make.leading.trailing.equalToSuperview().inset(53.adjusted)
-			make.height.equalTo(208.adjustedH)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(Metric.soptuneLogoRatio * Metric.soptuneLogoWidth)
+            make.width.equalTo(Metric.soptuneLogoWidth)
 		}
 		
 		checkTodayFortuneButton.snp.makeConstraints { make in
@@ -119,9 +140,11 @@ private extension DailySoptuneMainVC {
 		}
 		
 		titleCardsImage.snp.makeConstraints { make in
-			make.bottom.equalTo(checkTodayFortuneButton.snp.top).offset(-32.adjustedH)
             make.top.equalTo(todayFortuneImage.snp.bottom).offset(14.adjustedH)
-			make.leading.trailing.equalToSuperview().inset(34.adjusted)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(Metric.cardWidth)
+            make.height.equalTo(Metric.cardRatio * Metric.cardWidth)
+            make.bottom.equalToSuperview().inset(20)
 		}
 	}
     

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
@@ -36,14 +36,14 @@ public final class DailySoptuneMainVC: UIViewController, DailySoptuneMainViewCon
 	
 	private let dateLabel = UILabel().then {
 		$0.textColor = DSKitAsset.Colors.gray100.color
-		$0.font = DSKitFontFamily.Suit.medium.font(size: 16)
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 16)
 		$0.text = setDateFormat(to: "M월 d일 EEEE")
 	}
 	
 	private let recieveFortune = UILabel().then {
 		$0.text = I18N.DailySoptune.recieveTodayFortune
 		$0.textColor = DSKitAsset.Colors.gray100.color
-		$0.font = DSKitFontFamily.Suit.bold.font(size: 18)
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 18)
 	}
 	
 	private let todayFortuneImage = UIImageView().then {
@@ -91,18 +91,18 @@ private extension DailySoptuneMainVC {
 		self.view.addSubviews(backButton, dateLabel, recieveFortune, todayFortuneImage, titleCardsImage, checkTodayFortuneButton)
 		
 		backButton.snp.makeConstraints { make in
-			make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
-			make.leading.equalToSuperview().inset(8)
-			make.size.equalTo(40)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
+            make.leading.equalToSuperview().inset(8.adjusted)
+            make.size.equalTo(40.adjusted)
 		}
 		
 		dateLabel.snp.makeConstraints { make in
-			make.top.equalTo(view.safeAreaLayoutGuide).offset(40)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(40.adjustedH)
 			make.centerX.equalToSuperview()
 		}
 		
 		recieveFortune.snp.makeConstraints { make in
-			make.top.equalTo(dateLabel.snp.bottom).offset(2)
+            make.top.equalTo(dateLabel.snp.bottom).offset(2.adjustedH)
 			make.centerX.equalToSuperview()
 		}
 		
@@ -113,15 +113,15 @@ private extension DailySoptuneMainVC {
 		}
 		
 		checkTodayFortuneButton.snp.makeConstraints { make in
-			make.bottom.equalTo(view.safeAreaLayoutGuide).inset(49)
-			make.leading.trailing.equalToSuperview().inset(20)
-			make.height.equalTo(56)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(49)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(56)
 		}
 		
 		titleCardsImage.snp.makeConstraints { make in
 			make.bottom.equalTo(checkTodayFortuneButton.snp.top).offset(-32.adjustedH)
+            make.top.equalTo(todayFortuneImage.snp.bottom).offset(14.adjustedH)
 			make.leading.trailing.equalToSuperview().inset(34.adjusted)
-			make.height.equalTo(270.adjustedH)
 		}
 	}
     
@@ -133,6 +133,6 @@ private extension DailySoptuneMainVC {
                 receiveTodayFortuneButtonTap: todayFortuneButtonTapped
             )
         
-        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        let _ = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneMainVC.swift
@@ -104,7 +104,7 @@ private extension DailySoptuneMainVC {
         scrollView.addSubviews(dateLabel, recieveFortune, todayFortuneImage, titleCardsImage)
         
         scrollView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(backButton.snp.bottom)
             make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-100)
             make.leading.trailing.equalToSuperview()
         }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
@@ -99,9 +99,9 @@ extension DailySoptuneResultVC {
         self.view.addSubviews(backButton, scrollView, receiveTodaysFortuneCardButton)
         
         backButton.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
-            make.leading.equalToSuperview().inset(8)
-            make.size.equalTo(40)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
+            make.leading.equalToSuperview().inset(8.adjusted)
+            make.size.equalTo(40.adjusted)
         }
         
         setScrollViewLayout()
@@ -124,9 +124,9 @@ extension DailySoptuneResultVC {
         
         contentStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().inset(17)
-            make.width.equalTo(self.view.frame.size.width - 20 * 2)
-            make.bottom.equalToSuperview().inset(20)
+            make.top.equalToSuperview().inset(17.adjustedH)
+            make.width.equalTo((self.view.frame.size.width - 20 * 2).adjusted)
+            make.bottom.equalToSuperview().inset(20.adjustedH)
         }
         
     }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -117,9 +117,10 @@ extension DailySoptuneResultViewModel {
             }.store(in: cancelBag)
 
         useCase.pokedResponse
-            .sink { _ in
+            .withUnretained(self)
+            .sink { owner, pokeUserModel in
                 ToastUtils.showMDSToast(type: .success, text: I18N.Poke.pokeSuccess)
-            }
-            .store(in: cancelBag)
+                output.pokeResponse.send(pokeUserModel)
+            }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultContentView.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultContentView.swift
@@ -63,7 +63,7 @@ extension DailySoptuneResultContentView {
     }
     
     private func setContentLabel() {
-        self.contentLabel.setLineSpacing(lineSpacing: 8)
+        self.contentLabel.setLineSpacing(lineSpacing: 8.adjustedH)
         self.contentLabel.textAlignment = .center
     }
     
@@ -78,18 +78,18 @@ extension DailySoptuneResultContentView {
         }
         
         dateLabel.snp.makeConstraints { make in
-            make.top.equalTo(soptuneLogoImage.snp.bottom).offset(12)
+            make.top.equalTo(soptuneLogoImage.snp.bottom).offset(12.adjustedH)
             make.centerX.equalToSuperview()
         }
         
         contentLabel.snp.makeConstraints { make in
-            make.top.equalTo(dateLabel.snp.bottom).offset(20)
+            make.top.equalTo(dateLabel.snp.bottom).offset(20.adjustedH)
             make.centerX.equalToSuperview()
             make.leading.trailing.equalToSuperview()
         }
         
         self.snp.makeConstraints { make in
-            make.bottom.equalTo(contentLabel.snp.bottom).offset(34)
+            make.bottom.equalTo(contentLabel.snp.bottom).offset(34.adjustedH)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
@@ -105,30 +105,30 @@ extension DailySoptuneResultPokeView {
         self.addSubviews(titleLabel, subTitleLabel, pokeStackView)
         
         titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(20)
-            make.leading.equalToSuperview().inset(20)
+            make.top.equalToSuperview().inset(20.adjustedH)
+            make.leading.equalToSuperview().inset(20.adjusted)
         }
         
         subTitleLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(10)
-            make.leading.equalToSuperview().inset(20)
+            make.top.equalTo(titleLabel.snp.bottom).offset(10.adjustedH)
+            make.leading.equalToSuperview().inset(20.adjusted)
         }
         
         profileImageView.snp.makeConstraints { make in
-            make.size.equalTo(72)
+            make.size.equalTo(72.adjusted)
         }
         
         kokButton.snp.makeConstraints { make in
-            make.size.equalTo(44)
+            make.size.equalTo(44.adjusted)
         }
         
         pokeStackView.snp.makeConstraints { make in
-            make.top.equalTo(subTitleLabel.snp.bottom).offset(28)
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.top.equalTo(subTitleLabel.snp.bottom).offset(28.adjustedH)
+            make.leading.trailing.equalToSuperview().inset(20.adjusted)
         }
         
         self.snp.makeConstraints { make in
-            make.bottom.equalTo(pokeStackView.snp.bottom).offset(28)
+            make.bottom.equalTo(pokeStackView.snp.bottom).offset(28.adjustedH)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -66,14 +66,12 @@ extension NotificationDetailViewModel {
         input.shortCutButtonTap
             .withUnretained(self)
             .map { owner, _ -> Bool in
-                if let deepLink = owner.notification?.deepLink,
-                    let date = owner.notification?.createdAt {
-                    if !owner.isToday(date.toDate()) && deepLink.hasSuffix("fortune") {
-                        ToastUtils.showMDSToast(type: .alert, text: I18N.DailySoptune.dateErrorToastMessage)
-                        return false
-                    }
-                }
-                return true
+                guard let deepLink = owner.notification?.deepLink,
+                           let date = owner.notification?.createdAt,
+                           !owner.isToday(date.toDate()),
+                           deepLink.hasSuffix("fortune")
+                else { return true }
+                return false
             }
             .filter{ $0 }
             .withUnretained(self)


### PR DESCRIPTION
## 🌴 PR 요약
- SE기기 대응
- 솝마디 토스트 메세지 추가

🌱 작업한 브랜치
- feature/#410

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
~~adjusted 또는 adjustedH를 함께 사용하고 있는데, 컴포넌트의 비율을 기존과 같이 유지하려면 둘 중 하나만 써야합니다.! 하지만 그렇게 할 경우 SE 화면 속에서 스크롤뷰 없이 기기대응이 불가합니다.~~
~~우선 adjusted와 adjustedH를 혼합하여 사용했는데, 화면에서 차지하는 비율을 기준으로 레이아웃을 잡다보니 다른 기기들과 비율이 맞지 않습니다. . -> 솝마디 메인뷰와 솝마디 카드뷰도 스크롤뷰로 바꾸어야 할까요?~~   

- 버튼은 알림 상세와 통일성을 가지기 위해 기기대응을 적용하지 않았습니다.
- 디자이너 분들 의견에 따라 MainVC는 스크롤뷰 + 플로팅 버튼, CardVC는 스크롤뷰 적용하였습니다.
- 마찬가지로 디자이너 분들 의견에 맞게 dismiss 버튼은 스크롤뷰에 추가하지 않았습니다!

- UseCase에서 처리하려고 했으나, 버튼을 눌렀을 때 토스트 메세지를 띄워야한다고 해서 ViewModel에서 작업하였습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|SE 기기대응|<img src="https://github.com/user-attachments/assets/bf518d58-ce1c-49e9-9ace-028c2993b8ba" width=265>|
|솝마디 토스트 메세지 추가|<img src="https://github.com/user-attachments/assets/5dcb3fba-d64c-4a10-9376-0b2be1f96855" width=265>|

## 📮 관련 이슈
- Resolved: #410