### PR TITLE
[Hotfix] #498 - 신규 홈뷰 및 솝트로그: 두 번째 QA 내용 반영

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
@@ -19,7 +19,7 @@ extension SoptlogResponseEntity {
                                  soptampRank: self.soptampRank ?? "0",
                                  pokeCount: self.pokeCount,
                                  soptLevel: self.soptLevel,
-                                 during: self.during ?? 0,
+                                 during: self.during,
                                  profileMessage: self.profileMessage,
                                  icons: self.icons,
                                  isFortuneChecked: self.isFortuneChecked,

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -15,14 +15,14 @@ public struct  SoptlogModel {
     public let soptampRank: String
     public let pokeCount: String
     public let soptLevel: String
-    public let during: Int
+    public let during: String
     public let profileMessage: String
     public let icons: [String]
     public let isFortuneChecked: Bool
     public let todayFortuneText: String
     public let isActive: Bool
     
-    public init(userName: String?, profileImage: String?, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: Int, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+    public init(userName: String?, profileImage: String?, part: String, soptampRank: String, pokeCount: String, soptLevel: String, during: String, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
         self.userName = userName
         self.profileImage = profileImage
         self.part = part

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
@@ -99,17 +99,16 @@ extension DailySoptuneResultVC {
         self.view.addSubviews(backButton, scrollView, receiveTodaysFortuneCardButton)
         
         backButton.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(2.adjustedH)
-            make.leading.equalToSuperview().inset(8.adjusted)
-            make.size.equalTo(40.adjusted)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(2)
+            make.leading.equalToSuperview().inset(8)
+            make.size.equalTo(40)
         }
         
         setScrollViewLayout()
         
         receiveTodaysFortuneCardButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(56)
-            make.width.equalTo(335)
             make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).inset(16)
         }
     }
@@ -126,7 +125,7 @@ extension DailySoptuneResultVC {
         contentStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalToSuperview().inset(17.adjustedH)
-            make.width.equalTo((self.view.frame.size.width - 20 * 2).adjusted)
+            make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(20.adjustedH)
         }
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -78,6 +78,16 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
         registerCells()
         bindViewModels()
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        if let gradientLayer = gradientView.layer.sublayers?.first as? CAGradientLayer {
+            gradientLayer.frame = gradientView.bounds
+        }
+
+        scrollToRecentSchedule()
+    }
 }
 
 // MARK: - UI & Layout

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -78,16 +78,6 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
         registerCells()
         bindViewModels()
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        if let gradientLayer = gradientView.layer.sublayers?.first as? CAGradientLayer {
-            gradientLayer.frame = gradientView.bounds
-        }
-        
-        scrollToRecentSchedule()
-    }
 }
 
 // MARK: - UI & Layout
@@ -138,8 +128,8 @@ extension HomeCalendarDetailVC {
     
     private func bindViewModels() {
         let input = HomeCalendarDetailViewModel.Input(
-            viewDidLoad: Just<Void>(()).asDriver(), 
-            naviBackButtonTap: self.naviBar.leftButtonTapped.asDriver(), 
+            viewDidLoad: Just<Void>(()).asDriver(),
+            naviBackButtonTap: self.naviBar.leftButtonTapped.asDriver(),
             onAttendanceButtonTap: self.attendanceButton
                 .publisher(for: .touchUpInside)
                 .withUnretained(self)
@@ -154,15 +144,20 @@ extension HomeCalendarDetailVC {
             .sink { owner, calendarDetailInfo in
                 owner.calendarDetailInfo = calendarDetailInfo
                 owner.collectionView.reloadData()
+                self.scrollToRecentSchedule()
             }.store(in: cancelBag)
-            
+        
     }
     
     private func scrollToRecentSchedule() {
         if let index = self.calendarDetailInfo?.firstIndex(where: {$0.isRecentSchedule}) {
-            self.collectionView.scrollToItem(at: IndexPath(item: index, section: 0),
-                                             at: .top,
-                                        animated: true)
+            let itemCount = collectionView.numberOfItems(inSection: 0)
+            guard index < itemCount else {
+                print("🚨 아이템이 부족하여 스크롤할 수 없습니다.")
+                return
+            }
+            
+            self.collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .top, animated: true)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -86,7 +86,6 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
             gradientLayer.frame = gradientView.bounds
         }
 
-        scrollToRecentSchedule()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/AppService/AppServiceCardCVC.swift
@@ -81,10 +81,10 @@ extension AppServiceCardCVC {
     func configureCell(model: HomePresentationModel.AppService) {
         self.logoImageView.setImage(with: model.iconURL)
         self.titleLabel.text = model.serviceName
-        if model.alarmBadge.isEmpty {
-            self.notificationBadgeView.isHidden = true
-        } else {
+        if model.displayAlarmBadge && !model.alarmBadge.isEmpty {
             self.notificationBadgeView.setData(with: model.alarmBadge)
+        } else {
+            self.notificationBadgeView.isHidden = true
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -91,6 +91,7 @@ extension DashBoardCardCVC {
             self.descriptionLabel.text = I18N.Home.DashBoard.UserHistory.encourage
             self.descriptionLabel.setLineSpacing(lineSpacing: 5)
             self.rightArrowWithCircleImageView.isHidden = true
+            userHistoryView.setData(userType: userType, recentHistory: nil, allHistory: nil)
         case .active, .inactive:
             guard let model else { return }
             guard let description = model.description else { return }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -102,7 +102,7 @@ extension DashBoardCardCVC {
             self.descriptionLabel.setLineSpacing(lineSpacing: 5)
             self.rightArrowWithCircleImageView.isHidden = false
             guard let history = model.history else { return }
-            userHistoryView.setData(userType: userType, recentHistory: 35, allHistory: history)
+            userHistoryView.setData(userType: userType, recentHistory: history.first, allHistory: history)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -33,7 +33,7 @@ public protocol HomeCoordinatorOutput {
 
 public typealias DefaultHomeCoordinator = BaseCoordinator & HomeCoordinatorOutput
 
-public final class HomeCoordinator: DefaultCoordinator {
+public final class HomeCoordinator: DefaultHomeCoordinator {
     
     public var requestCoordinating: ((HomeCoordinatorDestination) -> Void)?
     public var finishFlow: (() -> Void)?

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -20,7 +20,6 @@ public enum HomeCoordinatorDestination {
     case signIn
     case notification
     case setting(userType: UserType)
-    case calendar
     case attendance
     case soptlog
     
@@ -127,7 +126,6 @@ public final class HomeCoordinator: DefaultCoordinator {
         
         homeCalendarDetail.vm.onNaviBackButtonTap = { [weak self] in
             self?.router.popModule()
-            self?.finishFlow?()
         }
         
         homeCalendarDetail.vm.onAttendanceButtonTap = { [weak self] in

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -26,14 +26,16 @@ struct HomePresentationModel {
     // MARK: - Item Structs
     
     struct DashBoard: Identifiable, Hashable {
-        let id = UUID()
+        let id = "dashboard"
         
         let description: String?
         let history: [Int]?
+        let isAllConfirm: Bool?
         
-        init(description: String? = nil, history: [Int]? = nil) {
+        init(description: String? = nil, history: [Int]? = nil, isAllConfirm: Bool? = nil) {
             self.description = description
             self.history = history
+            self.isAllConfirm = isAllConfirm
         }
     }
     
@@ -211,10 +213,11 @@ struct HomePresentationModel {
 // MARK: - toPresentation
 
 extension HomeDescriptionModel {
-    func toPresentation(history: [Int]) -> HomePresentationModel.DashBoard {
+    func toPresentation(history: [Int], isAllConfirm: Bool?) -> HomePresentationModel.DashBoard {
         return HomePresentationModel.DashBoard(
             description: self.description,
-            history: history
+            history: history,
+            isAllConfirm: isAllConfirm
         )
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -21,7 +21,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     
     public let viewModel: HomeForMemberViewModel
     private(set) var cancelBag = CancelBag()
-    private var requestUserInfo = PassthroughSubject<Void, Never>()
+    private var viewWillAppear = PassthroughSubject<Void, Never>()
     private var cellTapped = PassthroughSubject<HomeForMemberItem, Never>()
     private(set) var attendanceButtonTapped = PassthroughSubject<Void, Never>()
     
@@ -58,7 +58,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.requestUserInfo.send()
+        self.viewWillAppear.send()
     }
 }
 
@@ -184,8 +184,7 @@ extension HomeForMemberVC {
             .asDriver()
         
         let input = HomeForMemberViewModel.Input(
-            viewDidLoad: Just<Void>(()).asDriver(),
-            requestUserInfo: requestUserInfo.asDriver(),
+            viewWillAppear: viewWillAppear.asDriver(),
             cellTapped: cellTapped.asDriver(),
             attendanceButtonTapped: attendanceButtonTapped.asDriver(),
             noticeButtonTapped: noticeButtonTapped,
@@ -197,17 +196,8 @@ extension HomeForMemberVC {
         output.homeItem
             .withUnretained(self)
             .sink { owner, data in
-                owner.changeNaviBarUI(isAllConfirm: data.dashBoard.isAllConfirm)
-                owner.applySnapshot(with: data)
+                owner.updateUI(with: data)
             }.store(in: cancelBag)
-        
-        output.dashBoard
-            .withUnretained(self)
-            .sink { owner, data in
-                owner.changeNaviBarUI(isAllConfirm: data.isAllConfirm)
-                owner.setDashBoardNeedsUpdate(data)
-            }
-            .store(in: cancelBag)
         
         output.isLoading
             .withUnretained(self)
@@ -217,7 +207,17 @@ extension HomeForMemberVC {
             .store(in: cancelBag)
     }
     
-    private func changeNaviBarUI(isAllConfirm: Bool?) {
+    private func updateUI(with data: HomePresentationModel) {
+        if isFirstAppear {
+            applySnapshot(with: data)
+            isFirstAppear = false
+        } else {
+            setItemsNeedUpdate(data)
+        }
+        updateNaviBarUI(isAllConfirm: data.dashBoard.isAllConfirm)
+    }
+    
+    private func updateNaviBarUI(isAllConfirm: Bool?) {
         if let isAllConfirm = isAllConfirm {
             self.naviBar.changeNoticeButtonStyle(isActive: !isAllConfirm)
         }
@@ -244,11 +244,18 @@ extension HomeForMemberVC {
         dataSource.apply(snapshot, animatingDifferences: true)
     }
     
-    private func setDashBoardNeedsUpdate(_ dashBoard: HomePresentationModel.DashBoard) {
+    private func setItemsNeedUpdate(_ data: HomePresentationModel) {
         var snapshot = self.dataSource.snapshot()
-        let dashBoardItem = HomeForMemberItem.dashBoard(dashBoard)
-        if snapshot.itemIdentifiers.contains(dashBoardItem) {
-            snapshot.reconfigureItems([dashBoardItem])
+        
+        let items: [HomeForMemberItem] = [
+            .dashBoard(data.dashBoard),
+            .recentSchedule(data.recentSchedule)
+        ] + data.appServices.map { .appService($0) }
+        
+        let existingItems = snapshot.itemIdentifiers.filter { items.contains($0) }
+        
+        if !existingItems.isEmpty {
+            snapshot.reconfigureItems(existingItems)
             self.dataSource.apply(snapshot, animatingDifferences: true)
         }
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -18,11 +18,14 @@ import BaseFeatureDependency
 final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     
     // MARK: - Properties
-
+    
     public let viewModel: HomeForMemberViewModel
     private(set) var cancelBag = CancelBag()
+    private var requestUserInfo = PassthroughSubject<Void, Never>()
     private var cellTapped = PassthroughSubject<HomeForMemberItem, Never>()
     private(set) var attendanceButtonTapped = PassthroughSubject<Void, Never>()
+    
+    private var isFirstAppear = true
     
     // MARK: - UI Components
     
@@ -51,6 +54,11 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         configureDelegate()
         configureDataSource()
         bindViewModels()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.requestUserInfo.send()
     }
 }
 
@@ -177,6 +185,7 @@ extension HomeForMemberVC {
         
         let input = HomeForMemberViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
+            requestUserInfo: requestUserInfo.asDriver(),
             cellTapped: cellTapped.asDriver(),
             attendanceButtonTapped: attendanceButtonTapped.asDriver(),
             noticeButtonTapped: noticeButtonTapped,
@@ -188,8 +197,17 @@ extension HomeForMemberVC {
         output.homeItem
             .withUnretained(self)
             .sink { owner, data in
+                owner.changeNaviBarUI(isAllConfirm: data.dashBoard.isAllConfirm)
                 owner.applySnapshot(with: data)
             }.store(in: cancelBag)
+        
+        output.dashBoard
+            .withUnretained(self)
+            .sink { owner, data in
+                owner.changeNaviBarUI(isAllConfirm: data.isAllConfirm)
+                owner.setDashBoardNeedsUpdate(data)
+            }
+            .store(in: cancelBag)
         
         output.isLoading
             .withUnretained(self)
@@ -197,6 +215,12 @@ extension HomeForMemberVC {
                 isLoading ? owner.showLoading() : owner.stopLoading()
             }
             .store(in: cancelBag)
+    }
+    
+    private func changeNaviBarUI(isAllConfirm: Bool?) {
+        if let isAllConfirm = isAllConfirm {
+            self.naviBar.changeNoticeButtonStyle(isActive: !isAllConfirm)
+        }
     }
     
     private func applySnapshot(with data: HomePresentationModel) {
@@ -218,6 +242,15 @@ extension HomeForMemberVC {
 //        snapshot.appendItems(SocialLinkCardType.allCases.map { .socialLink($0) }, toSection: .socialLinks)
 //        
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func setDashBoardNeedsUpdate(_ dashBoard: HomePresentationModel.DashBoard) {
+        var snapshot = self.dataSource.snapshot()
+        let dashBoardItem = HomeForMemberItem.dashBoard(dashBoard)
+        if snapshot.itemIdentifiers.contains(dashBoardItem) {
+            snapshot.reconfigureItems([dashBoardItem])
+            self.dataSource.apply(snapshot, animatingDifferences: true)
+        }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -36,8 +36,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     // MARK: - Inputs
     
     public struct Input {
-        let viewDidLoad: Driver<Void>
-        let requestUserInfo: Driver<Void>
+        let viewWillAppear: Driver<Void>
         let cellTapped: Driver<HomeForMemberItem>
         let attendanceButtonTapped: Driver<Void>
         let noticeButtonTapped: Driver<Void>
@@ -48,7 +47,6 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     public struct Output {
         let homeItem = PassthroughSubject<HomePresentationModel, Never>()
-        let dashBoard = PassthroughSubject<HomePresentationModel.DashBoard, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
     }
     
@@ -73,7 +71,7 @@ extension HomeForMemberViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
 
-        input.viewDidLoad
+        input.viewWillAppear
             .handleEvents(receiveOutput: { _ in
                 output.isLoading.send(true)
             })
@@ -121,25 +119,6 @@ extension HomeForMemberViewModel {
             .withUnretained(self)
             .sink { owner, data in
                 output.homeItem.send(data)
-                output.isLoading.send(false)
-            }
-            .store(in: cancelBag)
-        
-        input.requestUserInfo
-            .dropFirst()
-            .handleEvents(receiveOutput: { _ in
-                output.isLoading.send(true)
-            })
-            .flatMap { _ in
-                self.useCase.getUserInfo()
-            }
-            .compactMap { $0 }
-            .flatMap { userInfo in
-                self.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList, isAllConfirm: userInfo.isAllConfirm) }
-            }
-            .withUnretained(self)
-            .sink { owner, data in
-                output.dashBoard.send(data)
                 output.isLoading.send(false)
             }
             .store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -37,6 +37,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     public struct Input {
         let viewDidLoad: Driver<Void>
+        let requestUserInfo: Driver<Void>
         let cellTapped: Driver<HomeForMemberItem>
         let attendanceButtonTapped: Driver<Void>
         let noticeButtonTapped: Driver<Void>
@@ -47,6 +48,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     public struct Output {
         let homeItem = PassthroughSubject<HomePresentationModel, Never>()
+        let dashBoard = PassthroughSubject<HomePresentationModel.DashBoard, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
     }
     
@@ -81,7 +83,7 @@ extension HomeForMemberViewModel {
             .compactMap { $0 }
             .flatMap { userInfo in
                 Publishers.Zip3(
-                    self.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList) },
+                    self.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList, isAllConfirm: userInfo.isAllConfirm) },
                     self.useCase.getRecentSchedule().map { $0.toPresentation() },
                     self.useCase.getAppServices().map { $0.map { $0.toPresentation() } }
                 )
@@ -119,6 +121,25 @@ extension HomeForMemberViewModel {
             .withUnretained(self)
             .sink { owner, data in
                 output.homeItem.send(data)
+                output.isLoading.send(false)
+            }
+            .store(in: cancelBag)
+        
+        input.requestUserInfo
+            .dropFirst()
+            .handleEvents(receiveOutput: { _ in
+                output.isLoading.send(true)
+            })
+            .flatMap { _ in
+                self.useCase.getUserInfo()
+            }
+            .compactMap { $0 }
+            .flatMap { userInfo in
+                self.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList, isAllConfirm: userInfo.isAllConfirm) }
+            }
+            .withUnretained(self)
+            .sink { owner, data in
+                output.dashBoard.send(data)
                 output.isLoading.send(false)
             }
             .store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -88,7 +88,8 @@ extension ApplicationCoordinator {
     }
     
     private func handleDeepLink(deepLink: DeepLinkComponentsExecutable) {
-        self.router.dismissModule(animated: false)
+        // TODO: 해당 부분 왜 .dismissModule(animated: false) 하고 있었는지 확인
+//        self.router.dismissModule(animated: false)
         deepLink.execute(coordinator: self)
     }
     
@@ -211,10 +212,6 @@ extension ApplicationCoordinator {
             factory: HomeBuilder(),
             userType: userType
         )
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            self?.removeDependency(coordinator)
-        }
-        
         coordinator.requestCoordinating = { [weak self, weak coordinator] destination in
             switch destination {
             case .attendance:

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -59,7 +59,7 @@ extension ApplicationCoordinator {
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .filter { _ in
-                self.childCoordinators.contains(where: { $0 is MainCoordinator })
+                self.childCoordinators.contains(where: { $0 is HomeCoordinator })
             }
             .sink { [weak self] deepLinkComponent in
                 self?.handleDeepLink(deepLink: deepLinkComponent)
@@ -70,7 +70,7 @@ extension ApplicationCoordinator {
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .filter { _ in
-                self.childCoordinators.contains(where: { $0 is MainCoordinator })
+                self.childCoordinators.contains(where: { $0 is HomeCoordinator })
             }.sink { [weak self] url in
                 self?.handleWebLink(webLink: url)
                 self?.notificationHandler.clearNotificationRecord()
@@ -80,7 +80,7 @@ extension ApplicationCoordinator {
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .filter { _ in
-                self.childCoordinators.contains(where: { $0 is MainCoordinator })
+                self.childCoordinators.contains(where: { $0 is HomeCoordinator })
             }.sink { [weak self] error in
                 self?.handleNotificationLinkError(error: error)
                 self?.notificationHandler.clearNotificationRecord()

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -217,8 +217,6 @@ extension ApplicationCoordinator {
         
         coordinator.requestCoordinating = { [weak self, weak coordinator] destination in
             switch destination {
-            case .calendar:
-                self?.runAttendanceFlow()
             case .attendance:
                 self?.runAttendanceFlow()
             case .setting(let userType):

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/HomeDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/HomeDeepLink.swift
@@ -18,7 +18,7 @@ public struct HomeDeepLink: DeepLinkExecutable {
         guard let coordinator = coordinator as? ApplicationCoordinator else { return nil }
         
         if self.isDestination == true {
-            coordinator.runMainFlow()
+            coordinator.runHomeFlow()
         }
         
         return coordinator

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAlarmCVC.swift
@@ -17,6 +17,7 @@ final class SoptlogAlarmCVC: UICollectionViewCell {
     
     private let serviceImageView = UIImageView().then {
         $0.image = DSKitAsset.Assets.imgDailysoptune.image
+        $0.contentMode = .scaleAspectFit
     }
 
     private let titleLabel = UILabel().then {

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Cell/SoptlogAppServiceCVC.swift
@@ -14,7 +14,13 @@ import DSKit
 final class SoptlogAppServiceCVC: UICollectionViewCell {
     
     // MARK: - UI Components
-
+    
+    private let stackView = UIStackView(frame: .zero).then {
+        $0.axis = .vertical
+        $0.spacing = 6
+        $0.alignment = .center
+    }
+    
     private let serviceLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.gray200.color
         $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
@@ -40,6 +46,11 @@ final class SoptlogAppServiceCVC: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.stackView.removeAllSubViews()
+    }
 }
 
 // MARK: - UI & Layout
@@ -50,22 +61,16 @@ extension SoptlogAppServiceCVC {
     }
     
     private func setLayout() {
-        contentView.addSubviews(serviceLabel, serviceImageView, serviceValue)
-        
-        serviceLabel.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalToSuperview().inset(10)
-        }
+        stackView.addArrangedSubviews(serviceLabel, serviceImageView, serviceValue)
         
         serviceImageView.snp.makeConstraints { make in
             make.size.equalTo(39)
-            make.centerX.equalToSuperview()
-            make.top.equalTo(serviceLabel.snp.bottom).offset(6)
         }
         
-        serviceValue.snp.makeConstraints { make in
-            make.top.equalTo(serviceImageView.snp.bottom).offset(4)
-            make.centerX.equalToSuperview()
+        contentView.addSubviews(stackView)
+        
+        stackView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -165,7 +165,6 @@ extension SoptlogVC: UICollectionViewDataSource {
         case .appService: return self.soptlogInfo?.appService.count ?? 0
         case .editProfile: return 1
         case .alarm: return 1
-        default: return 0
         }
     }
     

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -209,8 +209,6 @@ extension SoptlogVC: UICollectionViewDataSource {
                 for: indexPath) as? SoptlogAlarmCVC else { return UICollectionViewCell() }
             alarmCell.configureCell(model: self.soptlogInfo?.alarm)
             return alarmCell
-            
-        default: return UICollectionViewCell()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -120,6 +120,13 @@ extension SoptlogVC {
                 owner.soptlogInfo = soptlogModel
                 owner.collectionView.reloadData()
             }.store(in: cancelBag)
+        
+        output.isLoading
+            .withUnretained(self)
+            .sink { owner, isLoading in
+                isLoading ? owner.showLoading() : owner.stopLoading()
+            }
+            .store(in: cancelBag)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -81,7 +81,7 @@ extension SoptlogViewModel {
             .sink { owner, _ in
                 owner.onAlarmTapped?()
             }.store(in: cancelBag)
-        
+
         return output
     }
 }
@@ -107,7 +107,7 @@ extension SoptlogModel {
             appService.append(SoptlogPresentationModel.AppService(
                 serviceName: I18N.Soptlog.withSopt,
                 serviceImageURL: self.icons[2],
-                serviceValue: "\(self.during)개월"))
+                serviceValue: self.during))
         }
         
         

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -34,6 +34,7 @@ public class SoptlogViewModel: SoptlogViewModelType {
     
     public struct Output {
         let soptlogInfo = PassthroughSubject<SoptlogPresentationModel, Never>()
+        let isLoading = PassthroughSubject<Bool, Never>()
     }
     
     // MARK: - SoptlogCoordinatable
@@ -55,11 +56,15 @@ extension SoptlogViewModel {
         let output = Output()
         
         input.viewDidLoad
+            .handleEvents(receiveOutput: { _ in
+                output.isLoading.send(true)
+            })
             .flatMap(useCase.fetchSoptlogInfo)
             .withUnretained(self)
             .sink { owner, soptlogModel in
                 let info = soptlogModel.toPresentation()
                 output.soptlogInfo.send(info)
+                output.isLoading.send(false)
             }.store(in: cancelBag)
         
         input.naviBackButtonTap

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
@@ -56,4 +56,13 @@ extension HomeAPI: BaseAPI {
             return .requestParameters(parameters: ["page": 1, "take": 10, "category": "행사,세미나"], encoding: URLEncoding.queryString)
         }
     }
+    
+    public var headers: [String : String]? {
+        switch self {
+        case .getAppServiceAccessStatus:
+            let userType = UserDefaultKeyList.Auth.getUserType()
+            return userType == .visitor ? HeaderType.json.value : HeaderType.jsonWithToken.value
+        default: return HeaderType.jsonWithToken.value
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -16,14 +16,14 @@ public struct SoptlogResponseEntity: Decodable {
     public let soptampRank: String?
     public let pokeCount: String
     public let soptLevel: String
-    public let during: Int?
+    public let during: String
     public let profileMessage: String
     public let icons: [String]
     public let isFortuneChecked: Bool
     public let todayFortuneText: String
     public let isActive: Bool
     
-    public init(userName: String?, profileImage: String?, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: Int?, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
+    public init(userName: String?, profileImage: String?, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: String, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
         self.userName = userName
         self.profileImage = profileImage
         self.part = part


### PR DESCRIPTION
## 🌴 PR 요약
신규 홈뷰 및 솝트로그: 두 번째 QA 내용을 반영했습니다.

🌱 작업한 브랜치
- #498 

## 🌱 PR Point

- 금일 QA에서 발견됐던 내용들 중에서 할 수 있는 것들은 최대한 해결해뒀습니다~! (이슈에 체크리스트 만들었어용)
- QA 내용 외에도 (아무도 발견하지 못했던..) 저의 자잘한 실수들 혹은 잘못된 분기, 레이아웃 등등 다양하게 수정해뒀습니다.
- 근데 **캘린더 디테일뷰에서 가장 가까운 날짜의 이벤트 확인** -> 이 부분은 윤서 님이 봐주시는 게 더 정확할 것 같아서 따로 수정 안했습니다!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 지금 걱정되는 게 있는데요... mainFlow를 homeFlow로 변경하면서 딥링크 로직들이 조금씩 꼬이는 것 같은데 (ㅜ) 
제가 딥링크 로직을 짠 게 아니라서 좀 파악할 시간이 필요할 것 같습니다...
- 딥링크 관련 코드들을 직접 건드려 놓은 부분들이 있는데
1. **HomeDeepLink** 호출 시 runMainFlow 대신 **runHomeFlow**로 변경
2. **bindNotification() -> childCoordinators**에 MainCoordinator 포함되었는지 확인하는 부분 **HomeCoordinator**로 변경
3. handleDeepLink에서 **self.router.dismissModule(animated: false)** 주석 처리

2번 로직은 (확실치 않지만) 가장 root가 되는 메인 플로우가 진행되고 있는지를 확인하는 것 같은데, 저희 메인 플로우가 홈으로 변경되어서 해당 부분을 수정했거든요. 그랬더니 딥링크로 호출되는 화면들이 present 되자마자 dismiss 되는 현상이 나타나, 3번으로 대응했더니 해결됐습니다.

분명 딥링크 핸들링하기 전에 root controller를 dismiss 해야 하는 이유가 있었을텐데... 이유를 아직 잘 모르지만 일단 미심쩍은 상태로 해결했습니다.. -> 해결..했습니다 ..

딥링크 부분 읽다보니까 저희 탭바 생기면.. 딥링크에 관련해서 한 번 논의해봐야 될 것 같네요 ..

- 네트워크 모달 등 홈뷰 에러 처리도 필요할 것 같은데, QA 이슈에 함께 달만한 내용은 아닌 것 같아서 따로 이슈파서 작업하겠습니다.
- 그리고 레거시 뷰들 중에 메모리 릭 나는 부분들이 꽤 있네요... 일단은 흐린눈 하겠습니다 
- 탭바도 작업하신 부분까지 올려주시면 고쳐보겠습니다~ @yungu0010 


## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #498 
