### PR TITLE
[Feat] #477 - 솝트로그 API 연동 및 화면전환 구현

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -298,6 +298,11 @@ public struct I18N {
         public static let navigationTitle = "솝트로그"
         public static let editProfile = "프로필 수정"
         public static let enrollIntroduce = "프로필 수정에서 한 줄 소개 등록해보세요!"
+        public static let dailyFortuneButton = "바로 확인하기"
+        public static let soptlevel = "솝레벨"
+        public static let poke = "콕찌르기"
+        public static let soptamp = "솝탬프"
+        public static let withSopt = "솝트와"
     }
     
     public struct Attendance {

--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
@@ -1,0 +1,28 @@
+//
+//  SoptlogRepository.swift
+//  Data
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+import Domain
+import Networks
+
+public class SoptlogRepository {
+    
+    private let homeService: HomeService
+    
+    private let cancelBag = CancelBag()
+    
+    public init(homeService: HomeService) {
+        self.homeService = homeService
+    }
+}
+
+extension SoptlogRepository: SoptlogRepositoryInterface {
+    
+}

--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
-import Foundation
+import Combine
 
 import Core
 import Domain
@@ -14,15 +14,19 @@ import Networks
 
 public class SoptlogRepository {
     
-    private let homeService: HomeService
+    private let userService: UserService
     
     private let cancelBag = CancelBag()
     
-    public init(homeService: HomeService) {
-        self.homeService = homeService
+    public init(userService: UserService) {
+        self.userService = userService
     }
 }
 
 extension SoptlogRepository: SoptlogRepositoryInterface {
-    
+    public func fetchSoptlogModel() -> AnyPublisher<Domain.SoptlogModel, any Error> {
+        return self.userService.fetchSoptlogInfo()
+            .map{ $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
@@ -1,0 +1,9 @@
+//
+//  SoptlogTransform.swift
+//  Data
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
@@ -7,3 +7,23 @@
 //
 
 import Foundation
+
+import Domain
+import Networks
+
+extension SoptlogResponseEntity {
+    public func toDomain() -> SoptlogModel {
+        return SoptlogModel.init(userName: self.userName,
+                                 profileImage: self.profileImage,
+                                 part: self.part,
+                                 soptampRank: self.soptampRank ?? "0",
+                                 pokeCount: self.pokeCount,
+                                 soptLevel: self.soptLevel,
+                                 during: self.during ?? 0,
+                                 profileMessage: self.profileMessage,
+                                 icons: self.icons,
+                                 isFortuneChecked: self.isFortuneChecked,
+                                 todayFortuneText: self.todayFortuneText,
+                                 isActive: self.isActive)
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -179,5 +179,11 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: SoptlogRepositoryInterface.self,
+            implement: {
+                SoptlogRepository(userService: DefaultUserService())
+            }
+        )
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -7,3 +7,33 @@
 //
 
 import Foundation
+
+public struct  SoptlogModel {
+    public let userName: String
+    public let profileImage: String
+    public let part: String
+    public let soptampRank: String
+    public let pokeCount: String
+    public let soptLevel: String
+    public let during: Int
+    public let profileMessage: String
+    public let icons: [String]
+    public let isFortuneChecked: Bool
+    public let todayFortuneText: String
+    public let isActive: Bool
+    
+    public init(userName: String, profileImage: String, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+        self.userName = userName
+        self.profileImage = profileImage
+        self.part = part
+        self.soptampRank = soptampRank
+        self.pokeCount = pokeCount
+        self.soptLevel = soptLevel
+        self.during = during
+        self.profileMessage = profileMessage
+        self.icons = icons
+        self.isFortuneChecked = isFortuneChecked
+        self.todayFortuneText = todayFortuneText
+        self.isActive = isActive
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct  SoptlogModel {
-    public let userName: String
-    public let profileImage: String
+    public let userName: String?
+    public let profileImage: String?
     public let part: String
     public let soptampRank: String
     public let pokeCount: String
@@ -22,7 +22,7 @@ public struct  SoptlogModel {
     public let todayFortuneText: String
     public let isActive: Bool
     
-    public init(userName: String, profileImage: String, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+    public init(userName: String?, profileImage: String?, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
         self.userName = userName
         self.profileImage = profileImage
         self.part = part

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -1,0 +1,9 @@
+//
+//  SoptlogModel.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
@@ -6,4 +6,10 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
-import Foundation
+import Combine
+
+import Core
+
+public protocol SoptlogRepositoryInterface {
+    func fetchSoptlogModel() -> AnyPublisher<SoptlogModel, Error>
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
@@ -1,0 +1,9 @@
+//
+//  SoptlogRepositoryInterface.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
@@ -1,0 +1,9 @@
+//
+//  SoptlogUseCase.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
@@ -6,4 +6,31 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
-import Foundation
+import Combine
+
+import Core
+
+public protocol SoptlogUseCase {
+    func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, Never>
+}
+
+public class DefaultSoptlogUseCase: SoptlogUseCase {
+    
+    private let repository: SoptlogRepositoryInterface
+    private let cancelBag = CancelBag()
+    
+    public init(repository: SoptlogRepositoryInterface) {
+        self.repository = repository
+    }
+}
+
+extension DefaultSoptlogUseCase {
+    public func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, Never> {
+        self.repository.fetchSoptlogModel()
+            .catch { error in
+                print("Error: \(error)")
+                return Empty<SoptlogModel, Never>()
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
@@ -24,7 +24,7 @@ extension HomeBuilder: HomeFeatureBuildable {
         let homeForMemberVC = HomeForMemberVC(viewModel: viewModel)
         return (homeForMemberVC, viewModel)
     }
-    
+     
     public func makeHomeForVisitor() -> HomeForVisitorPresentable {
         let useCase = DefaultHomeUseCase(repository: homeRepository)
         let viewModel = HomeForVisitorViewModel(useCase: useCase)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeBuilder.swift
@@ -33,6 +33,7 @@ extension HomeBuilder: HomeFeatureBuildable {
     }
     
     public func makeHomeCalendarDetail() -> HomeCalendarDetailPresentable {
+        let useCase = DefaultHomeUseCase(repository: homeRepository)
         let viewModel = HomeCalendarDetailViewModel()
         let homeCalendarDetailVC = HomeCalendarDetailVC(viewModel: viewModel)
         return (homeCalendarDetailVC, viewModel)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -60,4 +60,3 @@ public final class HomeCoordinator: DefaultCoordinator {
         router.replaceRootWindow(homeForVisitor.vc, withAnimation: true)
     }
 }
-

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -21,6 +21,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
 
     public let viewModel: HomeForMemberViewModel
     private var cancelBag = CancelBag()
+    private var cellTapped = PassthroughSubject<IndexPath, Never>()
 
     // MARK: - UI Components
     
@@ -57,7 +58,6 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         setLayout()
         setDelegate()
         registerCells()
-        bindViewModels()
     }
 }
 
@@ -91,7 +91,9 @@ extension HomeForMemberVC {
 extension HomeForMemberVC {
     private func bindViewModels() {
         let input = HomeForMemberViewModel
-            .Input(viewDidLoad: Just<Void>(()).asDriver())
+            .Input(
+                cellTapped: cellTapped.asDriver(), 
+                viewDidLoad: Just<Void>(()).asDriver())
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
@@ -137,14 +139,6 @@ extension HomeForMemberVC {
                                      withReuseIdentifier: AnnouncementPageContolFooterView.className)
         self.collectionView.register(SocialLinkCardCVC.self,
                                      forCellWithReuseIdentifier: SocialLinkCardCVC.className)
-    }
-    
-    private func bindViewModels() {
-        let input = HomeForMemberViewModel.Input(
-            cellTapped: cellTapped.asDriver()
-        )
-        
-        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -132,6 +132,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     // MARK: - Inputs
     
     public struct Input {
+        let cellTapped: Driver<IndexPath>
         let viewDidLoad: Driver<Void>
     }
     
@@ -164,6 +165,14 @@ extension HomeForMemberViewModel {
                 owner.useCase.getHomeDescription()
                 owner.useCase.getRecentSchedule()
             }.store(in: cancelBag)
+        
+        input.cellTapped
+            .filter{ $0.section == 1 }
+            .withUnretained(self)
+            .sink(receiveValue: { owner, indexPath in
+                self.onDashBoardCellTapped?()
+            })
+            .store(in: cancelBag)
         
         return output
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -170,7 +170,7 @@ extension HomeForMemberViewModel {
             .filter{ $0.section == 1 }
             .withUnretained(self)
             .sink(receiveValue: { owner, indexPath in
-                self.onDashBoardCellTapped?()
+                owner.onDashBoardCellTapped?()
             })
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -403,6 +403,10 @@ extension ApplicationCoordinator {
             self?.removeDependency(coordinator)
         }
         
+        coordinator.requestCoordinating = { [weak self] in
+            self?.runDailySoptuneFlow()
+        }
+        
         addDependency(coordinator)
         coordinator.start()
         

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -13,7 +13,9 @@ import Core
 
 public protocol SoptlogViewControllable: ViewControllable { }
 public protocol SoptlogCoordinatable {
-    
+    var onNaviBackButtonTap: (() -> Void)? { get set }
+    var onProfileEditTapped: (() -> Void)? { get set }
+    var onAlarmTapped: (() -> Void)? { get set }
 }
 public typealias SoptlogViewModelType = ViewModelType & SoptlogCoordinatable
 public typealias SoptlogPresentable = (vc: SoptlogViewControllable, vm: any SoptlogViewModelType)

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/EditProfileCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/EditProfileCVC.swift
@@ -37,6 +37,7 @@ final class EditProfileCVC: UICollectionViewCell {
 extension EditProfileCVC {
     private func setUI() {
         contentView.backgroundColor = .clear
+        editProfileButton.isEnabled = false
     }
     
     private func setLayout() {

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/IntroduceCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/IntroduceCVC.swift
@@ -55,6 +55,7 @@ extension IntroduceCVC {
 
 extension IntroduceCVC {
     func configureCell(model: SoptlogPresentationModel.Introduce?) {
-        introduceLabel.text = model?.profileMessage.count == 0 ? "프로필 수정에서 한 줄 소개 등록해보세요!" : model?.profileMessage
+        guard let model else { return }
+        introduceLabel.text = model.profileMessage.count == 0 ? I18N.Soptlog.enrollIntroduce : model.profileMessage
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/IntroduceCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/IntroduceCVC.swift
@@ -54,7 +54,7 @@ extension IntroduceCVC {
 // MARK: - Methods
 
 extension IntroduceCVC {
-    func configureCell(_ text: String) {
-        introduceLabel.text = text
+    func configureCell(model: SoptlogPresentationModel.Introduce?) {
+        introduceLabel.text = model?.profileMessage.count == 0 ? "프로필 수정에서 한 줄 소개 등록해보세요!" : model?.profileMessage
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
@@ -26,7 +26,7 @@ final class SoptlogAlarmCVC: UICollectionViewCell {
     }
     
     private let subTitleLabel = UILabel().then {
-        $0.text = "바로 확인하기"
+        $0.text = I18N.Soptlog.dailyFortuneButton
         $0.textColor = DSKitAsset.Colors.gray200.color
         $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
     }
@@ -88,6 +88,7 @@ extension SoptlogAlarmCVC {
 
 extension SoptlogAlarmCVC {
     func configureCell(model: SoptlogPresentationModel.Alarm?) {
-        self.titleLabel.text = model?.todayFortuneText
+        guard let model else { return }
+        self.titleLabel.text = model.todayFortuneText
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
@@ -15,17 +15,18 @@ final class SoptlogAlarmCVC: UICollectionViewCell {
     
     // MARK: - UI Components
     
-    private let serviceImageView = UIImageView()
+    private let serviceImageView = UIImageView().then {
+        $0.image = DSKitAsset.Assets.imgDailysoptune.image
+    }
 
     private let titleLabel = UILabel().then {
-        $0.text = "차은우님, 잊지 말아야 할 말을 듣게 될 거예요"
         $0.numberOfLines = 1
         $0.textColor = DSKitAsset.Colors.white.color
         $0.font = DSKitFontFamily.Suit.bold.font(size: 18)
     }
     
     private let subTitleLabel = UILabel().then {
-        $0.text = "오늘의 솝마디"
+        $0.text = "바로 확인하기"
         $0.textColor = DSKitAsset.Colors.gray200.color
         $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
     }
@@ -53,7 +54,6 @@ final class SoptlogAlarmCVC: UICollectionViewCell {
 extension SoptlogAlarmCVC {
     private func setUI() {
         contentView.backgroundColor = DSKitAsset.Colors.gray800.color
-        serviceImageView.image = DSKitAsset.Assets.soptampLogo.image
     }
     
     private func setLayout() {
@@ -87,9 +87,7 @@ extension SoptlogAlarmCVC {
 // MARK: - Methods
 
 extension SoptlogAlarmCVC {
-    func configureCell(model: SoptlogAlarmInfo) {
-        self.titleLabel.text = model.title
-        self.serviceImageView.setImage(with: model.imageURL)
-        self.subTitleLabel.text = model.subTitle
+    func configureCell(model: SoptlogPresentationModel.Alarm?) {
+        self.titleLabel.text = model?.todayFortuneText
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
@@ -74,8 +74,9 @@ extension SoptlogAppServiceCVC {
 
 extension SoptlogAppServiceCVC {
     func configureCell(model: SoptlogPresentationModel.AppService?) {
-        self.serviceLabel.text = model?.serviceName
-        self.serviceValue.text = model?.serviceValue
-        self.serviceImageView.setImage(with: model?.serviceImageURL ?? "")
+        guard let model else { return }
+        self.serviceLabel.text = model.serviceName
+        self.serviceValue.text = model.serviceValue
+        self.serviceImageView.setImage(with: model.serviceImageURL)
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
@@ -73,9 +73,9 @@ extension SoptlogAppServiceCVC {
 // MARK: - Methods
 
 extension SoptlogAppServiceCVC {
-    func configureCell(model: AppServiceInfo) {
-        self.serviceLabel.text = model.serviceName
-        self.serviceValue.text = model.serviceValue
-        self.serviceImageView.setImage(with: model.serviceImageURL)
+    func configureCell(model: SoptlogPresentationModel.AppService?) {
+        self.serviceLabel.text = model?.serviceName
+        self.serviceValue.text = model?.serviceValue
+        self.serviceImageView.setImage(with: model?.serviceImageURL ?? "")
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogHeaderView.swift
@@ -20,18 +20,16 @@ final class SoptlogHeaderView: UICollectionReusableView {
     private let nameLabel = UILabel().then {
         $0.font = DSKitFontFamily.Suit.bold.font(size: 20)
         $0.textColor = DSKitAsset.Colors.white.color
-        $0.text = "차은우"
     }
     
     private let partLabel = UILabel().then {
         $0.font = DSKitFontFamily.Suit.medium.font(size: 12)
         $0.textColor = DSKitAsset.Colors.gray100.color
-        $0.text = "디자인/기획"
     }
     
     private let labelStackView = UIStackView().then {
         $0.axis = .vertical
-        $0.spacing = 2
+        $0.spacing = 7
     }
     
     // MARK: - init
@@ -77,9 +75,9 @@ extension SoptlogHeaderView {
 // MARK: - Methods
 
 extension SoptlogHeaderView {
-    func setData(model: ProfileInfo) {
-        self.nameLabel.text = model.name
-        self.partLabel.text = model.part
-        self.profileImageView.setImage(with: model.profileImageURL)
+    func setData(model: SoptlogPresentationModel.Profile?) {
+        self.nameLabel.text = model?.userName
+        self.partLabel.text = model?.part
+        self.profileImageView.setImage(with: model?.profileImage ?? "")
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogHeaderView.swift
@@ -76,8 +76,9 @@ extension SoptlogHeaderView {
 
 extension SoptlogHeaderView {
     func setData(model: SoptlogPresentationModel.Profile?) {
-        self.nameLabel.text = model?.userName
-        self.partLabel.text = model?.part
-        self.profileImageView.setImage(with: model?.profileImage ?? "")
+        guard let model else { return }
+        self.nameLabel.text = model.userName
+        self.partLabel.text = model.part
+        self.profileImageView.setImage(with: model.profileImage ?? "")
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogBuilder.swift
@@ -11,12 +11,15 @@ import Domain
 @_exported import SoptlogFeatureInterface
 
 public final class SoptlogBuilder {
+    @Injected public var soptlogReposiotry: SoptlogRepositoryInterface
+    
     public init() {}
 }
 
 extension SoptlogBuilder: SoptlogFeatureBuildable {
     public func makeSoptlog() -> SoptlogPresentable {
-        let viewModel = SoptlogViewModel()
+        let useCase = DefaultSoptlogUseCase(repository: soptlogReposiotry)
+        let viewModel = SoptlogViewModel(useCase: useCase)
         let soptlogVC = SoptlogVC(viewModel: viewModel)
         return (soptlogVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -14,6 +14,7 @@ import Domain
 
 import BaseFeatureDependency
 import SoptlogFeatureInterface
+import WebFeature
 
 public final class SoptlogCoordinator: DefaultCoordinator {
     
@@ -35,6 +36,18 @@ public final class SoptlogCoordinator: DefaultCoordinator {
     
     private func showSoptlog() {
         var soptlog = factory.makeSoptlog()
+        
+        soptlog.vm.onNaviBackButtonTap = { [weak self] in
+            self?.router.popModule()
+            self?.finishFlow?()
+        }
+        
+        soptlog.vm.onProfileEditTapped = { [weak self] in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/edit") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.rootController?.pushViewController(webView, animated: true)
+        }
         
         self.rootController = soptlog.vc.asNavigationController
         self.router.present(self.rootController, animated: true, modalPresentationSytle: .overFullScreen)

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -18,6 +18,7 @@ import WebFeature
 
 public final class SoptlogCoordinator: DefaultCoordinator {
     
+    public var requestCoordinating: (() -> Void)?
     public var finishFlow: (() -> Void)?
     
     private let factory: SoptlogFeatureBuildable
@@ -50,8 +51,7 @@ public final class SoptlogCoordinator: DefaultCoordinator {
         }
         
         soptlog.vm.onAlarmTapped = { [weak self] in
-            
-            
+            self?.requestCoordinating?()
         }
         
         self.rootController = soptlog.vc.asNavigationController

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -46,10 +46,15 @@ public final class SoptlogCoordinator: DefaultCoordinator {
             guard let url = URL(string: "\(ExternalURL.Playground.main)/members/edit") else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.rootController?.pushViewController(webView, animated: true)
+            self?.router.push(webView)
+        }
+        
+        soptlog.vm.onAlarmTapped = { [weak self] in
+            
+            
         }
         
         self.rootController = soptlog.vc.asNavigationController
-        self.router.present(self.rootController, animated: true, modalPresentationSytle: .overFullScreen)
+        self.router.push(soptlog.vc)
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -15,8 +15,8 @@ struct SoptlogPresentationModel {
     let alarm: Alarm
     
     struct Profile {
-        let userName: String
-        let profileImage: String
+        let userName: String?
+        let profileImage: String?
         let part: String
     }
     

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -7,3 +7,31 @@
 //
 
 import Foundation
+
+struct SoptlogPresentationModel {
+    let profile: Profile
+    let introduce: Introduce
+    let appService: [AppService]
+    let alarm: Alarm
+    
+    struct Profile {
+        let userName: String
+        let profileImage: String
+        let part: String
+    }
+    
+    struct Introduce {
+        let profileMessage: String
+    }
+
+    struct AppService {
+        let serviceName: String
+        let serviceImageURL: String
+        let serviceValue: String
+    }
+
+    struct Alarm {
+        let isFortuneChecked: Bool
+        let todayFortuneText: String
+    }
+}

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -1,0 +1,9 @@
+//
+//  SoptlogPresentationModel.swift
+//  SoptlogFeatureTests
+//
+//  Created by 강윤서 on 1/20/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -108,6 +108,7 @@ extension SoptlogVC {
     private func bindViewModels() {
         let input = SoptlogViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
+            naviBackButtonTap: self.naviBar.leftButtonTapped.asDriver(),
             cellTap: cellTap.asDriver())
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Combine
 
 import Core
 import Domain
@@ -19,6 +20,10 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     // MARK: - Properties
 
     public let viewModel: SoptlogViewModel
+    private let cancelBag = CancelBag()
+    private var cellTap = PassthroughSubject<IndexPath, Never>()
+    
+    private var soptlogInfo: SoptlogPresentationModel?
     
     // MARK: - UI Components
     
@@ -52,6 +57,7 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
         setLayout()
         setDelegate()
         registerCells()
+        bindViewModels()
     }
 }
 
@@ -98,6 +104,22 @@ extension SoptlogVC {
         self.collectionView.register(SoptlogAlarmCVC.self,
                                      forCellWithReuseIdentifier: SoptlogAlarmCVC.className)
     }
+    
+    private func bindViewModels() {
+        let input = SoptlogViewModel.Input(
+            viewDidLoad: Just<Void>(()).asDriver(),
+            cellTap: cellTap.asDriver())
+        
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        output.soptlogInfo
+            .withUnretained(self)
+            .subscribe(on: DispatchQueue.main)
+            .sink { owner, soptlogModel in
+                owner.soptlogInfo = soptlogModel
+                owner.collectionView.reloadData()
+            }.store(in: cancelBag)
+    }
 }
 
 // MARK: - UICollectionViewDelegate
@@ -109,11 +131,15 @@ extension SoptlogVC: UICollectionViewDelegate {
 // MARK: - UICollectionViewDataSource
 
 extension SoptlogVC: UICollectionViewDataSource {
-    public func numberOfSections(in collectionView: UICollectionView) -> Int {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        cellTap.send(indexPath)
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
         return SoptlogSectionLayoutKind.allCases.count
     }
         
-    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         guard kind == UICollectionView.elementKindSectionHeader else { return UICollectionReusableView() }
         guard let sectionKind = SoptlogSectionLayoutKind(rawValue: indexPath.section) else { return UICollectionReusableView() }
         
@@ -123,14 +149,14 @@ extension SoptlogVC: UICollectionViewDataSource {
                 ofKind: kind,
                 withReuseIdentifier: SoptlogHeaderView.className,
                 for: indexPath) as? SoptlogHeaderView else { return UICollectionReusableView() }
-            headerView.setData(model: viewModel.profileInfoList[indexPath.item])
+            headerView.setData(model: self.soptlogInfo?.profile)
             return headerView
         default:
             return UICollectionReusableView()
         }
     }
     
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         guard let sectionKind = SoptlogSectionLayoutKind(rawValue: section) else { return 0 }
         
         switch sectionKind {
@@ -142,7 +168,7 @@ extension SoptlogVC: UICollectionViewDataSource {
         }
     }
     
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let sectionKind = SoptlogSectionLayoutKind(rawValue: indexPath.section) else { return UICollectionViewCell() }
         
         switch sectionKind {
@@ -151,7 +177,7 @@ extension SoptlogVC: UICollectionViewDataSource {
             guard let introduceCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: IntroduceCVC.className,
                 for: indexPath) as? IntroduceCVC else { return UICollectionViewCell() }
-            introduceCell.configureCell(viewModel.profileInfoList[indexPath.item].introduce)
+            introduceCell.configureCell(model: self.soptlogInfo?.introduce)
             return introduceCell
             
         case .appService:
@@ -159,7 +185,7 @@ extension SoptlogVC: UICollectionViewDataSource {
             guard let appServiceCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: SoptlogAppServiceCVC.className,
                 for: indexPath) as? SoptlogAppServiceCVC else { return UICollectionViewCell() }
-            appServiceCell.configureCell(model: viewModel.appServiceInfoList[indexPath.item])
+            appServiceCell.configureCell(model: self.soptlogInfo?.appService[indexPath.row])
             return appServiceCell
             
         case .editProfile:
@@ -174,7 +200,7 @@ extension SoptlogVC: UICollectionViewDataSource {
             guard let alarmCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: SoptlogAlarmCVC.className,
                 for: indexPath) as? SoptlogAlarmCVC else { return UICollectionViewCell() }
-            alarmCell.configureCell(model: viewModel.soptlogAlarmInfoList[indexPath.item])
+            alarmCell.configureCell(model: self.soptlogInfo?.alarm)
             return alarmCell
             
         default: return UICollectionViewCell()

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -162,7 +162,7 @@ extension SoptlogVC: UICollectionViewDataSource {
         
         switch sectionKind {
         case .introduce: return 1
-        case .appService: return 3
+        case .appService: return self.soptlogInfo?.appService.count ?? 0
         case .editProfile: return 1
         case .alarm: return 1
         default: return 0
@@ -186,7 +186,7 @@ extension SoptlogVC: UICollectionViewDataSource {
             guard let appServiceCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: SoptlogAppServiceCVC.className,
                 for: indexPath) as? SoptlogAppServiceCVC else { return UICollectionViewCell() }
-            appServiceCell.configureCell(model: self.soptlogInfo?.appService[indexPath.row])
+            appServiceCell.configureCell(model: self.soptlogInfo?.appService[safe: indexPath.row])
             return appServiceCell
             
         case .editProfile:

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -37,6 +37,11 @@ public class SoptlogViewModel: SoptlogViewModelType {
         let soptlogInfo = PassthroughSubject<SoptlogPresentationModel, Never>()
     }
     
+    // MARK: - SoptlogCoordinatable
+    
+    public var onProfileEditTapped: (() -> Void)?
+    public var onAlarmTapped: (() -> Void)?
+    
     // MARK: - initialization
     
     public init(useCase: SoptlogUseCase, cancelBag: CancelBag = CancelBag()) {
@@ -58,17 +63,17 @@ extension SoptlogViewModel {
             }.store(in: cancelBag)
         
         input.cellTap
-            .filter{ $0.section == 1 }
-            .withUnretained(self)
-            .sink { owner, _ in
-                // 화면 전환
-            }.store(in: cancelBag)
-        
-        input.cellTap
             .filter{ $0.section == 2 }
             .withUnretained(self)
             .sink { owner, _ in
-                // 화면 전환
+                owner.onProfileEditTapped?()
+            }.store(in: cancelBag)
+        
+        input.cellTap
+            .filter{ $0.section == 3 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onAlarmTapped?()
             }.store(in: cancelBag)
         
         return output

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -17,8 +17,6 @@ import BaseFeatureDependency
 
 public class SoptlogViewModel: SoptlogViewModelType {
     
-    public var onNaviBackButtonTap: (() -> Void)?
-    
     // MARK: - Properties
 
     private let useCase: SoptlogUseCase
@@ -28,6 +26,7 @@ public class SoptlogViewModel: SoptlogViewModelType {
     
     public struct Input { 
         let viewDidLoad: Driver<Void>
+        let naviBackButtonTap: Driver<Void>
         let cellTap: Driver<IndexPath>
     }
     
@@ -39,6 +38,7 @@ public class SoptlogViewModel: SoptlogViewModelType {
     
     // MARK: - SoptlogCoordinatable
     
+    public var onNaviBackButtonTap: (() -> Void)?
     public var onProfileEditTapped: (() -> Void)?
     public var onAlarmTapped: (() -> Void)?
     
@@ -60,6 +60,12 @@ extension SoptlogViewModel {
             .sink { owner, soptlogModel in
                 let info = owner.transformToPresentationModel(model: soptlogModel)
                 output.soptlogInfo.send(info)
+            }.store(in: cancelBag)
+        
+        input.naviBackButtonTap
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onNaviBackButtonTap?()
             }.store(in: cancelBag)
         
         input.cellTap

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -15,75 +15,105 @@ import Domain
 import HomeFeatureInterface
 import BaseFeatureDependency
 
-struct ProfileInfo {
-    let profileImageURL: String
-    let name: String
-    let part: String
-    let introduce: String
-}
-
-struct AppServiceInfo {
-    let serviceName: String
-    let serviceImageURL: String
-    let serviceValue: String
-}
-
-struct SoptlogAlarmInfo {
-    let imageURL: String
-    let title: String
-    let subTitle: String
-}
-
 public class SoptlogViewModel: SoptlogViewModelType {
     
-    let profileInfoList: [ProfileInfo] = [
-        ProfileInfo(
-            profileImageURL: "https://i1.sndcdn.com/artworks-000660272461-rmfvxq-t500x500.jpg",
-            name: "짱구씨",
-            part: "iOS/디자인/기획/안드로이드/웹/서버",
-            introduce: "한줄소개는 공백포함 최대15"
-        )
-    ]
+    public var onNaviBackButtonTap: (() -> Void)?
     
-    let appServiceInfoList: [AppServiceInfo] = [
-        AppServiceInfo(
-            serviceName: "솝레벨",
-            serviceImageURL: "https://i.pinimg.com/originals/99/7a/9b/997a9b2cd93277769ca9b3d109bceed7.jpg",
-            serviceValue: "Lv.6"),
-        AppServiceInfo(
-            serviceName: "콕찌르기",
-            serviceImageURL: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS5_o58idJtowURqF99s9mM1pC76aIf9t1K7w&s",
-            serviceValue: "208회"),
-        AppServiceInfo(
-            serviceName: "솝탬프",
-            serviceImageURL: "https://i.pinimg.com/736x/7d/9d/e4/7d9de429c35854f0ec32d8e0704a7d63.jpg",
-            serviceValue: "14등"),
-    ]
-    
-    let soptlogAlarmInfoList: [SoptlogAlarmInfo] = [
-        SoptlogAlarmInfo(
-            imageURL: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTcvCXwH8rPUMVwEnu5ADHwOSdwGZcqdzotiQ&s",
-            title: "짱구님, 잊지 말아야 할 말들을 듣게 될 거예요",
-            subTitle: "바로 확인하기")
-    ]
-    
+    // MARK: - Properties
+
+    private let useCase: SoptlogUseCase
+    private var cancelBag = CancelBag()
+
     // MARK: - Inputs
     
-    public struct Input { }
+    public struct Input { 
+        let viewDidLoad: Driver<Void>
+        let cellTap: Driver<IndexPath>
+    }
     
     // MARK: - Outputs
     
-    public struct Output { }
+    public struct Output {
+        let soptlogInfo = PassthroughSubject<SoptlogPresentationModel, Never>()
+    }
     
     // MARK: - initialization
     
-    public init() { }
+    public init(useCase: SoptlogUseCase, cancelBag: CancelBag = CancelBag()) {
+        self.useCase = useCase
+        self.cancelBag = cancelBag
+    }
 }
 
 extension SoptlogViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
+        
+        input.viewDidLoad
+            .flatMap(useCase.fetchSoptlogInfo)
+            .withUnretained(self)
+            .sink { owner, soptlogModel in
+                let info = owner.transformToPresentationModel(model: soptlogModel)
+                output.soptlogInfo.send(info)
+            }.store(in: cancelBag)
+        
+        input.cellTap
+            .filter{ $0.section == 1 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                // 화면 전환
+            }.store(in: cancelBag)
+        
+        input.cellTap
+            .filter{ $0.section == 2 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                // 화면 전환
+            }.store(in: cancelBag)
+        
         return output
     }
 }
 
+extension SoptlogViewModel {
+    private func transformToPresentationModel(model: SoptlogModel) -> SoptlogPresentationModel {
+        var appService: [SoptlogPresentationModel.AppService] = []
+        appService.append(SoptlogPresentationModel.AppService(
+            serviceName: I18N.Soptlog.soptlevel,
+            serviceImageURL: model.icons[0],
+            serviceValue: model.soptLevel))
+        appService.append(SoptlogPresentationModel.AppService(
+            serviceName: I18N.Soptlog.poke,
+            serviceImageURL: model.icons[1],
+            serviceValue: model.pokeCount))
+        
+        if model.isActive {
+            appService.append(SoptlogPresentationModel.AppService(
+                serviceName: I18N.Soptlog.soptamp,
+                serviceImageURL: model.icons[2],
+                serviceValue: model.soptampRank))
+        } else {
+            appService.append(SoptlogPresentationModel.AppService(
+                serviceName: I18N.Soptlog.withSopt,
+                serviceImageURL: model.icons[2],
+                serviceValue: "\(model.during)개월"))
+        }
+        
+        
+        return SoptlogPresentationModel(
+            profile: SoptlogPresentationModel.Profile(
+                userName: model.userName,
+                profileImage: model.profileImage,
+                part: model.part
+            ),
+            introduce: SoptlogPresentationModel.Introduce(
+                profileMessage: model.profileMessage
+            ),
+            appService: appService,
+            alarm: SoptlogPresentationModel.Alarm(
+                isFortuneChecked: model.isFortuneChecked,
+                todayFortuneText: model.todayFortuneText
+            )
+        )
+    }
+}

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -58,7 +58,7 @@ extension SoptlogViewModel {
             .flatMap(useCase.fetchSoptlogInfo)
             .withUnretained(self)
             .sink { owner, soptlogModel in
-                let info = owner.transformToPresentationModel(model: soptlogModel)
+                let info = soptlogModel.toPresentation()
                 output.soptlogInfo.send(info)
             }.store(in: cancelBag)
         
@@ -86,44 +86,44 @@ extension SoptlogViewModel {
     }
 }
 
-extension SoptlogViewModel {
-    private func transformToPresentationModel(model: SoptlogModel) -> SoptlogPresentationModel {
+extension SoptlogModel {
+    func toPresentation() -> SoptlogPresentationModel {
         var appService: [SoptlogPresentationModel.AppService] = []
         appService.append(SoptlogPresentationModel.AppService(
             serviceName: I18N.Soptlog.soptlevel,
-            serviceImageURL: model.icons[0],
-            serviceValue: model.soptLevel))
+            serviceImageURL: self.icons[0],
+            serviceValue: self.soptLevel))
         appService.append(SoptlogPresentationModel.AppService(
             serviceName: I18N.Soptlog.poke,
-            serviceImageURL: model.icons[1],
-            serviceValue: model.pokeCount))
+            serviceImageURL: self.icons[1],
+            serviceValue: self.pokeCount))
         
-        if model.isActive {
+        if self.isActive {
             appService.append(SoptlogPresentationModel.AppService(
                 serviceName: I18N.Soptlog.soptamp,
-                serviceImageURL: model.icons[2],
-                serviceValue: model.soptampRank))
+                serviceImageURL: self.icons[2],
+                serviceValue: self.soptampRank))
         } else {
             appService.append(SoptlogPresentationModel.AppService(
                 serviceName: I18N.Soptlog.withSopt,
-                serviceImageURL: model.icons[2],
-                serviceValue: "\(model.during)개월"))
+                serviceImageURL: self.icons[2],
+                serviceValue: "\(self.during)개월"))
         }
         
         
         return SoptlogPresentationModel(
             profile: SoptlogPresentationModel.Profile(
-                userName: model.userName,
-                profileImage: model.profileImage,
-                part: model.part
+                userName: self.userName,
+                profileImage: self.profileImage,
+                part: self.part
             ),
             introduce: SoptlogPresentationModel.Introduce(
-                profileMessage: model.profileMessage
+                profileMessage: self.profileMessage
             ),
             appService: appService,
             alarm: SoptlogPresentationModel.Alarm(
-                isFortuneChecked: model.isFortuneChecked,
-                todayFortuneText: model.todayFortuneText
+                isFortuneChecked: self.isFortuneChecked,
+                todayFortuneText: self.todayFortuneText
             )
         )
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/UserAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/UserAPI.swift
@@ -24,6 +24,7 @@ public enum UserAPI {
     case optInPushNotificationInDetail(notificationSettings: DetailNotificationOptInEntity)
     case appService
     case hotboard
+    case fetchSoptlogInfo
 }
 
 extension UserAPI: BaseAPI {
@@ -53,13 +54,15 @@ extension UserAPI: BaseAPI {
             return "app-service"
         case .hotboard:
             return "playground/hot-post"
+        case .fetchSoptlogInfo:
+            return "sopt-log"
         }
     }
     
     // MARK: - Method
     public var method: Moya.Method {
         switch self {
-        case .getUserMainInfo, .fetchSoptampUser, .fetchActiveGenerationStatus, .getNotificationSettingsInDetail, .appService, .hotboard:
+        case .getUserMainInfo, .fetchSoptampUser, .fetchActiveGenerationStatus, .getNotificationSettingsInDetail, .appService, .hotboard, .fetchSoptlogInfo:
             return .get
         case .editSentence, .optInPushNotificationInDetail:
             return .patch
@@ -86,6 +89,8 @@ extension UserAPI: BaseAPI {
             params["pushToken"] = pushToken
         case .optInPushNotificationInDetail(let optInDTO):
             params = optInDTO.toDictionary()
+        case .fetchSoptlogInfo:
+            params["ko"] = "true"
         default: break
         }
         return params
@@ -93,6 +98,8 @@ extension UserAPI: BaseAPI {
     
     private var parameterEncoding: ParameterEncoding {
         switch self {
+        case .fetchSoptlogInfo:
+            return URLEncoding.default
         default:
             return JSONEncoding.default
         }
@@ -100,7 +107,7 @@ extension UserAPI: BaseAPI {
     
     public var task: Task {
         switch self {
-        case .editSentence, .registerPushToken, .optInPushNotificationInDetail, .deregisterPushToken:
+        case .editSentence, .registerPushToken, .optInPushNotificationInDetail, .deregisterPushToken, .fetchSoptlogInfo:
             return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -1,0 +1,40 @@
+//
+//  SoptlogEntity.swift
+//  Networks
+//
+//  Created by 강윤서 on 1/19/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - 한 줄 소개와 솝마디 추가되어야 함. 파트 방식 변경 요청 상태.
+public struct SoptlogResponseEntity: Decodable {
+    public let userName: String
+    public let profileImage: String
+    public let part: String
+    public let soptampRank: String
+    public let pokeCount: String
+    public let soptLevel: String
+    public let during: Int
+    public let profileMessage: String
+    public let icons: [String]
+    public let isFortuneChecked: Bool
+    public let todayFortuneText: String
+    public let isActive: Bool
+    
+    public init(userName: String, profileImage: String, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+        self.userName = userName
+        self.profileImage = profileImage
+        self.part = part
+        self.soptampRank = soptampRank
+        self.pokeCount = pokeCount
+        self.soptLevel = soptLevel
+        self.during = during
+        self.profileMessage = profileMessage
+        self.icons = icons
+        self.isFortuneChecked = isFortuneChecked
+        self.todayFortuneText = todayFortuneText
+        self.isActive = isActive
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -13,17 +13,17 @@ public struct SoptlogResponseEntity: Decodable {
     public let userName: String
     public let profileImage: String
     public let part: String
-    public let soptampRank: String
+    public let soptampRank: String?
     public let pokeCount: String
     public let soptLevel: String
-    public let during: Int
+    public let during: Int?
     public let profileMessage: String
     public let icons: [String]
     public let isFortuneChecked: Bool
     public let todayFortuneText: String
     public let isActive: Bool
     
-    public init(userName: String, profileImage: String, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+    public init(userName: String, profileImage: String, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: Int?, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
         self.userName = userName
         self.profileImage = profileImage
         self.part = part

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -10,8 +10,8 @@ import Foundation
 
 // MARK: - 한 줄 소개와 솝마디 추가되어야 함. 파트 방식 변경 요청 상태.
 public struct SoptlogResponseEntity: Decodable {
-    public let userName: String
-    public let profileImage: String
+    public let userName: String?
+    public let profileImage: String?
     public let part: String
     public let soptampRank: String?
     public let pokeCount: String
@@ -23,7 +23,7 @@ public struct SoptlogResponseEntity: Decodable {
     public let todayFortuneText: String
     public let isActive: Bool
     
-    public init(userName: String, profileImage: String, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: Int?, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+    public init(userName: String?, profileImage: String?, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: Int?, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
         self.userName = userName
         self.profileImage = profileImage
         self.part = part

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/UserService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/UserService.swift
@@ -27,6 +27,7 @@ public protocol UserService {
     func optInPushNotificationInDetail(notificationSettings: DetailNotificationOptInEntity) -> AnyPublisher<DetailNotificationOptInEntity, Error>
     func appService() -> AnyPublisher<[AppServiceEntity], Error>
     func hotBoard() -> AnyPublisher<HotBoardEntity, Error>
+    func fetchSoptlogInfo() -> AnyPublisher<SoptlogResponseEntity, Error>
 }
 
 extension DefaultUserService: UserService {
@@ -76,5 +77,9 @@ extension DefaultUserService: UserService {
 
     public func hotBoard() -> AnyPublisher<HotBoardEntity, Error> {
         requestObjectWithNetworkErrorInCombine(.hotboard)
+    }
+    
+    public func fetchSoptlogInfo() -> AnyPublisher<SoptlogResponseEntity, Error> {
+        requestObjectInCombine(.fetchSoptlogInfo)
     }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -179,5 +179,11 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: SoptlogRepositoryInterface.self,
+            implement: {
+                SoptlogRepository(userService: DefaultUserService())
+            }
+        )
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#477

## 🌱 PR Point
- #471 에서 논의한대로 Response, Request Entity를 명확히 구분지었습니다. 폴더로 나누어 관리하면 좋을 듯 싶어 **ResponseEntity 폴더를 추가**했어요.
![image](https://github.com/user-attachments/assets/e3122ff7-589d-4760-8ad9-f407d71a10a5)

- #471 에서 논의했던 것처럼 UseCase에서 DTO 가공이 없어 Publisher 반환해주었습니다! 대신 Error처리를 어떻게 해야할까 고민해보고 싶었는데,, 노타임 이슈로 Empty로 스트림을 끊어놓았습니다.. 금요일 이후 이 부분 고민해볼게요!

- 기존에는 UseCase에서 ViewModel을 통해 받은 데이터 스트림을 ViewModel의 변수에 저장하고, View에서는 ViewModel의 변수를 참조하여 UI를 업데이트하는 방식을 사용하고 있었는데, 문득 이 구조가 **ViewModel과 View의 결합도를 높이고 있지 않나?** 라는 의문이 들었습니다.
그래서 ViewModel과 View 간의 DTO인 `SoptlogPresentationModel`을 하나 생성했어요. 
ViewModel에서 UseCase로부터 받아온 데이터스트림을 가공하여 다시 View로 Subject를 전달하고, **View는 전달받은 Subject에 의해 UI를 업데이트하도록 변경**했습니다!

- 질문이 하나 있습니다.. 솝트로그 API에서 파트 정보를 현재 영어로 내려주고 있는데, 한글 변경은 안드로이드와 논의가 필요하다고 하여 queryString인 ko=true를 사용해 한국어로 변환하고 있습니다.
이때 queryString value로 true값을 직접 넣어주면 `https://app.dev.sopt.org/api/v2/user/sopt-log?ko=1`이 되어 string인 "true"값을 넣어주었어요.
![image](https://github.com/user-attachments/assets/3c466e40-ed10-46e0-93a3-40166976396b)
그런데 이런 오류 메세지가 뜹니다 .. !! 원인을 잘 모르겠어요.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 제가 #459 머지를 하는 과정에서 변경사항을 몇 가지 누락해서 그 부분 추가했습니다.


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|솝트로그|![Simulator Screen Recording - iPhone 15 Pro - 2025-01-21 at 00 03 42](https://github.com/user-attachments/assets/f23c6955-d764-4bd4-a17e-c67e87cc1a38)|

## 📮 관련 이슈
- Resolved: #477
