### PR TITLE
[Feat] #408 - Amplitude 설치

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -51,6 +51,7 @@ public enum AmplitudeEventType: String {
     // 뷰 이벤트
     case viewAppHome = "view_apphome"
     case viewPokeOnboarding = "view_poke_onboarding"
+    case viewNotificationDetail = "view_notification_detail"
     
     // 콕 찌르기 뷰 이벤트
     case viewPokeMain = "view_poke_main"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -26,6 +26,7 @@ public enum AmplitudeEventType: String {
     case clickFaq = "click_faq"
     case clickPlaygroundCommunity = "click_playground_community"
     case clickHotboard = "click_hotboard"
+    case clickShortcutButton = "click_link.btn"
     case clickReadAllButton = "click_allread.btn"
     
     // 콕 찌르기 클릭 이벤트

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -28,6 +28,7 @@ public enum AmplitudeEventType: String {
     case clickHotboard = "click_hotboard"
     case clickShortcutButton = "click_link.btn"
     case clickReadAllButton = "click_allread.btn"
+    case clickNotificationItem = "click_notification_item"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -52,6 +52,7 @@ public enum AmplitudeEventType: String {
     case viewAppHome = "view_apphome"
     case viewPokeOnboarding = "view_poke_onboarding"
     case viewNotificationDetail = "view_notification_detail"
+    case viewNotificationList = "view_notification_list"
     
     // 콕 찌르기 뷰 이벤트
     case viewPokeMain = "view_poke_main"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -26,6 +26,7 @@ public enum AmplitudeEventType: String {
     case clickFaq = "click_faq"
     case clickPlaygroundCommunity = "click_playground_community"
     case clickHotboard = "click_hotboard"
+    case clickReadAllButton = "click_allread.btn"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 public enum AmplitudeEventType: String {
+    // 푸시 이벤트
+    case receivedPush = "received_push"
     // 클릭 이벤트
     case clickAlarm = "click_alarm"
     case clickMyPage = "click_mypage"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum AmplitudeEventType: String {
     // 푸시 이벤트
     case receivedPush = "received_push"
+    case clickPush = "click_push"
     // 클릭 이벤트
     case clickAlarm = "click_alarm"
     case clickMyPage = "click_mypage"

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
@@ -59,6 +59,12 @@ final class NotificationCoordinator: DefaultNotificationCoordinator {
             let url = link.url
             
             let destination: NotificationCoordinatorDestination = link.isDeepLink ? .deepLink(url: url) : .webLink(url: url)
+            AmplitudeInstance.shared.track(eventType: .viewNotificationDetail, eventProperties: [
+                "notification_id": notificationId,
+                "open_method": link.isDeepLink ? "푸시알림" : "알림센터",
+                "contain_deeplink": link.isDeepLink
+            ])
+            
             self?.requestCoordinating?(destination)
         }
         

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -61,7 +61,6 @@ extension NotificationDetailViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.getNotificationDetail(notificationId: owner.notificationId)
-                owner.trackAmplitudeNoticeDetailView(with: owner.notificationId)
             }.store(in: cancelBag)
         
         input.shortCutButtonTap
@@ -120,16 +119,6 @@ extension NotificationDetailViewModel {
     private func isToday(_ date: Date) -> Bool {
         let calendar = Calendar.current
         return calendar.isDateInToday(date)
-    }
-    
-    private func trackAmplitudeNoticeDetailView(with notificationId: String) {
-        guard let notification else { return }
-        AmplitudeInstance.shared.track(eventType: .viewNotificationDetail,
-                                       eventProperties: [
-            "notification_id": notificationId,
-            "open_method": notification.hasDeepLink ? "푸시" : "알림센터",
-            "contain_deeplink": notification.hasDeepLink
-        ])
     }
     
     private func trackAmplitudeShortcutButtonTapped(with notificationId: String) {

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -80,6 +80,7 @@ extension NotificationDetailViewModel {
             .sink { owner, _ in
                 guard let shortCutLink = owner.makeShortCutLink() else { return }
                 owner.onShortCutButtonTap?(shortCutLink)
+                owner.trackAmplitudeShortcutButtonTapped(with: owner.notificationId)
             }.store(in: cancelBag)
     
         return output
@@ -118,5 +119,8 @@ extension NotificationDetailViewModel {
     private func isToday(_ date: Date) -> Bool {
         let calendar = Calendar.current
         return calendar.isDateInToday(date)
+    }
+    private func trackAmplitudeShortcutButtonTapped(with notificationId: String) {
+        AmplitudeInstance.shared.track(eventType: .clickShortcutButton, eventProperties: ["notification_id": notificationId])
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -61,6 +61,7 @@ extension NotificationDetailViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.getNotificationDetail(notificationId: owner.notificationId)
+                owner.trackAmplitudeNoticeDetailView(with: owner.notificationId)
             }.store(in: cancelBag)
         
         input.shortCutButtonTap
@@ -120,6 +121,17 @@ extension NotificationDetailViewModel {
         let calendar = Calendar.current
         return calendar.isDateInToday(date)
     }
+    
+    private func trackAmplitudeNoticeDetailView(with notificationId: String) {
+        guard let notification else { return }
+        AmplitudeInstance.shared.track(eventType: .viewNotificationDetail,
+                                       eventProperties: [
+            "notification_id": notificationId,
+            "open_method": notification.hasDeepLink ? "푸시" : "알림센터",
+            "contain_deeplink": notification.hasDeepLink
+        ])
+    }
+    
     private func trackAmplitudeShortcutButtonTapped(with notificationId: String) {
         AmplitudeInstance.shared.track(eventType: .clickShortcutButton, eventProperties: ["notification_id": notificationId])
     }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -70,6 +70,7 @@ extension NotificationListViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 output.filterList.send(owner.filterList)
+                AmplitudeInstance.shared.track(eventType: .viewNotificationList)
             }.store(in: cancelBag)
         
         input.requestNotifications

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -98,6 +98,7 @@ extension NotificationListViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.readAllNotifications()
+                AmplitudeInstance.shared.track(eventType: .clickReadAllButton)
             }.store(in: cancelBag)
         
         input.categoryCellTapped

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -92,6 +92,14 @@ extension NotificationListViewModel {
                 owner.onNotificationTap?(notification.notificationId)
                 owner.read(index: index)
                 output.notificationList.send(self.notifications)
+                AmplitudeInstance.shared.track(eventType: .clickNotificationItem,
+                                               eventProperties: [
+                                                "notification_id": notification.notificationId,
+                                                "send_timestamp": notification.createdAt,
+                                                "contents": notification.content ?? "",
+                                                "admin_category": notification.category ?? "",
+                                                "title": notification.title
+                                               ])
             }.store(in: cancelBag)
         
         input.readAllButtonTapped

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
@@ -34,8 +34,13 @@ public final class NotificationHandler: NSObject, UNUserNotificationCenterDelega
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
         let userInfo = response.notification.request.content.userInfo
         print("APNs 푸시 알림 페이로드: \(userInfo)")
-        
         guard let payload = NotificationPayload(dictionary: userInfo) else { return }
+        
+        AmplitudeInstance.shared.track(eventType: .receivedPush, eventProperties: ["notificationId": payload.id,
+                                                                                   "send_timeStamp": payload.sendAt,
+                                                                                   "title": payload.title,
+                                                                                   "contents": payload.content,
+                                                                                   "admin_category": payload.category ?? "없음"])
         guard payload.hasLink else {
             self.deepLink.send(makeComponentsForEmptyLink(notificationId: payload.id))
             return

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
@@ -27,6 +27,11 @@ public final class NotificationHandler: NSObject, UNUserNotificationCenterDelega
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
         print("APNs 푸시 알림 페이로드: \(userInfo)")
+        AmplitudeInstance.shared.track(eventType: .receivedPush, eventProperties: ["notificationId": payload.id,
+                                                                                   "send_timeStamp": payload.sendAt,
+                                                                                   "title": payload.title,
+                                                                                   "contents": payload.content,
+                                                                                   "admin_category": payload.category ?? "없음"])
         return([.badge, .banner, .list, .sound])
     }
     
@@ -36,11 +41,11 @@ public final class NotificationHandler: NSObject, UNUserNotificationCenterDelega
         print("APNs 푸시 알림 페이로드: \(userInfo)")
         guard let payload = NotificationPayload(dictionary: userInfo) else { return }
         
-        AmplitudeInstance.shared.track(eventType: .receivedPush, eventProperties: ["notificationId": payload.id,
-                                                                                   "send_timeStamp": payload.sendAt,
-                                                                                   "title": payload.title,
-                                                                                   "contents": payload.content,
-                                                                                   "admin_category": payload.category ?? "없음"])
+        AmplitudeInstance.shared.track(eventType: .clickPush, eventProperties: ["notificationId": payload.id,
+                                                                                "send_timeStamp": payload.sendAt,
+                                                                                "leadtime": "",
+                                                                                "contain_deeplink": payload.hasDeepLink,
+                                                                                "deeplink_url": payload.deepLink ?? "없음"])
         guard payload.hasLink else {
             self.deepLink.send(makeComponentsForEmptyLink(notificationId: payload.id))
             return

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationPayload.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationPayload.swift
@@ -12,6 +12,9 @@ import Sentry
 public struct NotificationPayload: Codable {
     public let aps: APS
     public let id: String
+    public let title: String
+    public let content: String
+    public let sendAt: String
     public let category: String?
     public let deepLink: String?
     public let webLink: String?


### PR DESCRIPTION
## 🌴 PR 요약
-  기획 명세에 따른 Amplitude 설치

🌱 작업한 브랜치
- feature/#408

## 🌱 PR Point
- 푸시 알림을 받았을 때
- 푸시 알림을 탭하여 열었을 때 
- 모든 알림을 읽음 처리했을 때 
- 알림 상세 화면 바로가기 눌렀을 때 
- 알림 상세 화면 조회할 때
- 특정 알림 숏컷을 탭할 때 
 - 특정 알림 숏컷을 조회할 때 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기존 프로젝트에서 Core 모듈에 Amplitude 트래킹 하는 코드가 있어서 해당 Enum에 추가해서 사용했습니다.
- 모듈별 Amplitude case를 생성하면 번거로울 것 같아서..!!!
```swift
/// 푸시 알림을 받았을 때 처리
 public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {}

/// 푸시 알림을 클릭했을 때    
@MainActor
public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {}
```
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #408 
