### PR TITLE
[Hotfix] #430 - 솝탬프 디테일뷰 크래시 이슈 해결

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -39,7 +39,7 @@ public extension UIImageView {
     
     private func setNewImage(with urlString: String, placeholder: UIImage? = nil, completion: ((UIImage?) -> Void)? = nil) {
         guard let url = URL(string: urlString) else { return }
-        let resource = ImageResource(downloadURL: url, cacheKey: urlString)
+        let resource = KF.ImageResource(downloadURL: url, cacheKey: urlString)
         
         self.kf.setImage(
             with: resource,

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -142,23 +142,27 @@ public class ListDetailVC: UIViewController, ListDetailViewControllable {
 extension ListDetailVC {
   private func bindViewModels() {
     let rightButtonTapped = naviBar.rightButtonTapped
-      .map { self.sceneType }
+      .withUnretained(self)
+      .map { owner, _ in
+          owner.sceneType
+      }
       .asDriver()
     
     let bottomButtonTapped = bottomButton
       .publisher(for: .touchUpInside)
-      .map { _ in
-        if self.sceneType == .edit {
-          self.bottomButton.setEnabled(false)
+      .withUnretained(self)
+      .map { owner, _ in
+        if owner.sceneType == .edit {
+          owner.bottomButton.setEnabled(false)
         }
-        if self.sceneType == .none {
+        if owner.sceneType == .none {
           self.showDimmerView()
         }
-        let content = self.textView.text
+        let content = owner.textView.text
         return ListDetailRequestModel(
-          missionId: self.viewModel.missionId ?? 0,
+          missionId: owner.viewModel.missionId ?? 0,
           content: content ?? "",
-          activityDate: self.missionDateTextField.getText() ?? ""
+          activityDate: owner.missionDateTextField.getText() ?? ""
         )
       }
       .asDriver()
@@ -174,50 +178,54 @@ extension ListDetailVC {
     
     output.$listDetailModel
       .compactMap { $0 }
-      .sink { model in
+      .withUnretained(self)
+      .sink { owner, model in
         if model.image.isEmpty {
           AlertUtils.presentNetworkAlertVC(theme: .soptamp,animated: true) {
-            self.backgroundDimmerView.removeFromSuperview()
+            owner.backgroundDimmerView.removeFromSuperview()
           }
         } else {
-          self.setData(model)
-          if self.sceneType == .none {
-            self.onComplete?(self.starLevel) {
+          owner.setData(model)
+          if owner.sceneType == .none {
+            owner.onComplete?(owner.starLevel) {
               UIView.animate(withDuration: 0.2, delay: 0, animations: {
-                self.backgroundDimmerView.alpha = 0
+                owner.backgroundDimmerView.alpha = 0
               }) { _ in
-                self.backgroundDimmerView.removeFromSuperview()
+                owner.backgroundDimmerView.removeFromSuperview()
               }
             }
           }
-          self.sceneType = .completed
-          self.reloadData(self.sceneType)
+          owner.sceneType = .completed
+          owner.reloadData(owner.sceneType)
         }
       }.store(in: self.cancelBag)
     
     output.editSuccessed
-      .sink { successed in
+      .withUnretained(self)
+      .sink { owner, successed in
         if successed {
-          self.reloadData(.completed)
-          self.showToast(message: I18N.ListDetail.editCompletedToast)
+          owner.reloadData(.completed)
+          owner.showToast(message: I18N.ListDetail.editCompletedToast)
         } else {
           AlertUtils.presentNetworkAlertVC(theme: .soptamp, animated: true)
         }
       }.store(in: self.cancelBag)
     
     output.showDeleteAlert
-      .sink { delete in
+      .withUnretained(self)
+      .sink { owner, delete in
         if delete {
-          self.presentDeleteAlertVC()
+          owner.presentDeleteAlertVC()
         } else {
-          self.reloadData(.edit)
+          owner.reloadData(.edit)
         }
       }.store(in: self.cancelBag)
     
     output.deleteSuccessed
-      .sink { success in
+      .withUnretained(self)
+      .sink { owner, success in
         if success {
-          self.navigationController?.popViewController(animated: true)
+          owner.navigationController?.popViewController(animated: true)
         } else {
           AlertUtils.presentNetworkAlertVC(theme: .soptamp, animated: true)
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -228,7 +228,7 @@ extension ListDetailVC {
     guard self.sceneType != .none else { return }
     
     if let imageURL = URL(string: model.image) {
-      self.missionImageView.kf.setImage(with: imageURL)
+      self.missionImageView.setImage(with: imageURL.absoluteString)
     }
     self.missionDateTextField.setText(with: model.activityDate)
     self.missionDateTextField.setIsEnabled(false)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -75,6 +75,7 @@ extension ListDetailViewModel {
       .filter { owner, _ in
         owner.sceneType == .completed
       }
+      .withUnretained(self)
       .sink { owner, _ in
         owner.isOtherUser
         ? owner.useCase.fetchListDetail(missionId: owner.missionId, username: owner.otherUserName)
@@ -119,16 +120,18 @@ extension ListDetailViewModel {
         var requestModel = requestModel
         return Just(requestModel.updateImgUrl(to: presignedUrl)).asDriver()
       }
-      .sink { requestModel in
-        if self.sceneType == ListDetailSceneType.none {
-          self.useCase.postStamp(stampData: requestModel)
+      .withUnretained(self)
+      .sink { owner, requestModel in
+        if owner.sceneType == ListDetailSceneType.none {
+          owner.useCase.postStamp(stampData: requestModel)
         } else {
-          self.useCase.putStamp(stampData: requestModel)
+          owner.useCase.putStamp(stampData: requestModel)
         }
       }.store(in: self.cancelBag)
     
     input.rightButtonTapped
-      .sink { sceneType in
+      .withUnretained(self)
+      .sink { owner, sceneType in
         switch sceneType {
         case .completed:
           output.showDeleteAlert.send(false)
@@ -140,8 +143,9 @@ extension ListDetailViewModel {
       }.store(in: self.cancelBag)
     
     input.deleteButtonTapped
-      .sink { _ in
-        self.useCase.deleteStamp(stampId: self.stampId)
+      .withUnretained(self)
+      .sink { owner, _ in
+        owner.useCase.deleteStamp(stampId: owner.stampId)
       }.store(in: self.cancelBag)
     
     return output
@@ -162,12 +166,14 @@ extension ListDetailViewModel {
       .store(in: self.cancelBag)
     
     editSuccess.asDriver()
-      .sink { success in
+      .withUnretained(self)
+      .sink { owner, success in
         output.editSuccessed.send(success)
       }.store(in: self.cancelBag)
     
     deleteSuccess.asDriver()
-      .sink { success in
+      .withUnretained(self)
+      .sink { owner, success in
         output.deleteSuccessed.send(success)
       }.store(in: self.cancelBag)
   }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -75,7 +75,6 @@ extension ListDetailViewModel {
       .filter { owner, _ in
         owner.sceneType == .completed
       }
-      .withUnretained(self)
       .sink { owner, _ in
         owner.isOtherUser
         ? owner.useCase.fetchListDetail(missionId: owner.missionId, username: owner.otherUserName)
@@ -157,11 +156,11 @@ extension ListDetailViewModel {
     let deleteSuccess = useCase.deleteSuccess
     
     listDetailModel.asDriver()
-      .compactMap {
-        self.uploadedUrl = $0.image
-        self.stampId = $0.stampId
-        self.uploadedUrl = $0.image
-        return $0
+      .withUnretained(self)
+      .compactMap { owner, model in
+        owner.stampId = model.stampId
+        owner.uploadedUrl = model.image
+        return model
       }
       .assign(to: \.self.listDetailModel, on: output)
       .store(in: self.cancelBag)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -158,6 +158,7 @@ extension ListDetailViewModel {
     
     listDetailModel.asDriver()
       .compactMap {
+        self.uploadedUrl = $0.image
         self.stampId = $0.stampId
         self.uploadedUrl = $0.image
         return $0


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #430 

## 🌱 PR Point

- 지속되고 있는 솝탬프 디테일뷰 크래시 이슈를 해결하고자 합니다. 
  - 현재 크래시가 발생하고 있는 분들의 IPS 파일을 받아보았을 때, KF을 사용하는 부분에서 `EXC_BAD_ACCESS`가 발생하는 것을 확인했습니다.
  - 이에 해당 라이브러리의 버전을 업데이트하고 재배포했으나, 테플에서는 이슈가 해결되었지만 앱스토어에서 설치할 경우 (일부 사용자에게) 여전히 크래시가 발생하고 있는 상황입니다.
  - 따라서, `2.6.2` 버전으로, 이슈의 원인으로 추정할 수 있는 여러 부분들을 수정해 재배포하려 합니다. 
  
- 수정한 부분
  - [x] kf.setImage -> 랩핑해서 사용하고 있는 setImge로 수정 (한글 URL 인코딩)
  - [x] 솝탬프 디테일뷰 바인딩 -> 강한참조 부분 수정


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #430 
