### PR TITLE
[Feat] #470 - 신규 홈뷰 - 대시보드, 캘린더 섹션 API 연동

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
@@ -56,12 +56,12 @@ public extension UILabel {
     /// - targerString에는 바꾸고자 하는 특정 문자열을 넣어주세요
     /// - font에는 targetString에 적용하고자 하는 UIFont를 넣어주세요
     /// - (선택) lineSpacing에 설정하고자 하는 행간의 크기를 넣어주세요
-    func partFontChange(targetString: String, font: UIFont, lineSpacing: CGFloat? = nil) {
+    func partFontChange(targetString: String, font: UIFont, lineSpacing: CGFloat = 0) {
         let fullText = self.text ?? ""
         let range = (fullText as NSString).range(of: targetString)
         let attributedString = NSMutableAttributedString(string: fullText)
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = lineSpacing ?? 0
+        paragraphStyle.lineSpacing = lineSpacing
         attributedString.addAttribute(.font, value: font, range: range)
         attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: fullText.count))
         self.attributedText = attributedString
@@ -78,18 +78,53 @@ public extension UILabel {
         self.attributedText = attributedString
     }
 
-    func htmlToString(_ targetString: String) -> NSAttributedString? {
+    /// 서버에서 받아온 string 값에서 html 태그를 적용해주는 함수
+    /// - targetString에는 특정 문자열을 넣어주세요
+    /// - defaultFont, defaultColor에는 기본 폰트와 컬러를 넣어주세요
+    func htmlToString(targetString: String,
+                      defaultFont: UIFont,
+                      defaultColor: UIColor) {
         let text = targetString
+        guard let data = text.data(using: .utf8) else { return }
         
-        guard let data = text.data(using: .utf8) else {
-            return NSAttributedString()
-        }
         do {
-            return try NSAttributedString(data: data,
-                                          options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
-                                          documentAttributes: nil)
-        } catch {
-            return NSAttributedString()
+            let attributedString = try NSMutableAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue],
+                documentAttributes: nil
+            )
+            let range = NSRange(location: 0, length: attributedString.length)
+            
+            attributedString.enumerateAttribute(.font, in: range, options: .longestEffectiveRangeNotRequired)
+            { value, range, _ in
+                let currentFont: UIFont = (value as? UIFont) ?? .init()
+                var replacementFont: UIFont?
+
+                // 기본 폰트 이름
+                let fontName = defaultFont.fontName.split(separator: "-").first ?? .init()
+                // 볼드 폰트
+                let boldFont = UIFont(name: String(fontName + "-" + "Bold"), size: defaultFont.pointSize) ?? .init()
+                
+                // 폰트 이름에 bold가 포함되어 있을 경우, 볼드체로 간주
+                if currentFont.fontName.contains("bold") || currentFont.fontName.contains("Bold") {
+                    replacementFont = boldFont
+                } else {
+                    replacementFont = defaultFont
+                }
+                
+                let replacingAttributedFont = [NSAttributedString.Key.font: replacementFont ?? .init()]
+                attributedString.addAttributes(replacingAttributedFont, range: range)
+            }
+            
+            attributedString.addAttributes([NSAttributedString.Key.foregroundColor: defaultColor],
+                                           range: range)
+            
+            self.attributedText = attributedString
+        
+        } catch let error {
+            print("htmlToString 변환 에러: ", error.localizedDescription)
         }
     }
     

--- a/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
@@ -55,14 +55,18 @@ public extension UILabel {
     /// 라벨 일부 font 변경해주는 함수
     /// - targerString에는 바꾸고자 하는 특정 문자열을 넣어주세요
     /// - font에는 targetString에 적용하고자 하는 UIFont를 넣어주세요
-    func partFontChange(targetString: String, font: UIFont) {
+    /// - (선택) lineSpacing에 설정하고자 하는 행간의 크기를 넣어주세요
+    func partFontChange(targetString: String, font: UIFont, lineSpacing: CGFloat? = nil) {
         let fullText = self.text ?? ""
         let range = (fullText as NSString).range(of: targetString)
         let attributedString = NSMutableAttributedString(string: fullText)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineSpacing ?? 0
         attributedString.addAttribute(.font, value: font, range: range)
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: fullText.count))
         self.attributedText = attributedString
     }
-    
+
     /// 라벨 일부 textColor 변경해주는 함수
     /// - targetString에는 바꾸고자 하는 특정 문자열을 넣어주세요
     /// - textColor에는 targetString에 적용하고자 하는 특정 UIColor에 넣어주세요
@@ -73,7 +77,7 @@ public extension UILabel {
         attributedString.addAttribute(.foregroundColor, value: textColor, range: range)
         self.attributedText = attributedString
     }
-    
+
     func htmlToString(_ targetString: String) -> NSAttributedString? {
         let text = targetString
         

--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -1,0 +1,28 @@
+//
+//  HomeRepository.swift
+//  Data
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+import Core
+import Domain
+import Networks
+
+public class HomeRepository {
+    
+    private let homeService: HomeService
+    
+    private let cancelBag = CancelBag()
+    
+    public init(homeService: HomeService) {
+        self.homeService = homeService
+    }
+}
+
+extension HomeRepository: HomeRepositoryInterface {
+
+}

--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -28,5 +28,15 @@ public class HomeRepository {
 }
 
 extension HomeRepository: HomeRepositoryInterface {
-
+    public func getHomeDescription() -> AnyPublisher<Domain.HomeDescriptionModel, any Error> {
+        homeService.getDescription()
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
+    
+    public func getRecentSchedule() -> AnyPublisher<Domain.HomeRecentScheduleModel, any Error> {
+        calendarService.getRecentSchedule()
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -15,11 +15,15 @@ import Networks
 public class HomeRepository {
     
     private let homeService: HomeService
+    private let calendarService: CalendarService
     
     private let cancelBag = CancelBag()
     
-    public init(homeService: HomeService) {
+    public init(homeService: HomeService,
+                calendarService: CalendarService
+    ) {
         self.homeService = homeService
+        self.calendarService = calendarService
     }
 }
 

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeDescriptionTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeDescriptionTransform.swift
@@ -1,0 +1,18 @@
+//
+//  HomeDescriptionTransform.swift
+//  Data
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension HomeDescriptionEntity {
+    public func toDomain() -> HomeDescriptionModel {
+        return HomeDescriptionModel.init(description: activityDescription)
+    }
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeRecentScheduleTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeRecentScheduleTransform.swift
@@ -1,0 +1,18 @@
+//
+//  HomeRecentScheduleTransform.swift
+//  Data
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension CalendarRecentEntity {
+    public func toDomain() -> HomeRecentScheduleModel {
+        return HomeRecentScheduleModel(date: date, type: type, title: title)
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -170,5 +170,14 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: HomeRepositoryInterface.self,
+            implement: {
+                HomeRepository(
+                    homeService: DefaultHomeService(),
+                    calendarService: DefaultCalendarService()
+                )
+            }
+        )
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeDescriptionModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeDescriptionModel.swift
@@ -1,0 +1,25 @@
+//
+//  HomeDescriptionModel.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+
+public struct HomeDescriptionModel {
+    public let description: String
+    
+    public init(description: String) {
+        self.description = description
+    }
+}
+
+extension HomeDescriptionModel {
+    public static var defaultDescription: Self {
+        return HomeDescriptionModel(description: I18N.Home.DashBoard.UserHistory.encourage)
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeRecentScheduleModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeRecentScheduleModel.swift
@@ -11,7 +11,7 @@ import Foundation
 import Core
 
 public struct HomeRecentScheduleModel: Codable {
-    public let date: String
+    public var date: String
     public let type: String
     public let title: String
     

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeRecentScheduleModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeRecentScheduleModel.swift
@@ -1,0 +1,23 @@
+//
+//  HomeRecentScheduleModel.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+
+public struct HomeRecentScheduleModel: Codable {
+    public let date: String
+    public let type: String
+    public let title: String
+    
+    public init(date: String, type: String, title: String) {
+        self.date = date
+        self.type = type
+        self.title = title
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -1,0 +1,15 @@
+//
+//  HomeRepositoryInterface.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+import Core
+
+public protocol HomeRepositoryInterface {
+    func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Error>
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -12,4 +12,5 @@ import Core
 
 public protocol HomeRepositoryInterface {
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Error>
+    func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -1,0 +1,56 @@
+//
+//  HomeUseCase.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+
+import Core
+
+public protocol HomeUseCase {
+    var homeDescription: PassthroughSubject<HomeDescriptionModel, Never> { get set }
+    var recentSchedule: PassthroughSubject<HomeRecentScheduleModel, Never> { get set }
+    
+    func getHomeDescription()
+    func getRecentSchedule()
+}
+
+public class DefaultHomeUseCase {
+    
+    private let repository: HomeRepositoryInterface
+    private let cancelBag = CancelBag()
+    
+    public var homeDescription = PassthroughSubject<HomeDescriptionModel, Never>()
+    public var recentSchedule = PassthroughSubject<HomeRecentScheduleModel, Never>()
+    
+    public init(repository: HomeRepositoryInterface) {
+        self.repository = repository
+    }
+}
+
+extension DefaultHomeUseCase: HomeUseCase {
+    public func getHomeDescription() {
+        repository.getHomeDescription()
+            .withUnretained(self)
+            .sink { event in
+                print("GetHomeDescription State: \(event)")
+            } receiveValue: { owner, description in
+                owner.homeDescription.send(description)
+            }
+            .store(in: cancelBag)
+    }
+    
+    public func getRecentSchedule() {
+        repository.getRecentSchedule()
+            .withUnretained(self)
+            .sink { event in
+                print("GetRecentSchedule State: \(event)")
+            } receiveValue: { owner, schedule in
+                owner.recentSchedule.send(schedule)
+            }
+            .store(in: cancelBag)
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import Domain
 import Core
 import DSKit
 
@@ -123,12 +124,16 @@ extension CalendarCardCVC {
 // MARK: - Methods
 
 extension CalendarCardCVC {
-    func configureCell(date: String, tagType: DashBoardCalenderCategoryTagType, title: String, userType: UserType) {
-        self.dateLabel.text = date
-        self.scheduleTitleLabel.text = title
-        self.scheduleCategoryTagView.setData(title: tagType.text,
-                                             titleColor: tagType.textColor,
-                                             backgroundColor: tagType.backgroundColor)
+    func configureCell(model: HomeRecentScheduleModel?,
+                       userType: UserType) {
+        guard let model = model else { return }
+        self.dateLabel.text = model.date
+        self.scheduleTitleLabel.text = model.title
+        if let tagType = DashBoardCalenderCategoryTagType(rawValue: model.type) {
+            self.scheduleCategoryTagView.setData(title: tagType.text,
+                                                 titleColor: tagType.textColor,
+                                                 backgroundColor: tagType.backgroundColor)
+        }
         self.attendanceButton.isHidden = userType == .visitor
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -81,7 +81,7 @@ extension DashBoardCardCVC {
 extension DashBoardCardCVC {
     func configureCell(userType: UserType, description: String?) {
         guard let description = description else { return }
-
+        
         switch userType {
         case .visitor:
             self.descriptionLabel.font = DSKitFontFamily.Suit.medium.font(size: 18)
@@ -90,39 +90,12 @@ extension DashBoardCardCVC {
             self.rightArrowWithCircleImageView.isHidden = true
         case .active, .inactive:
             self.descriptionLabel.text = description
-            setDescriptionLabel(description)
+            self.descriptionLabel.htmlToString(targetString: description,
+                                               defaultFont: DSKitFontFamily.Suit.medium.font(size: 18),
+                                               defaultColor: DSKitAsset.Colors.white100.color)
             self.rightArrowWithCircleImageView.isHidden = false
         }
         
         userHistoryView.setData(userType: userType, recentHistory: 35, allHistory: [35, 34, 33, 32, 31, 30, 29])
     }
-    
-    /// 볼드 태그로 감싸진 텍스트만 추출해서, 볼드 처리
-    func setDescriptionLabel(_ description: String) {
-        if description.isEmpty { return }
-        
-        do {
-            let pattern = "<b>(.*?)</b>"
-            let regex = try NSRegularExpression(pattern: pattern, options: [])
-            let range = NSRange(description.startIndex..., in: description)
-            let modifiedDescription = regex.stringByReplacingMatches(in: description, options: [], range: range, withTemplate: "$1")    // 태그가 삭제된 값
-            
-            self.descriptionLabel.text = modifiedDescription
-            
-            // 태그로 감싸진 값 탐색
-            let matches = regex.matches(in: description, options: [], range: NSRange(description.startIndex..., in: description))
-
-            for match in matches {
-                if let range = Range(match.range(at: 1), in: description) {
-                    let matchText = description[range]
-                    self.descriptionLabel.partFontChange(targetString: String(matchText),
-                                                         font: DSKitFontFamily.Suit.bold.font(size: 18),
-                                                         lineSpacing: 5)
-                }
-            }
-        } catch {
-            print("정규식 오류: \(error)")
-        }
-    }
-
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -15,12 +15,11 @@ final class DashBoardCardCVC: UICollectionViewCell {
     
     // MARK: - UI Components
         
-    private let descriptionLabel = UILabel().then {
+    private var descriptionLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.white100.color
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 18)
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 18)
         $0.numberOfLines = 2
         $0.textAlignment = .left
-        $0.setLineSpacing(lineSpacing: 4)
     }
     
     private let userHistoryView = UserHistoryView()
@@ -80,17 +79,50 @@ extension DashBoardCardCVC {
 // MARK: - Methods
 
 extension DashBoardCardCVC {
-    func configureCell(userType: UserType, description: String) {
+    func configureCell(userType: UserType, description: String?) {
+        guard let description = description else { return }
+
         switch userType {
         case .visitor:
+            self.descriptionLabel.font = DSKitFontFamily.Suit.medium.font(size: 18)
             self.descriptionLabel.text = I18N.Home.DashBoard.UserHistory.encourage
+            self.descriptionLabel.setLineSpacing(lineSpacing: 5)
             self.rightArrowWithCircleImageView.isHidden = true
         case .active, .inactive:
             self.descriptionLabel.text = description
+            setDescriptionLabel(description)
             self.rightArrowWithCircleImageView.isHidden = false
         }
         
-        self.descriptionLabel.setLineSpacing(lineSpacing: 5)
         userHistoryView.setData(userType: userType, recentHistory: 35, allHistory: [35, 34, 33, 32, 31, 30, 29])
     }
+    
+    /// 볼드 태그로 감싸진 텍스트만 추출해서, 볼드 처리
+    func setDescriptionLabel(_ description: String) {
+        if description.isEmpty { return }
+        
+        do {
+            let pattern = "<b>(.*?)</b>"
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let range = NSRange(description.startIndex..., in: description)
+            let modifiedDescription = regex.stringByReplacingMatches(in: description, options: [], range: range, withTemplate: "$1")    // 태그가 삭제된 값
+            
+            self.descriptionLabel.text = modifiedDescription
+            
+            // 태그로 감싸진 값 탐색
+            let matches = regex.matches(in: description, options: [], range: NSRange(description.startIndex..., in: description))
+
+            for match in matches {
+                if let range = Range(match.range(at: 1), in: description) {
+                    let matchText = description[range]
+                    self.descriptionLabel.partFontChange(targetString: String(matchText),
+                                                         font: DSKitFontFamily.Suit.bold.font(size: 18),
+                                                         lineSpacing: 5)
+                }
+            }
+        } catch {
+            print("정규식 오류: \(error)")
+        }
+    }
+
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -15,7 +15,7 @@ final class DashBoardCardCVC: UICollectionViewCell {
     
     // MARK: - UI Components
         
-    private let userInfoLabel = UILabel().then {
+    private let descriptionLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.white100.color
         $0.font = DSKitFontFamily.Suit.bold.font(size: 18)
         $0.numberOfLines = 2
@@ -52,18 +52,18 @@ extension DashBoardCardCVC {
     
     private func setLayout() {
         self.addSubviews(
-            userInfoLabel,
+            descriptionLabel,
             userHistoryView,
             rightArrowWithCircleImageView
         )
 
-        userInfoLabel.snp.makeConstraints { make in
+        descriptionLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(18)
             make.leading.equalToSuperview().inset(16)
         }
         
         userHistoryView.snp.makeConstraints { make in
-            make.top.equalTo(userInfoLabel.snp.bottom).offset(15)
+            make.top.equalTo(descriptionLabel.snp.bottom).offset(15)
             make.leading.equalToSuperview().inset(16)
             make.width.equalTo(250)
             make.height.equalTo(23)
@@ -80,17 +80,17 @@ extension DashBoardCardCVC {
 // MARK: - Methods
 
 extension DashBoardCardCVC {
-    func configureCell(userType: UserType) {
+    func configureCell(userType: UserType, description: String) {
         switch userType {
         case .visitor:
-            self.userInfoLabel.text = I18N.Home.DashBoard.UserHistory.encourage
+            self.descriptionLabel.text = I18N.Home.DashBoard.UserHistory.encourage
             self.rightArrowWithCircleImageView.isHidden = true
         case .active, .inactive:
-            self.userInfoLabel.text = "김솝트 님은\nSOPT와 N개월 째"
+            self.descriptionLabel.text = description
             self.rightArrowWithCircleImageView.isHidden = false
         }
         
-        self.userInfoLabel.setLineSpacing(lineSpacing: 5)
+        self.descriptionLabel.setLineSpacing(lineSpacing: 5)
         userHistoryView.setData(userType: userType, recentHistory: 35, allHistory: [35, 34, 33, 32, 31, 30, 29])
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/TagTypes/DashBoardCalenderCategoryTagType.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/TagTypes/DashBoardCalenderCategoryTagType.swift
@@ -11,9 +11,9 @@ import UIKit
 import Core
 import DSKit
 
-enum DashBoardCalenderCategoryTagType {
-    case event
-    case seminar
+enum DashBoardCalenderCategoryTagType: String {
+    case event = "EVENT"
+    case seminar = "SEMINAR"
     
     var text: String {
         switch self {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
@@ -11,18 +11,23 @@ import Domain
 @_exported import HomeFeatureInterface
 
 public final class HomeBuilder {
+    @Injected public var homeRepository: HomeRepositoryInterface
+    
     public init() {}
 }
 
 extension HomeBuilder: HomeFeatureBuildable {
+    
     public func makeHomeForMember() -> HomeForMemberPresentable {
-        let viewModel = HomeForMemberViewModel()
+        let useCase = DefaultHomeUseCase(repository: homeRepository)
+        let viewModel = HomeForMemberViewModel(useCase: useCase)
         let homeForMemberVC = HomeForMemberVC(viewModel: viewModel)
         return (homeForMemberVC, viewModel)
     }
     
     public func makeHomeForVisitor() -> HomeForVisitorPresentable {
-        let viewModel = HomeForVisitorViewModel()
+        let useCase = DefaultHomeUseCase(repository: homeRepository)
+        let viewModel = HomeForVisitorViewModel(useCase: useCase)
         let homeForVisitorVC = HomeForVisitorVC(viewModel: viewModel)
         return (homeForVisitorVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 import Core
 import Domain
@@ -19,6 +20,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     // MARK: - Properties
 
     public let viewModel: HomeForMemberViewModel
+    private var cancelBag = CancelBag()
 
     // MARK: - UI Components
     
@@ -85,6 +87,13 @@ extension HomeForMemberVC {
 // MARK: - Methods
 
 extension HomeForMemberVC {
+    private func bindViewModels() {
+        let input = HomeForMemberViewModel
+            .Input(viewDidLoad: Just<Void>(()).asDriver())
+        
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+    }
+    
     private func setDelegate() {
         self.collectionView.delegate = self
         self.collectionView.dataSource = self

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -52,6 +52,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        bindViewModels()
         setUI()
         setLayout()
         setDelegate()
@@ -92,6 +93,12 @@ extension HomeForMemberVC {
             .Input(viewDidLoad: Just<Void>(()).asDriver())
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.needToReload
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.collectionView.reloadData()
+            }.store(in: cancelBag)
     }
     
     private func setDelegate() {
@@ -199,7 +206,8 @@ extension HomeForMemberVC: UICollectionViewDataSource {
             guard let dashBoardCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: DashBoardCardCVC.className,
                                      for: indexPath) as? DashBoardCardCVC else { return UICollectionViewCell() }
-            dashBoardCardCell.configureCell(userType: .active)
+            dashBoardCardCell.configureCell(userType: viewModel.userType,
+                                            description: viewModel.homeDescription?.description)
             
             return dashBoardCardCell
             

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -216,10 +216,8 @@ extension HomeForMemberVC: UICollectionViewDataSource {
             guard let calendarCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: CalendarCardCVC.className,
                                      for: indexPath) as? CalendarCardCVC else { return UICollectionViewCell() }
-            calendarCardCell.configureCell(date: "10.22",
-                                           tagType: .event,
-                                           title: "1차 행사",
-                                           userType: .active)
+            calendarCardCell.configureCell(model: viewModel.recentSchedule,
+                                           userType: viewModel.userType)
             
             return calendarCardCell
             

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
@@ -147,7 +147,7 @@ extension HomeForVisitorVC: UICollectionViewDataSource {
             guard let dashBoardCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: DashBoardCardCVC.className,
                                      for: indexPath) as? DashBoardCardCVC else { return UICollectionViewCell() }
-            dashBoardCardCell.configureCell(userType: .visitor)
+            dashBoardCardCell.configureCell(userType: .visitor, description: "")
             
             return dashBoardCardCell
             

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -127,11 +127,16 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     // MARK: - Inputs
     
-    public struct Input { }
+    public struct Input {
+        let viewDidLoad: Driver<Void>
+    }
     
     // MARK: - Outputs
     
-    public struct Output { }
+    public struct Output {
+        let homeDescription = PassthroughSubject<HomeDescriptionModel, Never>()
+        let recentSchedule = PassthroughSubject<HomeRecentScheduleModel, Never>()
+    }
     
     // MARK: - initialization
     
@@ -143,6 +148,25 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
 extension HomeForMemberViewModel {
     public func transform(from input: Input, cancelBag: Core.CancelBag) -> Output {
         let output = Output()
+        self.bindOutput(output: output, cancelBag: cancelBag)
+        
+        input.viewDidLoad
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.useCase.getHomeDescription()
+                owner.useCase.getRecentSchedule()
+            }.store(in: cancelBag)
+        
         return output
+    }
+    
+    private func bindOutput(output: Output, cancelBag: CancelBag) {
+        useCase.homeDescription
+            .subscribe(output.homeDescription)
+            .store(in: cancelBag)
+        
+        useCase.recentSchedule
+            .subscribe(output.recentSchedule)
+            .store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -120,6 +120,11 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     let currentCardPage = PassthroughSubject<Int, Never>()
     
+    // MARK: - Properties
+
+    private let useCase: HomeUseCase
+    private var cancelBag = CancelBag()
+    
     // MARK: - Inputs
     
     public struct Input { }
@@ -130,7 +135,9 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     // MARK: - initialization
     
-    public init() { }
+    public init(useCase: HomeUseCase) {
+        self.useCase = useCase
+    }
 }
 
 extension HomeForMemberViewModel {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -125,6 +125,10 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     private let useCase: HomeUseCase
     private var cancelBag = CancelBag()
     
+    var userType: UserType = UserDefaultKeyList.Auth.getUserType()
+    var homeDescription: HomeDescriptionModel?
+    var recentSchedule: HomeRecentScheduleModel?
+    
     // MARK: - Inputs
     
     public struct Input {
@@ -134,8 +138,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     // MARK: - Outputs
     
     public struct Output {
-        let homeDescription = PassthroughSubject<HomeDescriptionModel, Never>()
-        let recentSchedule = PassthroughSubject<HomeRecentScheduleModel, Never>()
+        let needToReload = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - initialization
@@ -162,11 +165,18 @@ extension HomeForMemberViewModel {
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         useCase.homeDescription
-            .subscribe(output.homeDescription)
-            .store(in: cancelBag)
+            .withUnretained(self)
+            .sink { owner, description in
+                owner.homeDescription = description
+                output.needToReload.send()
+            }.store(in: cancelBag)
         
         useCase.recentSchedule
-            .subscribe(output.recentSchedule)
-            .store(in: cancelBag)
+            .withUnretained(self)
+            .sink { owner, schedule in
+                owner.recentSchedule = schedule
+                owner.recentSchedule?.date = setDateFormat(to: "MM.dd")
+                output.needToReload.send()
+            }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForVisitorViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForVisitorViewModel.swift
@@ -34,6 +34,11 @@ public class HomeForVisitorViewModel: HomeForVisitorViewModelType {
         AppServiceInfo(name: "솝탬프", imageURL: "https://images.mypetlife.co.kr/content/uploads/2018/12/09154907/cotton-tulear-2422612_1280.jpg", badgeText: "")
     ]
     
+    // MARK: - Properties
+
+    private let useCase: HomeUseCase
+    private var cancelBag = CancelBag()
+    
     // MARK: - Inputs
     
     public struct Input { }
@@ -44,7 +49,9 @@ public class HomeForVisitorViewModel: HomeForVisitorViewModelType {
     
     // MARK: - initialization
     
-    public init() { }
+    public init(useCase: HomeUseCase) {
+        self.useCase = useCase
+    }
 }
 
 extension HomeForVisitorViewModel {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/CalendarAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/CalendarAPI.swift
@@ -1,0 +1,42 @@
+//
+//  CalendarAPI.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+import Moya
+import Core
+
+public enum CalendarAPI {
+    case getRecentSchedule
+}
+
+extension CalendarAPI: BaseAPI {
+    public static var apiType: APIType = .calendar
+    
+    public var path: String {
+        switch self {
+        case .getRecentSchedule:
+            return "/recent"
+        }
+    }
+    
+    public var method: Moya.Method {
+        switch self {
+        case .getRecentSchedule:
+            return .get
+        }
+    }
+    
+    public var task: Moya.Task {
+        switch self {
+        case .getRecentSchedule:
+            return .requestPlain
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
@@ -1,0 +1,42 @@
+//
+//  HomeAPI.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+import Moya
+import Core
+
+public enum HomeAPI {
+    case getDescription
+}
+
+extension HomeAPI: BaseAPI {
+    public static var apiType: APIType = .home
+    
+    public var path: String {
+        switch self {
+        case .getDescription:
+            return "/description"
+        }
+    }
+    
+    public var method: Moya.Method {
+        switch self {
+        case .getDescription:
+            return .get
+        }
+    }
+    
+    public var task: Moya.Task {
+        switch self {
+        case .getDescription:
+            return .requestPlain
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CalendarRecentEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CalendarRecentEntity.swift
@@ -1,0 +1,15 @@
+//
+//  CalendarRecentEntity.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Entity
+
+public struct CalendarRecentEntity: Codable {
+    public let date, type, title: String
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeDescriptionEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeDescriptionEntity.swift
@@ -1,0 +1,15 @@
+//
+//  HomeDescriptionEntity.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Entity
+
+public struct HomeDescriptionEntity: Codable {
+    public let activityDescription: String
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
@@ -25,6 +25,7 @@ public enum APIType {
   case poke
   case s3
   case fortune
+  case home
 }
 
 public protocol BaseAPI: TargetType {
@@ -63,6 +64,8 @@ extension BaseAPI {
       base += "/s3"
     case .fortune:
       base += "/fortune"
+    case .home:
+      base += "/home"
     }
     
     guard let url = URL(string: base) else {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
@@ -26,6 +26,7 @@ public enum APIType {
   case s3
   case fortune
   case home
+  case calendar
 }
 
 public protocol BaseAPI: TargetType {
@@ -66,6 +67,8 @@ extension BaseAPI {
       base += "/fortune"
     case .home:
       base += "/home"
+    case .calendar:
+      base += "/calendar"
     }
     
     guard let url = URL(string: base) else {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CalendarService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CalendarService.swift
@@ -1,0 +1,24 @@
+//
+//  CalendarService.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Moya
+
+public typealias DefaultCalendarService = BaseService<CalendarAPI>
+
+public protocol CalendarService {
+    func getRecentSchedule() -> AnyPublisher<CalendarRecentEntity, Error>
+}
+
+extension DefaultCalendarService: CalendarService {
+    public func getRecentSchedule() -> AnyPublisher<CalendarRecentEntity, any Error> {
+        requestObjectInCombine(.getRecentSchedule)
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -1,0 +1,24 @@
+//
+//  HomeService.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/14/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Moya
+
+public typealias DefaultHomeService = BaseService<HomeAPI>
+
+public protocol HomeService {
+    func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
+}
+
+extension DefaultHomeService: HomeService {
+    public func getDescription() -> AnyPublisher<HomeDescriptionEntity, any Error> {
+        requestObjectInCombine(.getDescription)
+    }
+}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -170,5 +170,14 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: HomeRepositoryInterface.self,
+            implement: {
+                HomeRepository(
+                    homeService: DefaultHomeService(),
+                    calendarService: DefaultCalendarService()
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #470 

## 🌱 PR Point

신규 홈뷰의 대시보드, 캘린더 섹션에서의 API를 연동했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### **HomeDescription에서 Html 태그 처리**
- 서버에서 description에 "&lt;b&gt;이재현&lt;/b&gt;님은\nSOPT와 29개월째"와 같이, html 태그로 볼드가 필요한 부분을 명시해서 내려오고 있는데요.`NSAttributedString`로 변경하면 html 태그 정보를 그대로 적용할 수 있다고 알고 있었는데, 커스텀 폰트의 bold체를 인식하지 못하더라구요.. 
- 그래서 지금은 아래와 같이 **정규식을 활용해 볼드 부분만 추출**해서, 폰트를 바꾸어주는 방식을 사용하고 있는데요. 혹시 이 부분 더 현명한 방법으로 해결할 수 있을까요..? 👀 리뷰 부탁드립니다.. 

-> 남겨주신 코멘트 바탕으로 해결했습니다! https://github.com/sopt-makers/SOPT-iOS/pull/475#issuecomment-2599657373


```swift
/// 볼드 태그로 감싸진 텍스트만 추출해서, 볼드 처리
    func setDescriptionLabel(_ description: String) {
        if description.isEmpty { return }
        
        do {
            let pattern = "<b>(.*?)</b>"
            let regex = try NSRegularExpression(pattern: pattern, options: [])
            let range = NSRange(description.startIndex..., in: description)
            let modifiedDescription = regex.stringByReplacingMatches(in: description, options: [], range: range, withTemplate: "$1")    // 태그가 삭제된 값
            
            self.descriptionLabel.text = modifiedDescription
            
            // 태그로 감싸진 값 탐색
            let matches = regex.matches(in: description, options: [], range: NSRange(description.startIndex..., in: description))

            for match in matches {
                if let range = Range(match.range(at: 1), in: description) {
                    let matchText = description[range]
                    self.descriptionLabel.partFontChange(targetString: String(matchText),
                                                         font: DSKitFontFamily.Suit.bold.font(size: 18),
                                                         lineSpacing: 5)
                }
            }
        } catch {
            print("정규식 오류: \(error)")
        }
    }
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|대시보드, 캘린더 섹션|<img src="https://github.com/user-attachments/assets/58f17434-71a1-4ff8-9a10-f2091a81fd74" width = 300>|

## 📮 관련 이슈
- Resolved: #470 
