### PR TITLE
[Feat] #445 - 신규 홈뷰 활동/비활동 인사이트 섹션 UI 구현

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Cells/Insight/Empty.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Cells/Insight/Empty.swift
@@ -1,8 +1,0 @@
-//
-//  Empty.swift
-//  HomeFeature
-//
-//  Created by Jae Hyun Lee on 11/21/24.
-//  Copyright © 2024 SOPT-iOS. All rights reserved.
-//
-

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Cells/Insight/InsightCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Cells/Insight/InsightCardCVC.swift
@@ -1,0 +1,119 @@
+//
+//  InsightCardCVC.swift
+//  HomeFeature
+//
+//  Created by Jae Hyun Lee on 11/25/24.
+//  Copyright © 2024 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import DSKit
+
+final class InsightCardCVC: UICollectionViewCell {
+    
+    // MARK: - Properties
+
+    private let categoryTagView = HomeCategoryTagView()
+    
+    private let verticalDividerView = UIImageView().then {
+        $0.image = DSKitAsset.Assets.icVerticalDivider.image
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let profileImageView = UIImageView()
+    
+    private let userNameLabel = UILabel().then {
+        $0.textColor = DSKitAsset.Colors.gray100.color
+        $0.font = DSKitFontFamily.Suit.regular.font(size: 13)
+    }
+    
+    private let categoryStackView = UIStackView().then {
+        $0.axis = .horizontal
+    }
+    
+    private let postTitleLabel = UILabel().then {
+        $0.textColor = DSKitAsset.Colors.white100.color
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 16)
+        $0.lineBreakMode = .byTruncatingTail
+    }
+    
+    private let contentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+        $0.spacing = 6
+    }
+
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setStackView()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        setCornerRadius()
+    }
+}
+
+// MARK: - UI & Layout
+
+extension InsightCardCVC {
+    private func setUI() {
+        self.layer.cornerRadius = 12
+        self.backgroundColor = DSKitAsset.Colors.gray800.color
+    }
+
+    private func setLayout() {
+        self.addSubview(contentStackView)
+        
+        profileImageView.snp.makeConstraints { make in
+            make.size.equalTo(20)
+        }
+        
+        categoryStackView.setCustomSpacing(10, after: categoryTagView)
+        categoryStackView.setCustomSpacing(10, after: verticalDividerView)
+        categoryStackView.setCustomSpacing(4, after: profileImageView)
+        
+        contentStackView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.top.bottom.equalToSuperview().inset(14)
+        }
+    }
+    
+    private func setStackView() {
+        categoryStackView.addArrangedSubviews(
+            categoryTagView,
+            verticalDividerView,
+            profileImageView,
+            userNameLabel
+        )
+        
+        contentStackView.addArrangedSubviews(
+            categoryStackView,
+            postTitleLabel
+        )
+    }
+    
+    private func setCornerRadius() {
+        profileImageView.layer.cornerRadius = self.frame.height / 2
+    }
+}
+
+// MARK: - Methods
+
+extension InsightCardCVC {
+    func configureCell(model: InsightInfo) {
+        self.categoryTagView.setData(with: model.category, isHotTag: model.isHotTag)
+        self.profileImageView.image = model.profileImageURL
+        self.userNameLabel.text = model.userName
+        self.postTitleLabel.text = model.postTitle
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CollectionView/HomeForMemberCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CollectionView/HomeForMemberCompositionalLayout.swift
@@ -33,6 +33,8 @@ extension HomeForMemberVC {
                 return self.createMainProductSection()
             case .appService:
                 return self.createAppServiceSection()
+            case .insight:
+                return self.createInsightSection()
             default:
                 return self.createEmptySection()
             }
@@ -109,7 +111,7 @@ extension HomeForMemberVC {
     }
     
     private func createAppServiceSection() -> NSCollectionLayoutSection {
-        /// header: 유저 정보 및 활동 히스토리
+        /// header: default
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                 heightDimension: .absolute(30))
         let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
@@ -136,6 +138,43 @@ extension HomeForMemberVC {
                     heightDimension: .estimated(106)
                 ),
                 subitems: [appServiceGroup]
+            )
+        )
+        section.boundarySupplementaryItems = [header]
+        section.contentInsets = NSDirectionalEdgeInsets(top: Metric.defaultItemSpacing,
+                                                        leading: Metric.collectionViewDefaultSideInset,
+                                                        bottom: Metric.defaultLineSpacing,
+                                                        trailing: Metric.collectionViewDefaultSideInset)
+        return section
+    }
+    
+    private func createInsightSection() -> NSCollectionLayoutSection {
+        /// header: default
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                heightDimension: .absolute(30))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
+                                                                 elementKind: UICollectionView.elementKindSectionHeader,
+                                                                 alignment: .top)
+        
+        /// item: 인사이트 카드
+        let insightItemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                     heightDimension: .absolute(80))
+        let insightItem = NSCollectionLayoutItem(layoutSize: insightItemSize)
+        
+        /// group: 인사이트 카드
+        let insightGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                         heightDimension: .estimated(80))
+        let insightGroup = NSCollectionLayoutGroup.horizontal(layoutSize: insightGroupSize,
+                                                              subitems: [insightItem])
+        
+        /// section 지정
+        let section = NSCollectionLayoutSection(
+            group: NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1.0),
+                    heightDimension: .estimated(80)
+                ),
+                subitems: [insightGroup]
             )
         )
         section.boundarySupplementaryItems = [header]

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/VC/HomeForMemberVC.swift
@@ -106,6 +106,8 @@ extension HomeForMemberVC {
                                      forCellWithReuseIdentifier: MainProductCardCVC.className)
         self.collectionView.register(AppServiceCardCVC.self,
                                      forCellWithReuseIdentifier: AppServiceCardCVC.className)
+        self.collectionView.register(InsightCardCVC.self,
+                                     forCellWithReuseIdentifier: InsightCardCVC.className)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/VC/HomeForMemberVC.swift
@@ -154,6 +154,7 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .dashBoard: return 1
         case .mainProduct: return viewModel.productInfoList.count
         case .appService: return viewModel.appServiceInfoList.count
+        case .insight: return viewModel.insightInfoList.count
         default: return 0
         }
     }
@@ -193,7 +194,16 @@ extension HomeForMemberVC: UICollectionViewDataSource {
                                              name: viewModel.appServiceInfoList[appServiceIndex].name,
                                              badgeText: viewModel.appServiceInfoList[appServiceIndex].badgeText)
             return appServiceCardCell
+        
+        case .insight:
+            /// 인사이트 카드 셀
+            let insightIndex = indexPath.item
+            guard let insightCardCell = collectionView
+                .dequeueReusableCell(withReuseIdentifier: InsightCardCVC.className,
+                                     for: indexPath) as? InsightCardCVC else { return UICollectionViewCell() }
+            insightCardCell.configureCell(model: viewModel.insightInfoList[insightIndex])
             
+            return insightCardCell
         default: return UICollectionViewCell()
         }
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/ViewModel/HomeForMemberViewModel.swift
@@ -28,6 +28,14 @@ struct AppServiceInfo {
     let badgeText: String
 }
 
+struct InsightInfo {
+    let category: String
+    let profileImageURL: UIImage
+    let userName: String
+    let postTitle: String
+    let isHotTag: Bool
+}
+
 public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     // MARK: - Properties
@@ -44,6 +52,11 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
         AppServiceInfo(name: "콕찌르기", imageURL: "", badgeText: "3"),
         AppServiceInfo(name: "솝마디", imageURL: "", badgeText: "N"),
         AppServiceInfo(name: "솝탬프", imageURL: "", badgeText: "3위")
+    ]
+    
+    // TODO: 서버 연결 필요
+    let insightInfoList: [InsightInfo] = [
+        InsightInfo(category: "SOPT활동", profileImageURL: DSKitAsset.Assets.imgMemberLogo.image, userName: "차은우", postTitle: "차은우가 솝트 기획으로 활동한 썰 푼다 최대글자수입니다람지렁이", isHotTag: false)
     ]
     
     // MARK: - Inputs

--- a/SOPT-iOS/Projects/Modules/DSKit/Resources/Assets.xcassets/Home/Image/ic_vertical_divider.imageset/Contents.json
+++ b/SOPT-iOS/Projects/Modules/DSKit/Resources/Assets.xcassets/Home/Image/ic_vertical_divider.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_vertical_divider.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Projects/Modules/DSKit/Resources/Assets.xcassets/Home/Image/ic_vertical_divider.imageset/ic_vertical_divider.svg
+++ b/SOPT-iOS/Projects/Modules/DSKit/Resources/Assets.xcassets/Home/Image/ic_vertical_divider.imageset/ic_vertical_divider.svg
@@ -1,0 +1,3 @@
+<svg width="2" height="16" viewBox="0 0 2 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L1 15" stroke="#515159" stroke-width="1.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #445 

## 🌱 PR Point

- (활동/비활동 회원) 신규 홈뷰의 인사이트 섹션 UI를 구현했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|인사이트 섹션|<img src = "https://github.com/user-attachments/assets/685fd294-68f0-4e12-a655-8d6ffce8a562" width = 300>|

## 📮 관련 이슈
- Resolved: #445 
