### PR TITLE
[Feat] #471 - 신규 홈뷰 - 앱 서비스, 인사이트 섹션 API 연동

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -28,6 +28,18 @@ public class HomeRepository {
 }
 
 extension HomeRepository: HomeRepositoryInterface {
+    public func getAppServices() -> AnyPublisher<[Domain.HomeAppServicesModel], any Error> {
+        homeService.getAppServiceAccessStatus()
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
+    
+    public func getInsightPosts() -> AnyPublisher<[Domain.HomeInsightPostsModel], any Error> {
+        homeService.getInsightPosts()
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
+    
     public func getHomeDescription() -> AnyPublisher<Domain.HomeDescriptionModel, any Error> {
         homeService.getDescription()
             .map { $0.toDomain() }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -30,13 +30,13 @@ public class HomeRepository {
 extension HomeRepository: HomeRepositoryInterface {
     public func getAppServices() -> AnyPublisher<[Domain.HomeAppServicesModel], any Error> {
         homeService.getAppServiceAccessStatus()
-            .map { $0.toDomain() }
+            .map { $0.map { $0.toDomain() } }
             .eraseToAnyPublisher()
     }
     
     public func getInsightPosts() -> AnyPublisher<[Domain.HomeInsightPostsModel], any Error> {
         homeService.getInsightPosts()
-            .map { $0.toDomain() }
+            .map { $0.map { $0.toDomain() } }
             .eraseToAnyPublisher()
     }
     

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
@@ -12,11 +12,11 @@ import Domain
 import Networks
 
 extension HomeAppServiceAccessStatusEntity {
-    public func toDomain() -> [HomeAppServicesModel] {
-        return [HomeAppServicesModel(serviceName: serviceName,
-                                     displayAlarmBadge: displayAlarmBadge,
-                                     alarmBadge: alarmBadge,
-                                     iconURL: iconURL,
-                                     deepLink: deepLink)]
+    public func toDomain() -> HomeAppServicesModel {
+        return HomeAppServicesModel(serviceName: serviceName,
+                                    displayAlarmBadge: displayAlarmBadge,
+                                    alarmBadge: alarmBadge,
+                                    iconURL: iconURL,
+                                    deepLink: deepLink)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
@@ -12,11 +12,11 @@ import Domain
 import Networks
 
 extension HomeAppServiceAccessStatusEntity {
-    public func toDomain() -> HomeAppServicesModel {
-        return HomeAppServicesModel(serviceName: serviceName,
-                                    displayAlarmBadge: displayAlarmBadge,
-                                    alarmBadge: alarmBadge,
-                                    iconURL: iconURL,
-                                    deepLink: deepLink)
+    public func toDomain() -> [HomeAppServicesModel] {
+        return [HomeAppServicesModel(serviceName: serviceName,
+                                     displayAlarmBadge: displayAlarmBadge,
+                                     alarmBadge: alarmBadge,
+                                     iconURL: iconURL,
+                                     deepLink: deepLink)]
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeAppServicesTransform.swift
@@ -1,0 +1,22 @@
+//
+//  HomeAppServicesTransform.swift
+//  Data
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension HomeAppServiceAccessStatusEntity {
+    public func toDomain() -> HomeAppServicesModel {
+        return HomeAppServicesModel(serviceName: serviceName,
+                                    displayAlarmBadge: displayAlarmBadge,
+                                    alarmBadge: alarmBadge,
+                                    iconURL: iconURL,
+                                    deepLink: deepLink)
+    }
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeInsightPostsTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeInsightPostsTransform.swift
@@ -12,7 +12,7 @@ import Domain
 import Networks
 
 extension HomeInsightPostsEntity {
-    public func toDomain() -> [HomeInsightPostsModel] {
-        return [HomeInsightPostsModel(id: id, title: title, category: category, content: content, isHotPost: isHotPost)]
+    public func toDomain() -> HomeInsightPostsModel {
+        return HomeInsightPostsModel(id: id, title: title, category: category, content: content, isHotPost: isHotPost)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeInsightPostsTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeInsightPostsTransform.swift
@@ -1,0 +1,18 @@
+//
+//  HomeInsightPostsTransform.swift
+//  Data
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension HomeInsightPostsEntity {
+    public func toDomain() -> [HomeInsightPostsModel] {
+        return [HomeInsightPostsModel(id: id, title: title, category: category, content: content, isHotPost: isHotPost)]
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeAppServicesModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeAppServicesModel.swift
@@ -1,0 +1,23 @@
+//
+//  HomeAppServicesModel.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct HomeAppServicesModel: Codable {
+    public var serviceName: String
+    public var displayAlarmBadge: Bool
+    public var alarmBadge, iconURL, deepLink: String
+    
+    public init(serviceName: String, displayAlarmBadge: Bool, alarmBadge: String, iconURL: String, deepLink: String) {
+        self.serviceName = serviceName
+        self.displayAlarmBadge = displayAlarmBadge
+        self.alarmBadge = alarmBadge
+        self.iconURL = iconURL
+        self.deepLink = deepLink
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeInsightPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeInsightPostsModel.swift
@@ -1,0 +1,30 @@
+//
+//  HomeInsightPostsModel.swift
+//  Domain
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+
+public struct HomeInsightPostsModel: Codable {
+    public var id: Int
+    public var title, category: String
+    public var profileImage: String?
+    public var name: String?
+    public var content: String
+    public var isHotPost: Bool
+    
+    public init(id: Int, title: String, category: String, profileImage: String? = nil, name: String? = nil, content: String, isHotPost: Bool) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.profileImage = profileImage
+        self.name = name
+        self.content = content
+        self.isHotPost = isHotPost
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeInsightPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeInsightPostsModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import Core
 
-public struct HomeInsightPostsModel: Codable {
+public struct HomeInsightPostsModel {
     public var id: Int
     public var title, category: String
     public var profileImage: String?

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -13,5 +13,6 @@ import Core
 public protocol HomeRepositoryInterface {
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Error>
     func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Error>
-    func getAppServices() -> AnyPublisher<HomeAppServicesModel, Error>
+    func getAppServices() -> AnyPublisher<[HomeAppServicesModel], Error>
+    func getInsightPosts() -> AnyPublisher<[HomeInsightPostsModel], Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -13,4 +13,5 @@ import Core
 public protocol HomeRepositoryInterface {
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Error>
     func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Error>
+    func getAppServices() -> AnyPublisher<HomeAppServicesModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -13,9 +13,11 @@ import Core
 public protocol HomeUseCase {
     var homeDescription: PassthroughSubject<HomeDescriptionModel, Never> { get set }
     var recentSchedule: PassthroughSubject<HomeRecentScheduleModel, Never> { get set }
+    var appServices: PassthroughSubject<HomeAppServicesModel, Never> { get set }
     
     func getHomeDescription()
     func getRecentSchedule()
+    func getAppServices()
 }
 
 public class DefaultHomeUseCase {
@@ -25,6 +27,7 @@ public class DefaultHomeUseCase {
     
     public var homeDescription = PassthroughSubject<HomeDescriptionModel, Never>()
     public var recentSchedule = PassthroughSubject<HomeRecentScheduleModel, Never>()
+    public var appServices = PassthroughSubject<HomeAppServicesModel, Never>()
     
     public init(repository: HomeRepositoryInterface) {
         self.repository = repository
@@ -50,6 +53,17 @@ extension DefaultHomeUseCase: HomeUseCase {
                 print("GetRecentSchedule State: \(event)")
             } receiveValue: { owner, schedule in
                 owner.recentSchedule.send(schedule)
+            }
+            .store(in: cancelBag)
+    }
+    
+    public func getAppServices() {
+        repository.getAppServices()
+            .withUnretained(self)
+            .sink { event in
+                print("GetAppServices State: \(event)")
+            } receiveValue: { owner, services in
+                owner.appServices.send(services)
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -13,11 +13,13 @@ import Core
 public protocol HomeUseCase {
     var homeDescription: PassthroughSubject<HomeDescriptionModel, Never> { get set }
     var recentSchedule: PassthroughSubject<HomeRecentScheduleModel, Never> { get set }
-    var appServices: PassthroughSubject<HomeAppServicesModel, Never> { get set }
+    var appServices: PassthroughSubject<[HomeAppServicesModel], Never> { get set }
+    var insightPosts: PassthroughSubject<[HomeInsightPostsModel], Never> { get set }
     
     func getHomeDescription()
     func getRecentSchedule()
     func getAppServices()
+    func getInsightPosts()
 }
 
 public class DefaultHomeUseCase {
@@ -27,7 +29,8 @@ public class DefaultHomeUseCase {
     
     public var homeDescription = PassthroughSubject<HomeDescriptionModel, Never>()
     public var recentSchedule = PassthroughSubject<HomeRecentScheduleModel, Never>()
-    public var appServices = PassthroughSubject<HomeAppServicesModel, Never>()
+    public var appServices = PassthroughSubject<[HomeAppServicesModel], Never>()
+    public var insightPosts = PassthroughSubject<[HomeInsightPostsModel], Never>()
     
     public init(repository: HomeRepositoryInterface) {
         self.repository = repository
@@ -64,6 +67,17 @@ extension DefaultHomeUseCase: HomeUseCase {
                 print("GetAppServices State: \(event)")
             } receiveValue: { owner, services in
                 owner.appServices.send(services)
+            }
+            .store(in: cancelBag)
+    }
+    
+    public func getInsightPosts() {
+        repository.getInsightPosts()
+            .withUnretained(self)
+            .sink { event in
+                print("GetInsightPosts State: \(event)")
+            } receiveValue: { owner, posts in
+                owner.insightPosts.send(posts)
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import Core
 import DSKit
+import Domain
 
 final class AppServiceCardCVC: UICollectionViewCell {
     
@@ -77,13 +78,15 @@ extension AppServiceCardCVC {
 // MARK: - Methods
 
 extension AppServiceCardCVC {
-    func configureCell(imageURL: String, name: String, badgeText: String) {
-        self.logoImageView.setImage(with: imageURL)
-        self.titleLabel.text = name
-        if badgeText.isEmpty {
+    func configureCell(model: HomeAppServicesModel?) {
+        guard let model = model else { return }
+        
+        self.logoImageView.setImage(with: model.iconURL)
+        self.titleLabel.text = model.serviceName
+        if model.alarmBadge.isEmpty {
             self.notificationBadgeView.isHidden = true
         } else {
-            self.notificationBadgeView.setData(with: badgeText)
+            self.notificationBadgeView.setData(with: model.alarmBadge)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
@@ -79,7 +79,7 @@ extension AppServiceCardCVC {
 
 extension AppServiceCardCVC {
     func configureCell(model: HomeAppServicesModel?) {
-        guard let model = model else { return }
+        guard let model else { return }
         
         self.logoImageView.setImage(with: model.iconURL)
         self.titleLabel.text = model.serviceName

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Insight/InsightCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Insight/InsightCardCVC.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import Domain
 import Core
 import DSKit
 
@@ -102,10 +103,15 @@ extension InsightCardCVC {
 // MARK: - Methods
 
 extension InsightCardCVC {
-    func configureCell(model: InsightInfo) {
-        self.categoryTagView.setData(with: model.category, isHotTag: model.isHotTag)
-        self.profileImageView.setImage(with: model.profileImageURL)
-        self.userNameLabel.text = model.userName
-        self.postTitleLabel.text = model.postTitle
+    func configureCell(model: HomeInsightPostsModel?) {
+        guard let model = model else { return }
+        self.categoryTagView.setData(with: model.category, isHotTag: model.isHotPost)
+        if let profileImage = model.profileImage {
+            self.profileImageView.setImage(with: profileImage)
+        }
+        if let name = model.name {
+            self.userNameLabel.text = name
+        }
+        self.postTitleLabel.text = model.title
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/HomeNotificationBadgeView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/HomeNotificationBadgeView.swift
@@ -53,6 +53,7 @@ extension HomeNotificationBadgeView {
         titleLabel.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(6)
             make.top.bottom.equalToSuperview().inset(3)
+            make.width.greaterThanOrEqualTo(8)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -188,7 +188,7 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .dashBoard: return 1
         case .calendar: return 1
         case .mainProduct: return viewModel.productInfoList.count
-        case .appService: return viewModel.appServiceInfoList.count
+        case .appService: return viewModel.appServices?.count ?? 0
         case .insight: return viewModel.insightInfoList.count
         case .group: return viewModel.groupInfoList.count
         case .coffeeChat: return viewModel.coffeeChatHostInfoList.count
@@ -236,13 +236,11 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .appService:
             /// 앱 서비스 카드 셀
             let appServiceIndex = indexPath.item
-            guard let appService = viewModel.appServiceInfoList[safe: appServiceIndex] else { return UICollectionViewCell() }
+            guard let appService = viewModel.appServices?[safe: appServiceIndex] else { return UICollectionViewCell() }
             guard let appServiceCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: AppServiceCardCVC.className,
                                      for: indexPath) as? AppServiceCardCVC else { return UICollectionViewCell() }
-            appServiceCardCell.configureCell(imageURL: appService.imageURL,
-                                             name: appService.name,
-                                             badgeText: appService.badgeText)
+            appServiceCardCell.configureCell(model: appService)
             
             return appServiceCardCell
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -201,7 +201,7 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .calendar: return 1
         case .mainProduct: return viewModel.productInfoList.count
         case .appService: return viewModel.appServices?.count ?? 0
-        case .insight: return viewModel.insightInfoList.count
+        case .insight: return viewModel.insightPosts != nil ? 1 : 0
         case .group: return viewModel.groupInfoList.count
         case .coffeeChat: return viewModel.coffeeChatHostInfoList.count
         case .announcement: return viewModel.announcementInfoList.count
@@ -259,7 +259,7 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .insight:
             /// 인사이트 카드 셀
             let insightIndex = indexPath.item
-            guard let insight = viewModel.insightInfoList[safe: insightIndex] else { return UICollectionViewCell() }
+            guard let insight = viewModel.insightPosts?[safe: 2] else { return UICollectionViewCell() }
             guard let insightCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: InsightCardCVC.className,
                                      for: indexPath) as? InsightCardCVC else { return UICollectionViewCell() }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -259,7 +259,7 @@ extension HomeForMemberVC: UICollectionViewDataSource {
         case .insight:
             /// 인사이트 카드 셀
             let insightIndex = indexPath.item
-            guard let insight = viewModel.insightPosts?[safe: 2] else { return UICollectionViewCell() }
+            guard let insight = viewModel.insightPosts?[safe: 0] else { return UICollectionViewCell() }
             guard let insightCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: InsightCardCVC.className,
                                      for: indexPath) as? InsightCardCVC else { return UICollectionViewCell() }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -97,8 +97,20 @@ extension HomeForMemberVC {
         output.needToReload
             .withUnretained(self)
             .sink { owner, _ in
-                owner.collectionView.reloadData()
+                owner.updateUI()
             }.store(in: cancelBag)
+    }
+    
+    private func updateUI() {
+        updateCollectionViewLayout()
+        let sectionCount = HomeForMemberSectionLayoutKind.allCases.count
+        let indexSet = IndexSet(integersIn: 0..<sectionCount)
+        self.collectionView.reloadSections(indexSet)
+    }
+    
+    private func updateCollectionViewLayout() {
+      let newLayout = createLayout()
+      self.collectionView.setCollectionViewLayout(newLayout, animated: true)
     }
     
     private func setDelegate() {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
@@ -170,9 +170,7 @@ extension HomeForVisitorVC: UICollectionViewDataSource {
             guard let appServiceCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: AppServiceCardCVC.className,
                                      for: indexPath) as? AppServiceCardCVC else { return UICollectionViewCell() }
-            appServiceCardCell.configureCell(imageURL: appService.imageURL,
-                                             name: appService.name,
-                                             badgeText: appService.badgeText)
+            appServiceCardCell.configureCell(model: HomeAppServicesModel(serviceName: "", displayAlarmBadge: false, alarmBadge: "", iconURL: "", deepLink: ""))
             
             return appServiceCardCell
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
@@ -170,7 +170,13 @@ extension HomeForVisitorVC: UICollectionViewDataSource {
             guard let appServiceCardCell = collectionView
                 .dequeueReusableCell(withReuseIdentifier: AppServiceCardCVC.className,
                                      for: indexPath) as? AppServiceCardCVC else { return UICollectionViewCell() }
-            appServiceCardCell.configureCell(model: HomeAppServicesModel(serviceName: "", displayAlarmBadge: false, alarmBadge: "", iconURL: "", deepLink: ""))
+            appServiceCardCell.configureCell(model: HomeAppServicesModel(
+                serviceName: "",
+                displayAlarmBadge: false,
+                alarmBadge: "",
+                iconURL: "",
+                deepLink: ""
+            ))
             
             return appServiceCardCell
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -122,6 +122,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     var homeDescription: HomeDescriptionModel?
     var recentSchedule: HomeRecentScheduleModel?
     var appServices: [HomeAppServicesModel]?
+    var insightPosts: [HomeInsightPostsModel]?
     
     // MARK: - Inputs
     
@@ -153,6 +154,7 @@ extension HomeForMemberViewModel {
                 owner.useCase.getHomeDescription()
                 owner.useCase.getRecentSchedule()
                 owner.useCase.getAppServices()
+                owner.useCase.getInsightPosts()
             }.store(in: cancelBag)
         
         return output
@@ -178,6 +180,13 @@ extension HomeForMemberViewModel {
             .withUnretained(self)
             .sink { owner, services in
                 owner.appServices = services
+                output.needToReload.send()
+            }.store(in: cancelBag)
+        
+        useCase.insightPosts
+            .withUnretained(self)
+            .sink { owner, posts in
+                owner.insightPosts = posts
                 output.needToReload.send()
             }.store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -80,14 +80,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
         ProductInfo(name: I18N.Home.MainProduct.member, image: DSKitAsset.Assets.imgMemberLogo.image),
         ProductInfo(name: I18N.Home.MainProduct.project, image: DSKitAsset.Assets.imgProjectLogo.image)
     ]
-    
-    // TODO: 서버 연결 필요
-    let appServiceInfoList: [AppServiceInfo] = [
-        AppServiceInfo(name: "콕찌르기", imageURL: "https://images.mypetlife.co.kr/content/uploads/2018/12/09154907/cotton-tulear-2422612_1280.jpg", badgeText: "3"),
-        AppServiceInfo(name: "솝마디", imageURL: "https://images.mypetlife.co.kr/content/uploads/2018/12/09154907/cotton-tulear-2422612_1280.jpg", badgeText: "N"),
-        AppServiceInfo(name: "솝탬프", imageURL: "https://images.mypetlife.co.kr/content/uploads/2018/12/09154907/cotton-tulear-2422612_1280.jpg", badgeText: "3위")
-    ]
-    
+
     // TODO: 서버 연결 필요
     let insightInfoList: [InsightInfo] = [
         InsightInfo(category: "SOPT활동", profileImageURL: "https://img.seoul.co.kr/img/upload/2023/06/13/SSC_20230613163553_O2.png", userName: "차은우", postTitle: "차은우가 솝트 기획으로 활동한 썰 푼다 최대글자수입니다람지렁이", isHotTag: false)
@@ -128,6 +121,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     var userType: UserType = UserDefaultKeyList.Auth.getUserType()
     var homeDescription: HomeDescriptionModel?
     var recentSchedule: HomeRecentScheduleModel?
+    var appServices: [HomeAppServicesModel]?
     
     // MARK: - Inputs
     
@@ -158,6 +152,7 @@ extension HomeForMemberViewModel {
             .sink { owner, _ in
                 owner.useCase.getHomeDescription()
                 owner.useCase.getRecentSchedule()
+                owner.useCase.getAppServices()
             }.store(in: cancelBag)
         
         return output
@@ -176,6 +171,13 @@ extension HomeForMemberViewModel {
             .sink { owner, schedule in
                 owner.recentSchedule = schedule
                 owner.recentSchedule?.date = setDateFormat(to: "MM.dd")
+                output.needToReload.send()
+            }.store(in: cancelBag)
+        
+        useCase.appServices
+            .withUnretained(self)
+            .sink { owner, services in
+                owner.appServices = services
                 output.needToReload.send()
             }.store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
@@ -15,6 +15,7 @@ import Core
 public enum HomeAPI {
     case getDescription
     case getAppServiceAccessStatus
+    case getInsightPosts
 }
 
 extension HomeAPI: BaseAPI {
@@ -26,19 +27,21 @@ extension HomeAPI: BaseAPI {
             return "/description"
         case .getAppServiceAccessStatus:
             return "/app-service"
+        case .getInsightPosts:
+            return "/posts"
         }
     }
     
     public var method: Moya.Method {
         switch self {
-        case .getDescription, .getAppServiceAccessStatus:
+        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts:
             return .get
         }
     }
     
     public var task: Moya.Task {
         switch self {
-        case .getDescription, .getAppServiceAccessStatus:
+        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts:
             return .requestPlain
         }
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
@@ -14,6 +14,7 @@ import Core
 
 public enum HomeAPI {
     case getDescription
+    case getAppServiceAccessStatus
 }
 
 extension HomeAPI: BaseAPI {
@@ -23,19 +24,21 @@ extension HomeAPI: BaseAPI {
         switch self {
         case .getDescription:
             return "/description"
+        case .getAppServiceAccessStatus:
+            return "/app-service"
         }
     }
     
     public var method: Moya.Method {
         switch self {
-        case .getDescription:
+        case .getDescription, .getAppServiceAccessStatus:
             return .get
         }
     }
     
     public var task: Moya.Task {
         switch self {
-        case .getDescription:
+        case .getDescription, .getAppServiceAccessStatus:
             return .requestPlain
         }
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeAppServiceAccessStatusEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeAppServiceAccessStatusEntity.swift
@@ -1,0 +1,23 @@
+//
+//  HomeAppServiceAccessStatusEntity.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Entity
+
+public struct HomeAppServiceAccessStatusEntity: Codable {
+    public let serviceName: String
+    public let displayAlarmBadge: Bool
+    public let alarmBadge, iconURL, deepLink: String
+
+    enum CodingKeys: String, CodingKey {
+        case serviceName, displayAlarmBadge, alarmBadge
+        case iconURL = "iconUrl"
+        case deepLink
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeInsightPostsEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeInsightPostsEntity.swift
@@ -1,0 +1,20 @@
+//
+//  HomeInsightPostsEntity.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 1/18/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Entity
+
+public struct HomeInsightPostsEntity: Codable {
+    public let id: Int
+    public let title, category: String
+    public let profileImage: String?
+    public let name: String?
+    public let content: String
+    public let isHotPost: Bool
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -15,8 +15,8 @@ public typealias DefaultHomeService = BaseService<HomeAPI>
 
 public protocol HomeService {
     func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
-    func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, Error>
-    func getInsightPosts() -> AnyPublisher<HomeInsightPostsEntity, Error>
+    func getAppServiceAccessStatus() -> AnyPublisher<[HomeAppServiceAccessStatusEntity], Error>
+    func getInsightPosts() -> AnyPublisher<[HomeInsightPostsEntity], Error>
 }
 
 extension DefaultHomeService: HomeService {
@@ -24,11 +24,11 @@ extension DefaultHomeService: HomeService {
         requestObjectInCombine(.getDescription)
     }
     
-    public func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, any Error> {
+    public func getAppServiceAccessStatus() -> AnyPublisher<[HomeAppServiceAccessStatusEntity], any Error> {
         requestObjectInCombine(.getAppServiceAccessStatus)
     }
     
-    public func getInsightPosts() -> AnyPublisher<HomeInsightPostsEntity, any Error> {
+    public func getInsightPosts() -> AnyPublisher<[HomeInsightPostsEntity], any Error> {
         requestObjectInCombine(.getInsightPosts)
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -16,6 +16,7 @@ public typealias DefaultHomeService = BaseService<HomeAPI>
 public protocol HomeService {
     func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
     func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, Error>
+    func getInsightPosts() -> AnyPublisher<HomeInsightPostsEntity, Error>
 }
 
 extension DefaultHomeService: HomeService {
@@ -25,5 +26,9 @@ extension DefaultHomeService: HomeService {
     
     public func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, any Error> {
         requestObjectInCombine(.getAppServiceAccessStatus)
+    }
+    
+    public func getInsightPosts() -> AnyPublisher<HomeInsightPostsEntity, any Error> {
+        requestObjectInCombine(.getInsightPosts)
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -15,10 +15,15 @@ public typealias DefaultHomeService = BaseService<HomeAPI>
 
 public protocol HomeService {
     func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
+    func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, Error>
 }
 
 extension DefaultHomeService: HomeService {
     public func getDescription() -> AnyPublisher<HomeDescriptionEntity, any Error> {
         requestObjectInCombine(.getDescription)
+    }
+    
+    public func getAppServiceAccessStatus() -> AnyPublisher<HomeAppServiceAccessStatusEntity, any Error> {
+        requestObjectInCombine(.getAppServiceAccessStatus)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #471 

## 🌱 PR Point

신규 홈뷰의 앱 서비스, 인사이트 섹션에서의 API를 연동했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 인사이트 섹션에서 시간차를 두고, 화면에 보여지는 게시물이 달라져야 하는데 그 부분은 추후 구현하겠습니다.
- 일단은 index가 0인 게시물을 정적으로 보여주고 있습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|앱 서비스, 인사이트 섹션|<img  src="https://github.com/user-attachments/assets/311ab644-ddce-48d0-9668-bf450f5bfa98" width = 300>|


## 📮 관련 이슈
- Resolved: #471 
