### PR TITLE
[Fix] #416 - PokeOnboarding 새로고침 시 Push 계속 되는 현상 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Project.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Project.swift
@@ -12,6 +12,9 @@ import DependencyPlugin
 let project = Project.makeModule(
     name: "DailySoptuneFeature",
     targets: [.unitTest, .staticFramework, .demo, .interface],
+    internalDependencies: [
+        .Features.Poke.Interface
+    ],
     interfaceDependencies: [
         .Features.BaseFeatureDependency
     ]

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/SubViews/Cell/PokeOnboardingCollectionViewCell.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/SubViews/Cell/PokeOnboardingCollectionViewCell.swift
@@ -54,4 +54,9 @@ extension PokeOnboardingCollectionViewCell {
   private func setupConstraints() {
     self.sectionView.snp.makeConstraints { $0.directionalEdges.equalToSuperview() }
   }
+
+  public override func prepareForReuse() {
+    super.prepareForReuse()
+    self.cancelBag = CancelBag()
+  }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #416 

## 🌱 PR Point
- PokeOnboarding에서 pull to refresh를 진행할 때마다, 이어서 push되는 SoptWebView의 push 개수가 하나씩 증가되는 버그를 해결했습니다.
  - collection view cell을 reuse할 때 구독이 중복되어 발생하는 문제였습니다.
  - 따라서 `prepareForReuse`에서 **cell의 cancelBag을 초기화**하여 기존 구독을 취소하고, 새로운 구독을 생성하도록 처리했습니다. 기존에는 **vc의 생명주기 동안 구독이 유지**되었는데, 이렇게 해서 **cell의 생명주기에 맞추어** 구독을 초기화 해줄 수 있습니다...!!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
pr 올리는 김에... `Manifests`에서 **DailySoptuneFeature -> PokeFeatureInterface** 의존성 같이 추가해줬습니다..^.^

```swift
let project = Project.makeModule(
    name: "DailySoptuneFeature",
    targets: [.unitTest, .staticFramework, .demo, .interface],
    internalDependencies: [
        .Features.Poke.Interface
    ],
    interfaceDependencies: [
        .Features.BaseFeatureDependency
    ]
)
```



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|AS-IS|<video src = "https://github.com/user-attachments/assets/7dc7dd34-c0ca-487c-8f8d-32548e0b3192" width = 300>|
|TO-BE|<video src = "https://github.com/user-attachments/assets/6d050b2a-a00d-4df2-9c5e-06a5bbcd2cae" width = 300>|

## 📮 관련 이슈
- Resolved: #416 
