### PR TITLE
[Hotfix] #484 - WKWebView에서 이미지 다운로드 발생 시 갤러리에 저장하는 기능을 구현한다.

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/makeAlert.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/makeAlert.swift
@@ -34,4 +34,20 @@ public extension UIViewController {
         alertViewController.addAction(okAction)
         self.present(alertViewController, animated: true, completion: completion)
     }
+    
+    func makeAlert(
+        title: String,
+        message: String,
+        actions: UIAlertAction...,
+        completion: (() -> Void)? = nil
+    ) {
+        makeVibrate()
+        let alertVC = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        actions.forEach { alertVC.addAction($0) }
+        self.present(alertVC, animated: true, completion: completion)
+    }
 }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadExecutable.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadExecutable.swift
@@ -1,0 +1,24 @@
+//
+//  WKDownloadExecutable.swift
+//  BaseFeatureDependency
+//
+//  Created by 장석우 on 1/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+import WebKit
+
+public protocol WKDownloadExecutable {
+    
+    static var key: UTType { get }
+    
+    func execute(
+        _ download: WKDownload,
+        _ response: URLResponse,
+        _ suggestedFilename: String,
+        _ webVC: SOPTWebViewControllable?
+    ) async -> URL?
+}
+

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadManager.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadManager.swift
@@ -11,6 +11,7 @@ import UniformTypeIdentifiers
 import WebKit
 
 public final class WKDownloadManager {
+    
     private var downloadHandlers: [UTType: WKDownloadExecutable]
     var webVC: SOPTWebViewControllable?
     

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadManager.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKDownloadManager.swift
@@ -1,0 +1,51 @@
+//
+//  WKDownloadManager.swift
+//  BaseFeatureDependency
+//
+//  Created by 장석우 on 1/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+import WebKit
+
+public final class WKDownloadManager {
+    private var downloadHandlers: [UTType: WKDownloadExecutable]
+    var webVC: SOPTWebViewControllable?
+    
+    init(
+        downloadHandlers: [UTType : WKDownloadExecutable] = [:],
+        webVC: SOPTWebViewControllable? = nil
+    ) {
+        self.downloadHandlers = downloadHandlers
+        self.webVC = webVC
+    }
+    
+    public func register<T: WKDownloadExecutable>(_ object: T) {
+        self.downloadHandlers[T.key] = object
+    }
+    
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String
+    ) async -> URL? {
+        guard let mimeType = response.mimeType,
+              let utType = UTType(mimeType: mimeType)
+        else { return nil }
+        
+        guard let handler = downloadHandlers.first(where: { utType.conforms(to: $0.key) })?.value
+        else { return nil }
+        
+        return await handler.execute(download, response, suggestedFilename, webVC)
+    }
+    
+    public static let `default`: WKDownloadManager = {
+        let manager = WKDownloadManager()
+        manager.register(WKImageDownloadHandler())
+        return manager
+    }()
+}
+
+

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKImageDownloadHandler.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKImageDownloadHandler.swift
@@ -23,9 +23,8 @@ struct WKImageDownloadHandler: WKDownloadExecutable {
         
         guard let webVC else { return nil }
         
-        guard await requestAuthorization()
-        else {
-            //TODO: 권한 요청
+        guard await requestAuthorization() else {
+            await presentGoToSettingAlert(from: webVC)
             return nil
         }
         
@@ -41,8 +40,8 @@ struct WKImageDownloadHandler: WKDownloadExecutable {
         guard let fileURL = try? saveToTemporaryDirectory(pngData, suggestedFilename)
         else { return nil }
         
-        presentActivityVC(fileURL, from: webVC)
-  
+        await presentActivityVC(fileURL, from: webVC)
+        
         return nil
     }
     
@@ -60,29 +59,45 @@ struct WKImageDownloadHandler: WKDownloadExecutable {
         return temporaryURL
     }
     
+    @MainActor
     private func presentActivityVC(_ fileURL: URL, from webVC: SOPTWebViewControllable) {
-        Task { @MainActor in
-            let activityVC = UIActivityViewController(
-                activityItems: [fileURL],
-                applicationActivities: nil
-            )
-            
-            activityVC.completionWithItemsHandler = {
-                activityType, completed, returnedItems, activityError in
-                if activityType == .saveToCameraRoll {
-                    guard activityError == nil else {
-                        ToastUtils.showMDSToast(type: .error, text: "이미지 저장에 실패했습니다.")
-                        return
-                    }
-                    
-                    if completed {
-                        ToastUtils.showMDSToast(type: .success, text: "이미지가 저장되었습니다.")
-                    }
+        
+        let activityVC = UIActivityViewController(
+            activityItems: [fileURL],
+            applicationActivities: nil
+        )
+        
+        activityVC.completionWithItemsHandler = {
+            activityType, completed, returnedItems, activityError in
+            if activityType == .saveToCameraRoll {
+                guard activityError == nil else {
+                    ToastUtils.showMDSToast(type: .error, text: "이미지 저장에 실패했습니다.")
+                    return
+                }
+                
+                if completed {
+                    ToastUtils.showMDSToast(type: .success, text: "이미지가 저장되었습니다.")
                 }
             }
-            // 공유 화면 표시
-            webVC.vc.present(activityVC, animated: true, completion: nil)
         }
+        // 공유 화면 표시
+        webVC.vc.present(activityVC, animated: true, completion: nil)
+        
+    }
+    
+    @MainActor
+    private func presentGoToSettingAlert(from webVC: SOPTWebViewControllable) {
+        webVC.vc.makeAlert(
+            title: "갤러리 접근 권한 설정",
+            message: "이미지를 저장하시려면 갤러리 접근 권한이 필요합니다.",
+            actions: .init(title: "나중에", style: .destructive),
+            .init(title: "설정", style: .default, handler: { _ in
+                guard let url = URL(string: UIApplication.openSettingsURLString),
+                      UIApplication.shared.canOpenURL(url) else { return }
+                
+                UIApplication.shared.open(url, completionHandler: nil)
+            })
+        )
     }
 }
 

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKImageDownloadHandler.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/Download/WKImageDownloadHandler.swift
@@ -1,0 +1,90 @@
+//
+//  WKImageDownloadHandler.swift
+//  BaseFeatureDependency
+//
+//  Created by 장석우 on 1/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import WebKit
+import Photos
+
+struct WKImageDownloadHandler: WKDownloadExecutable {
+    
+    static let key = UTType.image
+    
+    func execute(
+        _ download: WKDownload,
+        _ response: URLResponse,
+        _ suggestedFilename: String,
+        _ webVC: SOPTWebViewControllable?
+    ) async -> URL? {
+        
+        guard let webVC else { return nil }
+        
+        guard await requestAuthorization()
+        else {
+            //TODO: 권한 요청
+            return nil
+        }
+        
+        guard let urlString = response.url?.absoluteString,
+              let range = urlString.range(of: "base64,"),
+              let encodedData = Data(base64Encoded: String(urlString[range.upperBound...])),
+              let image = UIImage(data: encodedData),
+              let pngData = image.pngData()
+        else {
+            return nil
+        }
+        
+        guard let fileURL = try? saveToTemporaryDirectory(pngData, suggestedFilename)
+        else { return nil }
+        
+        presentActivityVC(fileURL, from: webVC)
+  
+        return nil
+    }
+    
+    private func requestAuthorization() async -> Bool {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        return status == .authorized || status == .limited
+    }
+    
+    private func saveToTemporaryDirectory(_ data: Data, _ suggestedFilename: String) throws -> URL {
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(suggestedFilename)
+            .appendingPathExtension("png")
+        
+        try data.write(to: temporaryURL, options: [])
+        return temporaryURL
+    }
+    
+    private func presentActivityVC(_ fileURL: URL, from webVC: SOPTWebViewControllable) {
+        Task { @MainActor in
+            let activityVC = UIActivityViewController(
+                activityItems: [fileURL],
+                applicationActivities: nil
+            )
+            
+            activityVC.completionWithItemsHandler = {
+                activityType, completed, returnedItems, activityError in
+                if activityType == .saveToCameraRoll {
+                    guard activityError == nil else {
+                        ToastUtils.showMDSToast(type: .error, text: "이미지 저장에 실패했습니다.")
+                        return
+                    }
+                    
+                    if completed {
+                        ToastUtils.showMDSToast(type: .success, text: "이미지가 저장되었습니다.")
+                    }
+                }
+            }
+            // 공유 화면 표시
+            webVC.vc.present(activityVC, animated: true, completion: nil)
+        }
+    }
+}
+
+
+

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/WebView/SOPTWebView.swift
@@ -14,13 +14,20 @@ import WebKit
 
 import SnapKit
 
-public final class SOPTWebView: UIViewController {
+public protocol SOPTWebViewControllable {
+    var vc: UIViewController { get }
+    var webView: WKWebView { get }
+}
+
+public final class SOPTWebView: UIViewController, SOPTWebViewControllable {
     private enum Metric {
         static let navigationBarHeight = 44.f
     }
     
     private lazy var navigationBar = WebViewNavigationBar(frame: self.view.frame)
-    private let wkwebView: WKWebView
+    public let webView: WKWebView
+    public var vc: UIViewController { self }
+    private let downloadManager: WKDownloadManager
     
     // MARK: Variables
     private let cancelbag = CancelBag()
@@ -28,22 +35,23 @@ public final class SOPTWebView: UIViewController {
     
     public init(
         config: WebViewConfig = WebViewConfig(),
-        startWith url: URL
+        startWith url: URL,
+        downloadManager: WKDownloadManager = .default
     ) {
         let configuration = WKWebViewConfiguration().then {
             $0.allowsInlineMediaPlayback = config.allowsInlineMediaPlayback
             $0.mediaTypesRequiringUserActionForPlayback = config.mediaTypesRequiringUserActionForPlayback
         }
         
-        self.wkwebView = WKWebView(frame: .zero, configuration: configuration).then {
+        self.webView = WKWebView(frame: .zero, configuration: configuration).then {
             $0.allowsBackForwardNavigationGestures = config.allowsBackForwardNavigationGestures
         }
-        
+        self.downloadManager = downloadManager
         super.init(nibName: nil, bundle: nil)
         
         DispatchQueue.main.async {
             let request = URLRequest(url: url)
-            self.wkwebView.load(request)
+            self.webView.load(request)
         }
     }
     
@@ -56,10 +64,10 @@ public final class SOPTWebView: UIViewController {
         
         self.view.backgroundColor = DSKitAsset.Colors.black100.color
         
-        self.wkwebView.scrollView.delegate = self
-        self.wkwebView.navigationDelegate = self
-        self.wkwebView.uiDelegate = self
-        
+        self.webView.scrollView.delegate = self
+        self.webView.navigationDelegate = self
+        self.webView.uiDelegate = self
+        downloadManager.webVC = self
         self.initializeViews()
         self.setupConstraints()
         self.setupNavigationButtonActions()
@@ -68,7 +76,7 @@ public final class SOPTWebView: UIViewController {
 
 extension SOPTWebView {
     private func initializeViews() {
-        self.view.addSubviews(self.navigationBar, self.wkwebView)
+        self.view.addSubviews(self.navigationBar, self.webView)
     }
     
     private func setupConstraints() {
@@ -78,7 +86,7 @@ extension SOPTWebView {
             $0.height.equalTo(Metric.navigationBarHeight)
         }
         
-        self.wkwebView.snp.makeConstraints {
+        self.webView.snp.makeConstraints {
             $0.top.equalTo(self.navigationBar.snp.bottom)
             $0.leading.trailing.bottom.equalToSuperview()
         }
@@ -88,12 +96,12 @@ extension SOPTWebView {
         self.navigationBar
             .signalForClickLeftButton()
             .sink { [weak self] _ in
-                guard self?.wkwebView.canGoBack == true else {
+                guard self?.webView.canGoBack == true else {
                     self?.navigationController?.popViewController(animated: true)
                     return
                 }
                     
-                self?.wkwebView.goBack()
+                self?.webView.goBack()
             }.store(in: self.cancelbag)
         
         self.navigationBar
@@ -111,10 +119,10 @@ extension SOPTWebView: WKNavigationDelegate {
         }
         
         self.barrier = true
-        self.wkwebView.evaluateJavaScript(
+        self.webView.evaluateJavaScript(
             "localStorage.setItem(\"serviceAccessToken\", \"\(playgroundToken)\")"
         )
-        self.wkwebView.reload()
+        self.webView.reload()
     }
 }
 
@@ -136,5 +144,24 @@ extension SOPTWebView: WKUIDelegate {
 extension SOPTWebView: UIScrollViewDelegate {
     public func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
         scrollView.pinchGestureRecognizer?.isEnabled = false
+    }
+}
+
+extension SOPTWebView: WKDownloadDelegate {
+    
+    public func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
+        return await downloadManager.download(
+            download,
+            decideDestinationUsing: response,
+            suggestedFilename: suggestedFilename
+        )
+    }
+    
+    public func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
+        download.delegate = self
+    }
+    
+    public func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+        download.delegate = self
     }
 }

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Coordinator/MainCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Coordinator/MainCoordinator.swift
@@ -47,7 +47,7 @@ final class MainCoordinator: DefaultMainCoordinator {
             self?.requestCoordinating?(.myPage(userType))
         }
         main.vm.onSafari = { [weak self] url in
-            self?.router.pushSOPTWebView(url: url)
+            self?.router.pushSOPTWebView(url: "https://sopt-internal-dev.pages.dev/test/image")
         }
         main.vm.onNeedSignIn = { [weak self] in
             self?.requestCoordinating?(.signIn)

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Coordinator/MainCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Coordinator/MainCoordinator.swift
@@ -47,7 +47,7 @@ final class MainCoordinator: DefaultMainCoordinator {
             self?.requestCoordinating?(.myPage(userType))
         }
         main.vm.onSafari = { [weak self] url in
-            self?.router.pushSOPTWebView(url: "https://sopt-internal-dev.pages.dev/test/image")
+            self?.router.pushSOPTWebView(url: url)
         }
         main.vm.onNeedSignIn = { [weak self] in
             self?.requestCoordinating?(.signIn)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#484

## 🌱 PR Point
- WKWebView에서 이미지 다운로드 발생 시 갤러리에 저장하는 기능을 구현한다.
- 기획 사항
  - 웹에서 이미지 다운로드 발생 시 갤러리에 저장한다.
  - 갤러리 접근 권한을 설정한 적이 없는 유저에게 접근 권한을 묻는다.
  - 갤러리 접근 권한을 허용한 유저에겐 바로 공유하기(UIActivityVC)를 띄운다
  - 갤러리 접근 권한을 거부했던 유저에겐 설정으로 이동시켜 허용을 유도한다. ([관련 노션](https://www.notion.so/sopt-makers/iOS-f822c010c7e44d3f8b8d78a92222e44f?pvs=4), [관련 슬랙](https://sopt-makers.slack.com/archives/C06KS9ATSG1/p1729585709560259))
- [민소네 플러그인](https://www.youtube.com/watch?v=ngZAj2fsiXo) 참고해서 확장성 있는 DownloadHandler 구조로 구현했습니다.
- 현재 프로젝트에 존재하는 DeepLinkExecutable과 유사한 구조에요.

### 설계 배경

**1. WebVC에서 로직을 처리하지 않은 이유**
- 다운로드 처리 로직을 WebVC가 담당하게 된다면, 기능이 확장(영상 저장, 파일 저장)될 때마다 WebVC가 비대해지는 문제가 있어요.
- 해당 문제를 방지하고자 다운로드 처리 로직을 담당하는 객체를 만들었어요.
- 다운로드 처리로직을 담당하는 객체는 WKDownloadExecutable을 채택해야해요.
- 위 프로토콜을 채택한 WKImageDownloadHandler에 실제 로직이 구현되어있어요.

**2. WKDownloadManager를 구현한 이유**
- webview로 부터 전달받은 download를 어떤 Handler가 execute해야할지 결정할 필요가 있습니다.
- 해당 PR에선 webView로 부터 전달받은 mimeType을 통해 Handler를 결정합니다.
- 따라서 DownloadManager가 지니고 있는 핸들러 중 동일한 MimeType이 있을 경우 해당 핸들러를 execute합니다.

**3. mimeType이 아닌 UTType을 사용한 이유**
- mimeType은 String? 타입이기에 값이 명확하지 않습니다.
- 해당 값을 Apple에서 제공하는 데이터타입인 UTType으로 변환 후 사용해 타입 안정성을 높입니다.
- UTType에는 상하위 타입이 존재합니다.
- 이미지에는 여러 타입(.png, .jpeg .. 등등)이 있으며, 해당 타입들을 모두 UTType.image 를 conform 합니다.
- 따라서 UTType.image을 따르는 download가 들어올 시 WKImageDownloadHandler 가 실행됩니다.

**4. WKDownloadManager에 Handler 주입 방법**
- Handler를 구현하면 해당 핸들러를 manager에 주입시켜주어야 합니다.
- manager는 [UTType: WKDownloadExecutable]를 프로퍼티로 지닙니다.
- 해당 딕셔너리에 주입할 수 있는 방법은 두 가지를 고려해봤습니다.
```swift 
  // AS IS
    public func register(key: UTType, _ object: WKDownloadExecutable) {
        self.downloadHandlers[key] = object
    }
    
    // TOBE
    public func register<T: WKDownloadExecutable>(_ object: T) {
        self.downloadHandlers[T.key] = object
    }
```
- AS-IS 방식은 런타임에 key와 value(구현체)를 주입하게 됩니다.
- 두 가지 이유로 AS-IS 방식에서 TOBE 방식으로 변경했습니다.
  - key와 handler의 관계는 런타임이 아닌 컴파일시점에 결정됩니다.
  - key를 결정하는 책임은 manager에 register()를 호출하는 쪽이 아닌 Handler에게 있다고 판단 
- 따라서 TO-BE 구조로 바꾸었으며, 제네릭을 통해 타입 프로퍼티를 바로 사용할 수 있게 구현했습니다.

## 📌 참고 사항
- 개선점은 코드리뷰에 남기겠습니다. :)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|접근 권한 허용한 유저|<img src="https://github.com/user-attachments/assets/56f1f2c1-d80b-4e69-add2-6cf30e9ea46d" width="300">|
|접근 권한 거부한 유저|<img src="https://github.com/user-attachments/assets/b5ea695a-46b2-4062-b080-978dc55119fc" width="300" >|



## 📮 관련 이슈
- closed: #484
