### PR TITLE
[Hotfix] #428 - 솝탬프 수정 오류

### DIFF
--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -155,6 +155,7 @@ extension ListDetailViewModel {
     listDetailModel.asDriver()
       .compactMap {
         self.stampId = $0.stampId
+        self.uploadedUrl = $0.image
         return $0
       }
       .assign(to: \.self.listDetailModel, on: output)

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
@@ -7,8 +7,9 @@
 //
 
 import UIKit
+import Combine
 
-import Domain
+import Core
 
 /// 테두리가 있는 원형 프로필 이미지 뷰
 public final class CustomProfileImageView: UIImageView {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/ #428 

## 🌱 PR Point
- 솝탬프 수정 오류 반영했습니다! @dlwogus0128 감사합니다🫶

### 문제 원인
1. ListDetailViewModel에서 uploadUrl을 옵셔널 프로퍼티로 가지고 있음.  
2. DetailVC로 진입할 때 솝탬프 정보를 fetch해오는 과정에서 uploadUrl을 지정해주지 않음  
```swift
listDetailModel.asDriver()
    .compactMap {
        self.stampId = $0.stampId
        return $0
}
```
3. 수정 완료 버튼을 눌렀을 때 self의 uploadUrl이 nil이라 데이터 흐름이 전달되지 않음
```swift
input.bottomButtonTapped
      .eraseToAnyPublisher()
      .flatMap { [weak self] requestModel -> Driver<ListDetailRequestModel> in
        guard
          let self,
          let presignedUrl = self.uploadedUrl?.removePercentEncodingIfNeeded()    // crash 발생 ‼️
        else { return .empty() }
```

### 문제 해결
- @dlwogus0128이 도움주신대로 처음 값을 fetch해올 때 self.uploadUrl을 지정해주었습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- release에 머지해서 2.6.1로 업데이트 하겠습니다 ! 
- 해당 PR 내용은 develop 작업할 때 같이 추가하면 되겠죠 .. ?

## 📮 관련 이슈
- Resolved: #428 
