### PR TITLE
[Setting] #491 - 모듈 생성 자동화 명령어 구현

### DIFF
--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -25,6 +25,7 @@ regenerate:
 createModule:
 	@tuist scaffold feature \
 	--name ${name} \
+	--author "$(shell git config user.name || whoami)" \
 	--current_date "$(shell date +"%m/%d/%y")"
 
 	tuist edit

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -8,18 +8,8 @@ clean:
 	rm -rf **/*.xcodeproj
 	rm -rf *.xcworkspace
 
-reset:
-	tuist clean
-	rm -rf **/**/**/*.xcodeproj
-	rm -rf **/**/*.xcodeproj
-	rm -rf **/*.xcodeproj
-	rm -rf *.xcworkspace
-
 regenerate:
-	rm -rf **/**/**/*.xcodeproj
-	rm -rf **/**/*.xcodeproj
-	rm -rf **/*.xcodeproj
-	rm -rf *.xcworkspace
+	make clean
 	tuist generate
 
 createModule:

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -21,6 +21,13 @@ regenerate:
 	rm -rf **/*.xcodeproj
 	rm -rf *.xcworkspace
 	tuist generate
+
+createModule:
+	@tuist scaffold feature \
+	--name ${name} \
+	--current_date "$(shell date +"%m/%d/%y")"
+
+	tuist edit
 	
 # Privates 파일 다운로드
 

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/Contents.json
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Demo/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/Contents.json
+++ b/SOPT-iOS/Tuist/Templates/feature/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
@@ -2,7 +2,7 @@
 //  Empty.swift
 //  Templates
 //
-//  Created by author on {{ current_date }}
+//  Created by {{ author }} on {{ current_date }}
 //
 
 import Foundation

--- a/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
@@ -1,0 +1,8 @@
+//
+//  Empty.stencil.swift
+//  Templates
+//
+//  Created by 강윤서 on 2/2/25.
+//
+
+import Foundation

--- a/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Empty.stencil
@@ -1,8 +1,8 @@
 //
-//  Empty.stencil.swift
+//  Empty.swift
 //  Templates
 //
-//  Created by 강윤서 on 2/2/25.
+//  Created by author on {{ current_date }}
 //
 
 import Foundation

--- a/SOPT-iOS/Tuist/Templates/feature/Info.plist
+++ b/SOPT-iOS/Tuist/Templates/feature/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   Info.plist
+   Manifests
+
+   Created by 강윤서 on 2/1/25.
+   Copyright (c) 2025 ___ORGANIZATIONNAME___. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/SOPT-iOS/Tuist/Templates/feature/LaunchScreen.storyboard
+++ b/SOPT-iOS/Tuist/Templates/feature/LaunchScreen.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="0.0" y="626.5" width="375" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Templates" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/SOPT-iOS/Tuist/Templates/feature/Project.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Project.stencil
@@ -2,7 +2,7 @@
 //  Project.swift
 //  ProjectDescriptionHelpers
 //
-//  Created by author on {{ current_date }}.
+//  Created by {{ author }} on {{ current_date }}.
 //
 
 import ProjectDescription

--- a/SOPT-iOS/Tuist/Templates/feature/Project.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Project.stencil
@@ -1,0 +1,18 @@
+//
+//  Project.swift
+//  Templates
+//
+//  Created by 강윤서 on 2/1/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: "{{name}}Feature",
+    targets: [.unitTest, .staticFramework, .demo, .interface],
+    interfaceDependencies: [
+        .Features.Web.Feature
+    ]
+)

--- a/SOPT-iOS/Tuist/Templates/feature/Project.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Project.stencil
@@ -12,7 +12,8 @@ import DependencyPlugin
 let project = Project.makeModule(
     name: "{{name}}Feature",
     targets: [.unitTest, .staticFramework, .demo, .interface],
-    interfaceDependencies: [
-        .Features.Web.Feature
+    internalDependencies: [
+    ],
+    interfaceDependencies: [  
     ]
 )

--- a/SOPT-iOS/Tuist/Templates/feature/Project.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Project.stencil
@@ -2,7 +2,7 @@
 //  Project.swift
 //  ProjectDescriptionHelpers
 //
-//  Created by {} on 2/1/25.
+//  Created by author on {{ current_date }}.
 //
 
 import ProjectDescription

--- a/SOPT-iOS/Tuist/Templates/feature/Project.stencil
+++ b/SOPT-iOS/Tuist/Templates/feature/Project.stencil
@@ -1,8 +1,8 @@
 //
 //  Project.swift
-//  Templates
+//  ProjectDescriptionHelpers
 //
-//  Created by 강윤서 on 2/1/25.
+//  Created by {} on 2/1/25.
 //
 
 import ProjectDescription

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -13,5 +13,41 @@ let template = Template(
     description: "Creates a new feature module",
     attributes: [
         nameAttribute
+    ],
+    items: [
+        // Main
+        .directory(path: "Projects/Features/\(nameAttribute)Feature", sourcePath: ""),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Project.swift", templatePath: "Project.stencil"),
+        
+        // Tests
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests", sourcePath: "./"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources/.empty", templatePath: ".empty"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources/.empty", templatePath: ".empty"),
+        
+        // Sources
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Sources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Sources/.empty", templatePath: ".empty"),
+        
+        // Interface
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Interface", sourcePath: "./"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources/.empty", templatePath: ".empty"),
+        
+        // Derived
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived", sourcePath: "./"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources/.empty", templatePath: ".empty"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived/InfoPlists", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/InfoPlists/Info.plist", templatePath: "Info.plist"),
+        
+        // Demo
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo", sourcePath: "./"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/LaunchScreen.storyboard", templatePath: "LaunchScreen.storyboard"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/Assets.xcassets", sourcePath: "Assets.xcassets"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/.empty", templatePath: ".empty"),
     ]
 )

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -1,0 +1,17 @@
+//
+//  feature.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 강윤서 on 2/1/25.
+//
+
+import ProjectDescription
+
+let nameAttribute: Template.Attribute = .required("name")
+
+let template = Template(
+    description: "Creates a new feature module",
+    attributes: [
+        nameAttribute
+    ]
+)

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -8,11 +8,13 @@
 import ProjectDescription
 
 let nameAttribute: Template.Attribute = .required("name")
+let currentDate: Template.Attribute = .required("current_date")
 
 let template = Template(
     description: "Creates a new feature module",
     attributes: [
-        nameAttribute
+        nameAttribute,
+        currentDate
     ],
     items: ModuleTemplate.allCases.flatMap{ $0.item }
 )

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -8,12 +8,14 @@
 import ProjectDescription
 
 let nameAttribute: Template.Attribute = .required("name")
+let author: Template.Attribute = .required("author")
 let currentDate: Template.Attribute = .required("current_date")
 
 let template = Template(
     description: "Creates a new feature module",
     attributes: [
         nameAttribute,
+        author,
         currentDate
     ],
     items: ModuleTemplate.allCases.flatMap{ $0.item }

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -20,34 +20,22 @@ let template = Template(
         .file(path: "Projects/Features/\(nameAttribute)Feature/Project.swift", templatePath: "Project.stencil"),
         
         // Tests
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests", sourcePath: "./"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources/.empty", templatePath: ".empty"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources/.empty", templatePath: ".empty"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources/Empty.swift", templatePath: "Empty.stencil"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources/Empty.swift", templatePath: "Empty.stencil"),
         
         // Sources
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Sources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Sources/.empty", templatePath: ".empty"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Sources/Empty.swift", templatePath: "Empty.stencil"),
         
         // Interface
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Interface", sourcePath: "./"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources/.empty", templatePath: ".empty"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources/Empty.swift", templatePath: "Empty.stencil"),
         
         // Derived
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived", sourcePath: "./"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources/.empty", templatePath: ".empty"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Derived/InfoPlists", sourcePath: "./"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources/Empty.swift", templatePath: "Empty.stencil"),
         .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/InfoPlists/Info.plist", templatePath: "Info.plist"),
         
         // Demo
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo", sourcePath: "./"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/LaunchScreen.storyboard", templatePath: "LaunchScreen.storyboard"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/Assets.xcassets", sourcePath: "Assets.xcassets"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources", sourcePath: "./"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/.empty", templatePath: ".empty"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources/LaunchScreen.storyboard", templatePath: "LaunchScreen.storyboard"),
+        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources/Assets.xcassets", sourcePath: "Assets.xcassets"),
+        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/Empty.swift", templatePath: "Empty.stencil"),
     ]
 )

--- a/SOPT-iOS/Tuist/Templates/feature/feature.swift
+++ b/SOPT-iOS/Tuist/Templates/feature/feature.swift
@@ -14,28 +14,54 @@ let template = Template(
     attributes: [
         nameAttribute
     ],
-    items: [
-        // Main
-        .directory(path: "Projects/Features/\(nameAttribute)Feature", sourcePath: ""),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Project.swift", templatePath: "Project.stencil"),
-        
-        // Tests
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Sources/Empty.swift", templatePath: "Empty.stencil"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Tests/Resources/Empty.swift", templatePath: "Empty.stencil"),
-        
-        // Sources
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Sources/Empty.swift", templatePath: "Empty.stencil"),
-        
-        // Interface
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Interface/Sources/Empty.swift", templatePath: "Empty.stencil"),
-        
-        // Derived
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/Sources/Empty.swift", templatePath: "Empty.stencil"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Derived/InfoPlists/Info.plist", templatePath: "Info.plist"),
-        
-        // Demo
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources/LaunchScreen.storyboard", templatePath: "LaunchScreen.storyboard"),
-        .directory(path: "Projects/Features/\(nameAttribute)Feature/Demo/Resources/Assets.xcassets", sourcePath: "Assets.xcassets"),
-        .file(path: "Projects/Features/\(nameAttribute)Feature/Demo/Sources/Empty.swift", templatePath: "Empty.stencil"),
-    ]
+    items: ModuleTemplate.allCases.flatMap{ $0.item }
 )
+
+enum ModuleTemplate: CaseIterable {
+    case main, tests, sources, interface, derived, demo
+    
+    var path: String {
+        switch self {
+        case .main:
+            return .basePath
+        case .tests:
+            return .basePath + "/Tests"
+        case .sources:
+            return .basePath + "/Sources"
+        case .interface:
+            return .basePath + "/Interface"
+        case .derived:
+            return .basePath + "/Derived"
+        case .demo:
+            return .basePath + "/Demo"
+        }
+    }
+    
+    var item: [Template.Item] {
+        switch self {
+        case .main:
+            return [.directory(path: path, sourcePath: ""),
+                    .file(path: path + "/Project.swift", templatePath: "Project.stencil")]
+        case .tests:
+            return [.file(path: path + "/Sources/Empty.swift", templatePath: "Empty.stencil"),
+                    .file(path: path + "/Resources/Empty.swift", templatePath: "Empty.stencil")]
+        case .sources:
+            return [.file(path: path + "/Empty.swift", templatePath: "Empty.stencil")]
+        case .interface:
+            return [.file(path: path + "/Sources/Empty.swift", templatePath: "Empty.stencil")]
+        case .derived:
+            return [.file(path: path + "/Sources/Empty.swift", templatePath: "Empty.stencil"),
+                    .file(path: path + "/InfoPlists/Info.plist", templatePath: "Info.plist")]
+        case .demo:
+            return [.file(path: path + "/Resources/LaunchScreen.storyboard", templatePath: "LaunchScreen.storyboard"),
+                    .directory(path: path + "/Resources/Assets.xcassets", sourcePath: "Assets.xcassets"),
+                    .file(path: path + "/Sources/Empty.swift", templatePath: "Empty.stencil")]
+        }
+    }
+}
+
+extension String {
+    static var basePath: Self {
+        return "Projects/Features/\(nameAttribute)Feature"
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#491

## 🌱 PR Point
- 모듈 생성 자동화 명령어를 구현했어요. 앞으로 모듈을 생성할 때 아래 명령어를 사용해주세요!
   ```bash
   make createModule name=모듈이름      # Main을 입력하면 MainFeature가 생성됩니다.
   ```
- `tuist scaffold`으로 모듈을 생성한 다음 `tuist edit`로 편집기를 열도록 해두었어요. **`Project.swift`에서 모듈 간 의존성을 지정**해주세요.
- 그 다음, **`Dependency+Project.swift`에서 새 모듈에 대한 코드를 추가**해주세요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 앞으로 모듈을 생성할 일이 많지 않을 것 같고 대부분이 기능 모듈일 것이라 생각해요. 그래서 모듈 이름에 항상 Feature를 붙이도록 해두었는데, 접미사가 없는 것이 좋을까요?
- `Dependency+Project.swift` 도 스크립트로 자동화할 수 있을 것 같아요. 하지만 모듈마다 필요한 설정이 다를 듯 하여 구현하지 않았습니다!!
- Makefile에서 reset과 clean의 차이점을 잘 모르겠어요. 차이가 없다면 하나만 남겨도 될까요? (`make reset` 제거 했습니다!)

## 📸 스크린샷

https://github.com/user-attachments/assets/276bd4a7-a218-435c-9e72-5ad6007d9d43



## 📮 관련 이슈
- Resolved: #491 
