### PR TITLE
[Fix] #507 - 솝탬프 메모리 최적화

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -40,12 +40,13 @@ public extension UIImageView {
     private func setNewImage(with urlString: String, placeholder: UIImage? = nil, completion: ((UIImage?) -> Void)? = nil) {
         guard let url = URL(string: urlString) else { return }
         let resource = KF.ImageResource(downloadURL: url, cacheKey: urlString)
-        
+                
         self.kf.setImage(
             with: resource,
             placeholder: placeholder,
             options: [
-                .scaleFactor(UIScreen.main.scale/4),
+                .processor(DownsamplingImageProcessor(size: self.bounds.size)),
+                .scaleFactor(UIScreen.main.scale),
                 .transition(.fade(0.5)),
                 .cacheMemoryOnly
             ],

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -45,31 +45,34 @@ public class DefaultListDetailUseCase {
 extension DefaultListDetailUseCase: ListDetailUseCase {
   public func fetchListDetail(missionId: Int, username: String?) {
     repository.fetchListDetail(missionId: missionId, username: username)
+      .withUnretained(self)
       .sink(receiveCompletion: { event in
         print("completion: \(event)")
-      }, receiveValue: { model in
-        self.listDetailModel.send(model)
+      }, receiveValue: { owner, model in
+          owner.listDetailModel.send(model)
       })
       .store(in: self.cancelBag)
   }
   
   public func getPresignedURL() {
     self.repository.getPresignedURL()
+      .withUnretained(self)
       .sink(receiveCompletion: {
         print("completion: \($0)")
-      }, receiveValue: { presignedModel in
-        self.presignedURL.send(presignedModel)
+      }, receiveValue: { owner, presignedModel in
+        owner.presignedURL.send(presignedModel)
       }).store(in: self.cancelBag)
   }
 
   public func uploadMedia(imageData: Data, presignedUrl: String) {
     self.repository
       .uploadMedia(imageData: imageData, presignedUrl: presignedUrl)
+      .withUnretained(self)
       .sink(receiveCompletion: {
         print("completion: \($0)")
-      }, receiveValue: {
-        self.mediaUploadCompleted.send(())
-        print("receivedValue: \($0)")
+      }, receiveValue: { owner, _ in
+        owner.mediaUploadCompleted.send(())
+          print("receivedValue: \(owner)")
       }).store(in: self.cancelBag)
   }
   
@@ -84,26 +87,29 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
           activityDate: ""
         )
       )
+      .withUnretained(self)
       .sink { event in
         print("completion: \(event)")
-      } receiveValue: { model in
-        self.listDetailModel.send(model)
+      } receiveValue: { owner, model in
+          owner.listDetailModel.send(model)
       }.store(in: self.cancelBag)
   }
   
   public func putStamp(stampData: ListDetailRequestModel) {
     repository.putStamp(stampData: stampData)
       .replaceError(with: -1)
-      .sink { result in
-        self.editSuccess.send(result == -1 ? false: true)
+      .withUnretained(self)
+      .sink { owner, result in
+        owner.editSuccess.send(result == -1 ? false: true)
       }.store(in: self.cancelBag)
   }
   
   public func deleteStamp(stampId: Int) {
     repository.deleteStamp(stampId: stampId)
       .replaceError(with: false)
-      .sink { success in
-        self.deleteSuccess.send(success)
+      .withUnretained(self)
+      .sink { owner, success in
+        owner.deleteSuccess.send(success)
       }.store(in: self.cancelBag)
   }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
@@ -23,6 +23,7 @@ public protocol MissionListCoordinatable {
 public protocol ListDetailViewControllable: ViewControllable & ListDetailCoordinatable { }
 public protocol ListDetailCoordinatable {
   var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)? { get set }
+  var onNaviBackTap: (() -> Void)? { get set }
 }
 public protocol MissionCompletedViewControllable: ViewControllable { }
 public protocol RankingViewControllable: ViewControllable & RankingCoordinatable { }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/MissionDetailCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/MissionDetailCoordinator.swift
@@ -44,6 +44,11 @@ final class MissionDetailCoordinator: DefaultCoordinator {
         missionDetail.onComplete = { [weak self] starViewLevel, handler in
             self?.showMissionComplete(starViewLevel, handler)
         }
+        missionDetail.onNaviBackTap = { [weak self] in
+            self?.router.popModule()
+            self?.finishFlow?()
+        }
+        
         router.push(missionDetail)
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -44,8 +44,7 @@ extension StampBuilder: StampFeatureViewBuildable {
             missionTitle: missionTitle,
             otherUsername: otherUserName
         )
-        let listDetailVC = ListDetailVC()
-        listDetailVC.viewModel = viewModel
+        let listDetailVC = ListDetailVC(viewModel: viewModel)
         return listDetailVC
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -74,57 +74,73 @@ extension StarViewLevel {
 }
 
 public class ListDetailVC: UIViewController, ListDetailViewControllable {
-  
-  // MARK: - Properties
-  
-  public var viewModel: ListDetailViewModel!
-  private var cancelBag = CancelBag()
-  private var sceneType: ListDetailSceneType {
-    get {
-      return self.viewModel.sceneType
-    } set(type) {
-      self.viewModel.sceneType = type
+    
+    // MARK: - Properties
+    
+    public var viewModel: ListDetailViewModel
+    private var cancelBag = CancelBag()
+    private var sceneType: ListDetailSceneType {
+        get {
+            return self.viewModel.sceneType
+        } set(type) {
+            self.viewModel.sceneType = type
+        }
     }
-  }
-  private var starLevel: StarViewLevel {
-    return self.viewModel.starLevel
-  }
-  private var missionTitle: String {
-    return self.viewModel.missionTitle
-  }
-  private var originImage: UIImage = UIImage()
-  private var originText: String = ""
-  private let deleteButtonTapped = PassthroughSubject<Bool, Never>()
-  private let imageSelected = PassthroughSubject<Data, Never>()
-  
-  // MARK: - ListDetailCoordinatable
-  
-  public var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)?
-  
-  // MARK: - UI Components
-  
-  private lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton)
-    .setTitle(I18N.ListDetail.mission)
-    .setRightButton(.none)
-  private let scrollView = UIScrollView()
-  private let contentView = UIView()
-  private let contentStackView = UIStackView()
-  private lazy var missionView = MissionView(level: starLevel, mission: missionTitle)
-  private let missionImageView = UIImageView()
-  private let imagePlaceholderLabel = UILabel()
-  private let textView = UITextView()
-  private lazy var missionDateTextField = MissionDateView(frame: self.view.frame)
-  private lazy var bottomButton = STCustomButton(title: sceneType == .none ? I18N.ListDetail.missionComplete : I18N.ListDetail.editComplete)
-    .setEnabled(false)
-    .setColor(bgColor: starLevel.pointColor,
-              disableColor: starLevel.disableColor,
-              textColor: starLevel.buttonTitleColor)
-  private lazy var backgroundDimmerView = CustomDimmerView(self)
+    private var starLevel: StarViewLevel {
+        return self.viewModel.starLevel
+    }
+    private var missionTitle: String {
+        return self.viewModel.missionTitle
+    }
+    private var originImage: UIImage = UIImage()
+    private var originText: String = ""
+    private let deleteButtonTapped = PassthroughSubject<Bool, Never>()
+    private let imageSelected = PassthroughSubject<Data, Never>()
+    
+    private var keyboardWillShowObserver: NSObjectProtocol?
+    private var keyboardWillHideObserver: NSObjectProtocol?
+    
+    // MARK: - ListDetailCoordinatable
+    
+    public var onNaviBackTap: (() -> Void)?
+    public var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)?
+    
+    // MARK: - UI Components
+    
+    private lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
+        .setTitle(I18N.ListDetail.mission)
+        .setRightButton(.none)
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
+    private let contentStackView = UIStackView()
+    private lazy var missionView = MissionView(level: starLevel, mission: missionTitle)
+    private let missionImageView = UIImageView()
+    private let imagePlaceholderLabel = UILabel()
+    private let textView = UITextView()
+    private lazy var missionDateTextField = MissionDateView(frame: self.view.frame)
+    private lazy var bottomButton = STCustomButton(title: sceneType == .none ? I18N.ListDetail.missionComplete : I18N.ListDetail.editComplete)
+        .setEnabled(false)
+        .setColor(bgColor: starLevel.pointColor,
+                  disableColor: starLevel.disableColor,
+                  textColor: starLevel.buttonTitleColor)
+    private lazy var backgroundDimmerView = CustomDimmerView(self)
+    
+    
+    public init(viewModel: ListDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
   
   // MARK: - View Life Cycle
   
   public override func viewDidLoad() {
     super.viewDidLoad()
+    self.bindViews()
     self.bindViewModels()
     self.setLayout()
     self.setStackView()
@@ -135,11 +151,25 @@ public class ListDetailVC: UIViewController, ListDetailViewControllable {
     self.setDelegate()
     self.hideKeyboard()
   }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        self.missionImageView.image = nil
+    }
 }
 
 // MARK: - Methods
 
 extension ListDetailVC {
+    
+  private func bindViews() {
+      naviBar.leftButtonTapped
+          .withUnretained(self)
+          .sink { owner, _ in
+              owner.onNaviBackTap?()
+          }.store(in: cancelBag)
+  }
+    
   private func bindViewModels() {
     let rightButtonTapped = naviBar.rightButtonTapped
       .withUnretained(self)
@@ -166,7 +196,7 @@ extension ListDetailVC {
         )
       }
       .asDriver()
-    
+      
     let input = ListDetailViewModel.Input(
       viewDidLoad: Driver.just(()), 
       imageSelected: self.imageSelected.eraseToAnyPublisher(),
@@ -262,18 +292,21 @@ extension ListDetailVC {
   }
   
   private func setObserver() {
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(keyboardWillShow),
-      name: UIResponder.keyboardWillShowNotification,
-      object: nil
-    )
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(keyboardWillHide),
-      name: UIResponder.keyboardWillHideNotification,
-      object: nil
-    )
+      keyboardWillShowObserver = NotificationCenter.default.addObserver(
+          forName: UIResponder.keyboardWillShowNotification,
+          object: nil,
+          queue: .main
+      ) { [weak self] notification in
+          self?.keyboardWillShow(notification as NSNotification)
+      }
+      
+      keyboardWillHideObserver = NotificationCenter.default.addObserver(
+          forName: UIResponder.keyboardWillHideNotification,
+          object: nil,
+          queue: .main
+      ) { [weak self] notification in
+          self?.keyboardWillHide(notification as NSNotification)
+      }
     
     self.missionDateTextField
       .signalForChangeDate()

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -156,7 +156,7 @@ extension ListDetailVC {
           owner.bottomButton.setEnabled(false)
         }
         if owner.sceneType == .none {
-          self.showDimmerView()
+          owner.showDimmerView()
         }
         let content = owner.textView.text
         return ListDetailRequestModel(

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -52,13 +52,13 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
   lazy var naviBar: STNavigationBar = {
     switch sceneType {
     case .default:
-      return STNavigationBar(self, type: .title)
+        return STNavigationBar(type: .title)
         .setTitle("전체 미션")
         .setTitleTypoStyle(.SoptampFont.h2)
         .setTitleButtonMenu(menuItems: self.menuItems)
         .addLeftButtonToTitleMenu()
     case .ranking(let username, _):
-      return STNavigationBar(self, type: .titleWithLeftButton)
+        return STNavigationBar(type: .titleWithLeftButton)
         .setTitle(username)
         .setRightButton(.none)
         .setTitleTypoStyle(.SoptampFont.h2)
@@ -237,13 +237,11 @@ extension MissionListVC {
         owner.onGuideTap?()
       }.store(in: self.cancelBag)
 
-    if case .default = sceneType {
-      naviBar.leftButtonTapped
-        .withUnretained(self)
-        .sink { owner, _ in
-          owner.onNaviBackTap?()
-        }.store(in: self.cancelBag)
-    }
+    naviBar.leftButtonTapped
+      .withUnretained(self)
+      .sink { owner, _ in
+        owner.onNaviBackTap?()
+      }.store(in: self.cancelBag)
 
     partRankingFloatingButton.publisher(for: .touchUpInside)
       .withUnretained(self)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
@@ -35,7 +35,7 @@ public class PartRankingVC: UIViewController, PartRankingViewControllable {
 
   // MARK: - UI Components
 
-  lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton, ignorePopAction: true)
+  lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
     .setTitleTypoStyle(.SoptampFont.h2)
     .setTitle("파트별 랭킹")
     .setRightButton(.none)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -35,7 +35,7 @@ public class RankingVC: UIViewController, RankingViewControllable {
   
   // MARK: - UI Components
   
-  lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton, ignorePopAction: true)
+  lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
     .setTitleTypoStyle(.SoptampFont.h2)
     .setTitle("랭킹")
     .setRightButton(.none)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/StampGuideScene/VC/StampGuideVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/StampGuideScene/VC/StampGuideVC.swift
@@ -34,7 +34,7 @@ public class StampGuideVC: UIViewController, StampGuideViewControllable {
     
     // MARK: - UI Components
     
-    private lazy var naviBar = STNavigationBar(self, type: .titleWithLeftButton)
+    private lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
         .setTitle(I18N.StampGuide.guide)
     
     private lazy var stampGuideCollectionView: UICollectionView = {

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
@@ -66,12 +66,10 @@ public class STNavigationBar: UIView {
     
     // MARK: - Initialize
     
-    public init(_ vc: UIViewController, type: NaviType, ignorePopAction: Bool = false) {
+    public init(type: NaviType) {
         super.init(frame: .zero)
-        self.vc = vc
         self.setUI(type)
         self.setLayout(type)
-        self.setAddTarget(ignorePopAction)
     }
     
     required init?(coder: NSCoder) {
@@ -96,7 +94,7 @@ extension STNavigationBar {
     
     private func setAddTarget(_ ignorePopAction: Bool = false) {
         guard !ignorePopAction else { return }
-        self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
+//        self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
     }
     
     @discardableResult
@@ -201,11 +199,6 @@ extension STNavigationBar {
 // MARK: - @objc
 
 extension STNavigationBar {
-    @objc
-    private func popToPreviousVC() {
-        self.vc?.navigationController?.popViewController(animated: true)
-    }
-    
     @objc
     private func tappedRightButton() {
         self.rightButtonClosure?()


### PR DESCRIPTION
## 🌴 PR 요약

솝탬프 기능의 메모리 최적화를 진행했습니다.

🌱 작업한 브랜치
- #507 

## 🌱 PR Point

### 1. 문제 상황 인지
![스크린샷 2025-03-07 오전 1 39 37](https://github.com/user-attachments/assets/8176432c-584c-4464-b960-dc229d6faa9d)
- 솝탬프 디테일뷰에 진입했을 때의 모습인데요. **디테일뷰에 들어갈 때마다 메모리가 증가**함을 알 수 있었고, 해당 뷰를 pop 시켰음에도 메모리가 줄어들지 않아 이상함을 느꼈습니다. (ListDetailVC에서 deinit이 호출되지 않는 것을 보고, 메모리에 해당 VC가 계속 남아있음을 알았습니다.)

*****

### 2. 객체 개수 확인
![image](https://github.com/user-attachments/assets/01074330-4dc2-4fc7-a090-da8175046f37)
- Leaks 검사를 했을 때 잡히지 않는 것 같아서 **memgraph**를 살펴보았습니다.

![image](https://github.com/user-attachments/assets/7712b595-2d98-4612-a59c-bf732917951d)
- ListDetailVC, ListDetailViewModel, MissionView 등 디테일뷰로 진입했을 때, 진입 횟수만큼 관련 Presentation 객체가 생겨나고 있음을 알았습니다.

![스크린샷 2025-03-07 오전 1 48 26](https://github.com/user-attachments/assets/0fb29193-0c47-47e0-a9ba-b3b504a77abb)
- ListDetailVC의 그래프를 좀 더 자세히 찾아보니, `NotificationCenter`와 `STNavigationBar`가 VC를 강하게 참조하고 있음을 알 수 있었습니다.

### 2.1. NotificationCenter 

**`AS-IS`**
```swift
NotificationCenter.default.addObserver(
      self,
      selector: #selector(keyboardWillShow),
      name: UIResponder.keyboardWillShowNotification,
      object: nil
)
```
**`TO-BE`**
```swift
keyboardWillShowObserver = NotificationCenter.default.addObserver(
          forName: UIResponder.keyboardWillShowNotification,
          object: nil,
          queue: .main
      ) { [weak self] notification in
          self?.keyboardWillShow(notification as NSNotification)
      }
```
- `NotificationCenter`가 **Self를 약하게 참조하도록** 변경했습니다. 또한 deinit할 때 `NotificationCenter.removeObserver()`도 호출해주고 있습니다.


### 2.2. STNavigationBar
```swift
public init(_ vc: UIViewController, type: NaviType, ignorePopAction: Bool = false)
```
- 기존 STNavigationBar를 보면, 네비바를 들고 있는 VC를 주입받아 강하게 참조하고 있었는데요. 이 때문에 VC가 계속해서 메모리에서 해제되지 못하고 있었습니다. 
```swift
@objc
private func popToPreviousVC() {
    self.vc?.navigationController?.popViewController(animated: true)
}
````
- 그래서 주입받은 vc를 어떻게 활용하고 있는지 살펴보았는데, **해당 vc를 pop하기 위해서만 사용**되고 있었습니다. 이 부분의 경우, 기존 방식처럼 Coor에서 화면 전환을 수행해주는 것이 아닌, View단에서 pop시키는 방식으로 구현되고 있었습니다. (아마 초반에 만들어진 코드라서 잘못 구현된 것 같습니다.)
- 그 이외에는 네비바가 vc를 참조해야 할 이유는 없어보여서 제거했습니다.

### 2.3. 그 외
```swift
missionDetail.onNaviBackTap = { [weak self] in
    self?.router.popModule()
    self?.finishFlow?()
}
```
- ListDetailVC가 pop 되었을 때 finishFlow를 부르는 코드가 누락되어 있어, 이 또한 메모리에 잔존해있는 원인이 될 것 같아 추가했습니다. 

*****
### 3. memgraph - command line에서
- 위와 같이 강한 참조 문제가 있었던 부분들을 해결했는데도, 여전히 메모리 문제가 해결되지 않아 **memgraph를 command line에서** 더 자세히 살펴보았습니다.
![image](https://github.com/user-attachments/assets/2e950fb2-9adc-4f35-8d4d-4c0bb6c17211)
- `vmmap summary`를 살펴보았을 때 **ImageIO의 swapped size**가 큰 메모리를 차지하고 있었고, 해당 화면의 이미지 관련 문제임을 유추할 수 있었습니다. 
![image](https://github.com/user-attachments/assets/80001678-6b52-4e57-8c4b-7fcfd5528df5)
- (여기까진 안봐도 알 것 같지만) 해당 객체를 참조하고 있는 트리도 확인해보았습니다.

### 3.1. Kingfisher 이미지 캐싱 시 다운샘플링

**`AS-IS`**
```swift
options: [
    .scaleFactor(UIScreen.main.scale/4),
    .transition(.fade(0.5)),
    .cacheMemoryOnly
]
```

**`TO-BE`**
```swift
options: [
    .processor(DownsamplingImageProcessor(size: self.bounds.size)),
    .scaleFactor(UIScreen.main.scale),
    .transition(.fade(0.5)),
    .cacheMemoryOnly
]
```

- 따라서 이미지를 캐싱할 때 다운샘플링하도록 기존 코드를 수정했습니다.
- 기존에는 `scaleFactor`로 이미지 크기 자체를 조정해 저장하고 있었는데, `DownsamplingImageProcessor`로 ImageView의 사이즈로 다운샘플링하고 이미지 크기 자체는 해상도를 유지하도록 수정했습니다.

*****
### 4. 결과

![스크린샷 2025-03-07 오전 2 29 26](https://github.com/user-attachments/assets/fd3463ff-302a-452d-8cb0-74ca46f3dd44)
- 우리의 메모리가 정상으로 돌아왔어요!

![스크린샷 2025-03-07 오전 2 27 42](https://github.com/user-attachments/assets/3509d4e9-3e1a-405b-ba2b-8a603f40cb5d)
- summary에도 ImageIO가 사라졌네요. 야호~

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 솝탬프 코드는 건드리기 항상 두려운 것 같아요... 이번에는 어떻게 될 지 모르겠지만, 만약 활동 기수에서 솝탬프 기능을 사용한다면 사용률이 가장 높은 기능이기도 하고, 또 이전에 작성된 코드라 프로젝트의 전반적인 코드 스타일이랑 좀 다른 것 같아요... 글구 제가 솝탬프의 플로우를 100% 이해하고 있는 게 아닐수도 있어서, 수정이 더 두렵네요...
- 그렇지만 솝탬프 디테일뷰는 저번 기수동안 이유 모를 크래시가 더러 발생하기도 했었고, 그 때 원인을 킹피셔의 버전 문제로 부정확하게 넘어갔던 게 마음에 걸려서 좀 더 살펴봤습니다. 
- 그래서 제가 잘못 생각했거나, 확인해보시고 우려되는 부분이 보인다면 코리 달아주세요!! 🙇🏼
- [메모리 딥 다이브](https://developer.apple.com/videos/play/wwdc2018/416) 보면서 따라갔습니다. 옛날 영상이지만.. 정말 멋지네요...

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #507 