### PR TITLE
[Hotfix] #486 hotboard contents 오류 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/UIKit+/UILabel+.swift
@@ -74,18 +74,53 @@ public extension UILabel {
         self.attributedText = attributedString
     }
     
-    func htmlToString(_ targetString: String) -> NSAttributedString? {
+    /// 서버에서 받아온 string 값에서 html 태그를 적용해주는 함수
+    /// - targetString에는 특정 문자열을 넣어주세요
+    /// - defaultFont, defaultColor에는 기본 폰트와 컬러를 넣어주세요
+    func htmlToString(targetString: String,
+                      defaultFont: UIFont,
+                      defaultColor: UIColor) {
         let text = targetString
+        guard let data = text.data(using: .utf8) else { return }
         
-        guard let data = text.data(using: .utf8) else {
-            return NSAttributedString()
-        }
         do {
-            return try NSAttributedString(data: data,
-                                          options: [.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
-                                          documentAttributes: nil)
-        } catch {
-            return NSAttributedString()
+            let attributedString = try NSMutableAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue],
+                documentAttributes: nil
+            )
+            let range = NSRange(location: 0, length: attributedString.length)
+            
+            attributedString.enumerateAttribute(.font, in: range, options: .longestEffectiveRangeNotRequired)
+            { value, range, _ in
+                let currentFont: UIFont = (value as? UIFont) ?? .init()
+                var replacementFont: UIFont?
+                
+                // 기본 폰트 이름
+                let fontName = defaultFont.fontName.split(separator: "-").first ?? .init()
+                // 볼드 폰트
+                let boldFont = UIFont(name: String(fontName + "-" + "Bold"), size: defaultFont.pointSize) ?? .init()
+                
+                // 폰트 이름에 bold가 포함되어 있을 경우, 볼드체로 간주
+                if currentFont.fontName.contains("bold") || currentFont.fontName.contains("Bold") {
+                    replacementFont = boldFont
+                } else {
+                    replacementFont = defaultFont
+                }
+                
+                let replacingAttributedFont = [NSAttributedString.Key.font: replacementFont ?? .init()]
+                attributedString.addAttributes(replacingAttributedFont, range: range)
+            }
+            
+            attributedString.addAttributes([NSAttributedString.Key.foregroundColor: defaultColor],
+                                           range: range)
+            
+            self.attributedText = attributedString
+            
+        } catch let error {
+            print("htmlToString 변환 에러: ", error.localizedDescription)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/MainService/HotBoardHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/MainFeature/Sources/MainScene/Cells/MainService/HotBoardHeaderView.swift
@@ -39,8 +39,7 @@ final class HotBoardHeaderView: UICollectionReusableView {
 
   private let descriptionLabel: UILabel = {
     let label = UILabel()
-    label.font = .Main.body2
-    label.textColor = DSKitAsset.Colors.gray300.color
+    label.numberOfLines = 0
     label.textAlignment = .left
     return label
   }()
@@ -137,7 +136,10 @@ extension HotBoardHeaderView {
   func initCell(_ hotBoard: HotBoardModel) {
     self.hotBoard = hotBoard
     titleLabel.text = hotBoard.title
-    descriptionLabel.text = hotBoard.content
+    descriptionLabel.htmlToString(targetString: hotBoard.content,
+                                  defaultFont: DSKitFontFamily.Suit.medium.font(size: 14),
+                                  defaultColor: DSKitAsset.Colors.gray300.color
+    )
   }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#486

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 원인
contents가 `\n`으로 시작하는 경우 UILabel에 내용이 보이지 않음

### 해결 방법
**방법1) replacingOccurrences를 활용하여 \n을 빈 문자열로 변경하기**
- 만약 컨텐츠에서 의도적으로 \n을 사용한 경우 문제가 될 수 있음 ex) 소제목을 달았을 때

**방법2) htmlToString을 사용**
- 기존에 만들어둔 html을 String으로 파싱하는 함수 사용
- 서버에서 내려주는 형식을 보았을 때 웹 컨텐츠를 그대로 내려주는 것으로 보임. 태그가 그대로 내려올 수 있기 때문에 htmlToString이 적합하다고 판단

### 글자 잘림 문제
<img width="348" alt="image" src="https://github.com/user-attachments/assets/bd6cc2f8-81a1-4963-b449-ca7c0524925f" />  

- numberOfLines가 default값인 1로 되어있는 경우 글자가 잘리게 됨

**방법1)** numberOfLines를 1로 유지한 채 Label의 너비를 늘리고 lineBreakMode로 말줄임표 적용
**방법2)** numberOfLines를 0으로 변경
- 방법1이 말줄임표가 나와 더 자연스럽다고 생각했으나 홈뷰 리뉴얼이 한 달 이내로 이뤄지기 때문에 방법2로 간단하게 수정


<br>





## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|before|<img width=375 src=https://github.com/user-attachments/assets/4f62e4cf-6f7a-490d-a054-f9075502dd52>|
|after|<img width=375 src=https://github.com/user-attachments/assets/d45e623b-a22c-42b7-b3d3-96d6cf58e9e3>|

## 📮 관련 이슈
- Resolved: #486 
