### PR TITLE
[Feat] #502 - 홈뷰, 솝트로그 에러처리 및 푸시알림 권한 요청 플로우 추가

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -34,6 +34,14 @@ public class HomeRepository {
 }
 
 extension HomeRepository: HomeRepositoryInterface {
+    public func registerPushToken(with token: String) -> AnyPublisher<Bool, any Error> {
+        userService.registerPushToken(with: token)
+            .map {
+                return 200..<300 ~= $0
+            }
+            .eraseToAnyPublisher()
+    }
+    
     public func getAppServices() -> AnyPublisher<[Domain.HomeAppServicesModel], any Error> {
         homeService.getAppServiceAccessStatus()
             .map { $0.map { $0.toDomain() } }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptlogRepository.swift
@@ -24,8 +24,22 @@ public class SoptlogRepository {
 }
 
 extension SoptlogRepository: SoptlogRepositoryInterface {
-    public func fetchSoptlogModel() -> AnyPublisher<Domain.SoptlogModel, any Error> {
+    public func fetchSoptlogModel() -> AnyPublisher<Domain.SoptlogModel, MainError> {
         return self.userService.fetchSoptlogInfo()
+            .mapError{ error in
+                guard let error = error as? APIError else {
+                    return MainError.networkError(message: error.localizedDescription)
+                }
+                
+                switch error {
+                case .network(_, _):
+                    return MainError.networkError(message: "networkError: \(error.localizedDescription)")
+                case .tokenReissuanceFailed:
+                    return MainError.authFailed
+                default:
+                    return MainError.networkError(message: error.localizedDescription)
+                }
+            }
             .map{ $0.toDomain() }
             .eraseToAnyPublisher()
     }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -11,6 +11,7 @@ import Combine
 import Core
 
 public protocol HomeRepositoryInterface {
+    func registerPushToken(with token: String) -> AnyPublisher<Bool, Error>
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Error>
     func getUserInfo() -> AnyPublisher<UserMainInfoModel?, MainError>
     func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Error>

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptlogRepositoryInterface.swift
@@ -11,5 +11,5 @@ import Combine
 import Core
 
 public protocol SoptlogRepositoryInterface {
-    func fetchSoptlogModel() -> AnyPublisher<SoptlogModel, Error>
+    func fetchSoptlogModel() -> AnyPublisher<SoptlogModel, MainError>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -11,6 +11,7 @@ import Combine
 import Core
 
 public protocol HomeUseCase {
+    func registerPushToken()
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Never>
     func getUserInfo() -> AnyPublisher<UserMainInfoModel?, Never>
     func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Never>
@@ -34,7 +35,18 @@ public class DefaultHomeUseCase {
 }
 
 extension DefaultHomeUseCase: HomeUseCase {
-
+    public func registerPushToken() {
+        guard let pushToken = UserDefaultKeyList.User.pushToken, !pushToken.isEmpty else { return }
+        
+        repository.registerPushToken(with: pushToken)
+            .sink { event in
+                print("MainUseCase Register PushToken: \(event)")
+            } receiveValue: { didSucceed in
+                print("푸시 토큰 등록 결과: \(didSucceed)")
+            }.store(in: cancelBag)
+    }
+    
+    
     public func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Never> {
         repository.getHomeDescription()
             .catch { error in

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -13,7 +13,7 @@ import Core
 public protocol HomeUseCase {
     func registerPushToken()
     func getHomeDescription() -> AnyPublisher<HomeDescriptionModel, Never>
-    func getUserInfo() -> AnyPublisher<UserMainInfoModel?, Never>
+    func getUserInfo() -> AnyPublisher<UserMainInfoModel?, MainError>
     func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Never>
     func getAppServices() -> AnyPublisher<[HomeAppServicesModel], Never>
     func getInsightPosts() -> AnyPublisher<[HomeInsightPostsModel], Never>
@@ -54,11 +54,9 @@ extension DefaultHomeUseCase: HomeUseCase {
             }.eraseToAnyPublisher()
     }
     
-    public func getUserInfo() -> AnyPublisher<UserMainInfoModel?, Never> {
+    public func getUserInfo() -> AnyPublisher<UserMainInfoModel?, MainError> {
         repository.getUserInfo()
-            .catch { error in
-                return Empty<UserMainInfoModel?, Never>()
-            }.eraseToAnyPublisher()
+            .eraseToAnyPublisher()
     }
     
     public func getRecentSchedule() -> AnyPublisher<HomeRecentScheduleModel, Never> {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptlogUseCase.swift
@@ -9,9 +9,10 @@
 import Combine
 
 import Core
+import Networks
 
 public protocol SoptlogUseCase {
-    func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, Never>
+    func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, MainError>
 }
 
 public class DefaultSoptlogUseCase: SoptlogUseCase {
@@ -25,12 +26,8 @@ public class DefaultSoptlogUseCase: SoptlogUseCase {
 }
 
 extension DefaultSoptlogUseCase {
-    public func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, Never> {
+    public func fetchSoptlogInfo() -> AnyPublisher<SoptlogModel, MainError> {
         self.repository.fetchSoptlogModel()
-            .catch { error in
-                print("Error: \(error)")
-                return Empty<SoptlogModel, Never>()
-            }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
@@ -20,6 +20,8 @@ public protocol HomeForMemberCoordinatable {
     var onAppServiceCellTapped: ((String) -> Void)? { get set }
     var onNotificationButtonTapped: (() -> Void)? { get set }
     var onSettingButtonTapped: ((UserType) -> Void)? { get set }
+    var onNeedSignIn: (() -> Void)? { get set }
+    var onNetworkError: (() -> Void)? { get set }
 }
 public typealias HomeForMemberViewModelType = ViewModelType & HomeForMemberCoordinatable
 public typealias HomeForMemberPresentable = (vc: HomeForMemberViewControllable, vm: any HomeForMemberViewModelType)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -95,7 +95,14 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
         homeForMember.vm.onAttendanceButtonTapped = { [weak self] in
             self?.requestCoordinating?(.attendance)
         }
+        
+        homeForMember.vm.onNeedSignIn = { [weak self] in
+            self?.requestCoordinating?(.signIn)
+        }
     
+        homeForMember.vm.onNetworkError = {
+            AlertUtils.presentNetworkAlertVC()
+        }
         rootViewController = homeForMember.vc.viewController
         
         router.push(homeForMember.vc)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -20,7 +20,7 @@ import BaseFeatureDependency
 public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     // MARK: - Properties
-
+    
     private let useCase: HomeUseCase
     private var cancelBag = CancelBag()
     
@@ -50,6 +50,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public struct Output {
         let homeItem = PassthroughSubject<HomePresentationModel, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
+        let needNetworkAlert = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - HomeForMemberCoordinating
@@ -61,6 +62,8 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public var onAppServiceCellTapped: ((String) -> Void)?
     public var onNotificationButtonTapped: (() -> Void)?
     public var onSettingButtonTapped: ((UserType) -> Void)?
+    public var onNeedSignIn: (() -> Void)?
+    public var onNetworkError: (() -> Void)?
     
     // MARK: - initialization
     
@@ -79,20 +82,31 @@ extension HomeForMemberViewModel {
                 owner.useCase.getReportURL()
                 owner.requestAuthorizationForNotification()
             }.store(in: cancelBag)
-
+        
         input.viewWillAppear
             .handleEvents(receiveOutput: { _ in
                 output.isLoading.send(true)
             })
             .flatMap { _ in
                 self.useCase.getUserInfo()
+                    .catch{ mainError -> AnyPublisher<UserMainInfoModel?, Never> in
+                        switch mainError {
+                        case .networkError(_):
+                            self.onNetworkError?()
+                            return Empty().eraseToAnyPublisher()
+                        case .authFailed:
+                            self.onNeedSignIn?()
+                            return Empty().eraseToAnyPublisher()
+                        }
+                    }
             }
             .compactMap { $0 }
-            .flatMap { userInfo in
+            .withUnretained(self)
+            .flatMap { owner, userInfo in
                 Publishers.Zip3(
-                    self.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList, isAllConfirm: userInfo.isAllConfirm) },
-                    self.useCase.getRecentSchedule().map { $0.toPresentation() },
-                    self.useCase.getAppServices().map { $0.map { $0.toPresentation() } }
+                    owner.useCase.getHomeDescription().map { $0.toPresentation(history: userInfo.historyList, isAllConfirm: userInfo.isAllConfirm) },
+                    owner.useCase.getRecentSchedule().map { $0.toPresentation() },
+                    owner.useCase.getAppServices().map { $0.map { $0.toPresentation() } }
                 )
                 .map { dashBoard, recentSchedule, appService in
                     HomePresentationModel(
@@ -125,8 +139,7 @@ extension HomeForMemberViewModel {
         //                    )
         //                }
         //            }
-            .withUnretained(self)
-            .sink { owner, data in
+            .sink { data in
                 output.homeItem.send(data)
                 output.isLoading.send(false)
             }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import UserNotifications
 
 import Core
 import Domain
@@ -76,6 +77,7 @@ extension HomeForMemberViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.getReportURL()
+                owner.requestAuthorizationForNotification()
             }.store(in: cancelBag)
 
         input.viewWillAppear
@@ -100,29 +102,29 @@ extension HomeForMemberViewModel {
                     )
                 }
             }
-            // TODO: 이후 스프린트에서 순차 배포
-//            .flatMap {
-//                description,
-//                recentSchedule,
-//                appService in
-//                Publishers.Zip4(
-//                    self.useCase.getInsightPosts().map { $0.map { $0.toPresentation() } },
-//                    self.useCase.getGroupPosts().map { $0.map { $0.toPresentation() } },
-//                    self.useCase.getCoffeeChatPosts().map { $0.map { $0.toPresentation() } },
-//                    self.useCase.getAnnouncementPosts().map { $0.map { $0.toPresentation() } }
-//                )
-//                .map { insight, group, coffeeChat, announcement in
-//                    HomePresentationModel(
-//                        description: description,
-//                        recentSchedule: recentSchedule,
-//                        appServices: appService,
-//                        insightPosts: insight,
-//                        groupPosts: group,
-//                        coffeeChatPosts: coffeeChat,
-//                        announcementPosts: announcement
-//                    )
-//                }
-//            }
+        // TODO: 이후 스프린트에서 순차 배포
+        //            .flatMap {
+        //                description,
+        //                recentSchedule,
+        //                appService in
+        //                Publishers.Zip4(
+        //                    self.useCase.getInsightPosts().map { $0.map { $0.toPresentation() } },
+        //                    self.useCase.getGroupPosts().map { $0.map { $0.toPresentation() } },
+        //                    self.useCase.getCoffeeChatPosts().map { $0.map { $0.toPresentation() } },
+        //                    self.useCase.getAnnouncementPosts().map { $0.map { $0.toPresentation() } }
+        //                )
+        //                .map { insight, group, coffeeChat, announcement in
+        //                    HomePresentationModel(
+        //                        description: description,
+        //                        recentSchedule: recentSchedule,
+        //                        appServices: appService,
+        //                        insightPosts: insight,
+        //                        groupPosts: group,
+        //                        coffeeChatPosts: coffeeChat,
+        //                        announcementPosts: announcement
+        //                    )
+        //                }
+        //            }
             .withUnretained(self)
             .sink { owner, data in
                 output.homeItem.send(data)
@@ -169,5 +171,24 @@ extension HomeForMemberViewModel {
             .store(in: cancelBag)
         
         return output
+    }
+    
+    private func requestAuthorizationForNotification() {
+        guard self.userType != .visitor,
+              UserDefaultKeyList.Auth.hasAccessToken(),
+              UserDefaultKeyList.User.hasPushToken()
+        else { return }
+        
+        // APNS 권한 허용 확인
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
+            if let error = error { print(error) }
+            AmplitudeInstance.shared.addPushNotificationAuthorizationIdentity(isAuthorized: granted)
+            print("APNs-알림 권한 허용 유무 \(granted)")
+            
+            if granted {
+                self.useCase.registerPushToken()
+            }
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -231,6 +231,8 @@ extension ApplicationCoordinator {
                     switch destination {
                     case .dailySoptune:
                         self?.runDailySoptuneFlow()
+                    case .signIn:
+                        self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
                     case .webLink(let url):
                         self?.handleWebLink(webLink: url)
                     }
@@ -532,6 +534,8 @@ extension ApplicationCoordinator {
             switch destination {
             case .dailySoptune:
                 self?.runDailySoptuneFlow()
+            case .signIn:
+                self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
             case .webLink(let url):
                 self?.handleWebLink(webLink: url)
             }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -16,6 +16,8 @@ public protocol SoptlogCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onProfileEditTapped: (() -> Void)? { get set }
     var onAlarmTapped: (() -> Void)? { get set }
+    var onNetworkError: (() -> Void)? { get set }
+    var onNeedSignIn: (() -> Void)? { get set }
 }
 public typealias SoptlogViewModelType = ViewModelType & SoptlogCoordinatable
 public typealias SoptlogPresentable = (vc: SoptlogViewControllable, vm: any SoptlogViewModelType)

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -18,6 +18,7 @@ import WebFeature
 
 public enum SoptlogCoordinatorDestination {
     case dailySoptune
+    case signIn
     case webLink(url: String)
 }
 
@@ -56,6 +57,14 @@ public final class SoptlogCoordinator: DefaultCoordinator {
         
         soptlog.vm.onAlarmTapped = { [weak self] in
             self?.requestCoordinating?(.dailySoptune)
+        }
+        
+        soptlog.vm.onNetworkError = {
+            AlertUtils.presentNetworkAlertVC()
+        }
+        
+        soptlog.vm.onNeedSignIn = { [weak self] in
+            self?.requestCoordinating?(.signIn)
         }
         
         self.rootViewController = soptlog.vc.viewController

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -42,6 +42,9 @@ public class SoptlogViewModel: SoptlogViewModelType {
     public var onNaviBackButtonTap: (() -> Void)?
     public var onProfileEditTapped: (() -> Void)?
     public var onAlarmTapped: (() -> Void)?
+    public var onNetworkError: (() -> Void)?
+    public var onNeedSignIn: (() -> Void)?
+    
     
     // MARK: - initialization
     
@@ -59,7 +62,20 @@ extension SoptlogViewModel {
             .handleEvents(receiveOutput: { _ in
                 output.isLoading.send(true)
             })
-            .flatMap(useCase.fetchSoptlogInfo)
+            .flatMap{ _ in
+                self.useCase.fetchSoptlogInfo()
+                    .catch { error  -> AnyPublisher<SoptlogModel, Never> in
+                        switch error {
+                        case .networkError(_):
+                            self.onNetworkError?()
+                            return Empty().eraseToAnyPublisher()
+                        case .authFailed:
+                            self.onNeedSignIn?()
+                            return Empty().eraseToAnyPublisher()
+                        }
+                    }
+            }
+            .compactMap{ $0 }
             .withUnretained(self)
             .sink { owner, soptlogModel in
                 let info = soptlogModel.toPresentation()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#502

## 🌱 PR Point
- 누락된 푸시알림 권한 요청 플로우 추가했습니다! (진짜 끝  !_!!!_ 🥹)
- 홈뷰, 솝트로그뷰에서 네트워크와 토큰만료 에러처리 진행했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 현재는 viewModel로부터 이벤트를 받아 VC에서 Alert창을 띄워주는 방식입니다. 저는 **Alert창을 띄우는 것도 화면전환이라 생각**해서 코디네이터로 진행했는데 이 부분에 대한 여러분의 생각이 궁금해요!
- 에러처리를 나름대로 해보았는데, 부족한 부분이 있다면 마구 알려주세요.
- 기존에 사용하던 MainError가 있는데, `authFail`과 `networkError`만 발생하는 경우 **`MainError`를 범용적으로 사용**하는건 어떠신가요? (이제 곧 MainFeature가 없어지기도 해서 나쁘지 않다고 생각해요!) 
  우선 MainError로 처리해두었는데 SoptlogError나 HomeError를 따로 생성하는게 좋을지 의견부탁드립니다~!


## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #502
