### PR TITLE
[Fix] #511 - 솝트로그 화면 전환 수정 및 메모리 최적화

### DIFF
--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
@@ -47,6 +47,8 @@ public final class DailySoptuneCardCoordinator: DefaultCoordinator {
         
         dailySoptuneCard.vm.onGoToHomeButtonTapped = { [weak self] in
             self?.requestCoordinating?()
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
         }
         
         self.rootController = dailySoptuneCard.vc.asNavigationController

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -39,9 +39,9 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     private func showDailySoptuneMain() {
         var dailySoptuneMain = factory.makeDailySoptuneMainVC()
         
-        dailySoptuneMain.vm.onNaviBackTap = {
-            self.router.dismissModule(animated: true)
-            self.finishFlow?()
+        dailySoptuneMain.vm.onNaviBackTap = { [weak self] in
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
         }
         
         dailySoptuneMain.vm.onReciveTodayFortuneButtonTap = { [weak self] result in
@@ -68,6 +68,8 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
         
         dailySoptuneResultCoordinator.requestCoordinating = { [weak self] in
             self?.requestCoordinating?()
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
         }
         
         addDependency(dailySoptuneResultCoordinator)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -82,6 +82,8 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         
         dailySoptuneCardCoordinator.requestCoordinating = { [weak self] in
             self?.requestCoordinating?()
+            self?.router.dismissModule(animated: true)
+            self?.finishFlow?()
         }
         
         addDependency(dailySoptuneCardCoordinator)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -26,6 +26,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     private let resultModel: DailySoptuneResultModel
     private let router: Router
     private weak var rootController: UINavigationController?
+    private weak var viewController: UIViewController?
 
     public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
         self.router = router
@@ -48,7 +49,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         
         dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
             guard let self else { return .empty() }
-            return self.showMessageBottomSheet(userModel: userModel, on: dailySoptuneResult.vc.viewController)
+            return self.showMessageBottomSheet(userModel: userModel, on: self.viewController)
         }
         
         dailySoptuneResult.vm.onReceiveTodaysFortuneCardButtonTapped = { [weak self] cardModel in
@@ -64,6 +65,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         }
         
         rootController = dailySoptuneResult.vc.asNavigationController
+        viewController = dailySoptuneResult.vc.viewController
         router.present(rootController, animated: true, modalPresentationSytle: .overFullScreen)
     }
     

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/Views/DailySoptuneResultPokeView.swift
@@ -16,7 +16,9 @@ import Domain
 public final class DailySoptuneResultPokeView: UIView {
     
     public lazy var kokButtonTap: Driver<PokeUserModel?> = kokButton.tap
-        .map { self.user }
+        .map { [weak self] in
+            self?.user
+        }
         .asDriver()
     
     lazy var profileTap = self.profileImageView.gesture()

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -35,6 +35,9 @@ final class ApplicationCoordinator: BaseCoordinator {
     private weak var rootController: UINavigationController?
     private weak var tabBarController: UITabBarController?
     
+    private weak var homeCoordinator: HomeCoordinator?
+    private weak var soptlogCoordinator: SoptlogCoordinator?
+    
     public init(router: Router, notificationHandler: NotificationHandler) {
         self.router = router
         self.notificationHandler = notificationHandler
@@ -176,11 +179,11 @@ extension ApplicationCoordinator {
         let tabBarBuilder = TabBarBuilder()
         let userType = type ?? UserDefaultKeyList.Auth.getUserType()
 
-        let homeCoordinator = runHomeFlow(type: userType)
-        guard let homeVC = homeCoordinator.rootViewController else { return }
+        self.homeCoordinator = runHomeFlow(type: userType)
+        guard let homeVC = self.homeCoordinator?.rootViewController else { return }
         
-        let soptlogCoordinator = runSoptlogFlow()
-        guard let soptlogVC = soptlogCoordinator.rootViewController else { return }
+        self.soptlogCoordinator = runSoptlogFlow()
+        guard let soptlogVC = self.soptlogCoordinator?.rootViewController else { return }
                 
         let (tabbarController, viewModel) = tabBarBuilder.makeTabBar(
             with: [homeVC,
@@ -204,7 +207,7 @@ extension ApplicationCoordinator {
         coordinator.requestCoordinating = { [weak self] destination in
             switch destination {
             case .home:
-                homeCoordinator.requestCoordinating = { [weak self, weak coordinator] destination in
+                self?.homeCoordinator?.requestCoordinating = { [weak self, weak coordinator] destination in
                     switch destination {
                     case .attendance:
                         self?.runAttendanceFlow()
@@ -228,7 +231,7 @@ extension ApplicationCoordinator {
                     }
                 }
             case .soptlog:
-                soptlogCoordinator.requestCoordinating = { [weak self] destination in
+                self?.soptlogCoordinator?.requestCoordinating = { [weak self] destination in
                     switch destination {
                     case .dailySoptune:
                         self?.runDailySoptuneFlow()

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -33,6 +33,7 @@ final class ApplicationCoordinator: BaseCoordinator {
     private let notificationHandler: NotificationHandler
     
     private weak var rootController: UINavigationController?
+    private weak var tabBarController: UITabBarController?
     
     public init(router: Router, notificationHandler: NotificationHandler) {
         self.router = router
@@ -92,7 +93,6 @@ extension ApplicationCoordinator {
     
     private func handleDeepLink(deepLink: DeepLinkComponentsExecutable) {
         self.rootController?.dismiss(animated: false)
-//        router.dismissModule(animated: false)
         deepLink.execute(coordinator: self)
     }
     
@@ -198,6 +198,7 @@ extension ApplicationCoordinator {
         )
                         
         self.rootController = tabbarController.asNavigationController
+        self.tabBarController = tabbarController
         
         // 각 코디네이터 실행
         coordinator.requestCoordinating = { [weak self] destination in
@@ -215,7 +216,7 @@ extension ApplicationCoordinator {
                     case .notification:
                         self?.runNotificationFlow()
                     case .soptlog:
-                        tabbarController.selectedIndex = 1
+                        self?.tabBarController?.selectedIndex = 1
                     case .deepLink(let url):
                         self?.notificationHandler.receive(deepLink: url)
                         guard let deepLink = self?.notificationHandler.deepLink.value else { return }
@@ -303,7 +304,7 @@ extension ApplicationCoordinator {
             case .notification:
                 self?.runNotificationFlow()
             case .soptlog:
-                self?.runSoptlogFlow()
+                self?.tabBarController?.selectedIndex = 1
             case .deepLink(let url):
                 self?.notificationHandler.receive(deepLink: url)
                 guard let deepLink = self?.notificationHandler.deepLink.value else { return }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -510,10 +510,9 @@ extension ApplicationCoordinator {
             self?.removeDependency(coordinator)
         }
         
-        coordinator.requestCoordinating = { [weak self] in
-            self?.notificationHandler.receive(deepLink: "home")
-            guard let deepLinkComponent = self?.notificationHandler.deepLink.value else { return }
-            self?.handleDeepLink(deepLink: deepLinkComponent)
+        coordinator.requestCoordinating = { [weak self, weak coordinator] in
+            self?.router.popToRootModule(animated: true)
+            coordinator?.childCoordinators = []
         }
         
         addDependency(coordinator)


### PR DESCRIPTION
## 🌴 PR 요약

솝트로그가 탭바 인덱스로만 전환될 수 있도록 수정하고, 누수가 발생하는 부분을 수정합니다.

🌱 작업한 브랜치
- #511 

## 🌱 PR Point

## ✅ 솝트로그 -> 탭바로 전환될 수 있도록

|기능|스크린샷|
|:--:|:--:|
|AS-IS|<video src = "https://github.com/user-attachments/assets/765f9b3b-89e7-4ad1-a07e-d87015866565" width = 300>|

- 위와 같이, **탭바 아이템을 누르지 않으면 솝트로그 페이지가 새롭게 push되는 문제**가 발생했습니다.

**`AS-IS`**
```swift
// runHomeFlow()
 case .soptlog:
        self?.runSoptlogFlow()
```
- 그 이유는 `runHomeFlow()` 내에서 새롭게 솝트로그 플로우를 부르며, **솝트로그 코디네이터를 재생성**하고 있었기 때문인데요.

<img width="1512" alt="스크린샷 2025-03-07 오후 3 29 12" src="https://github.com/user-attachments/assets/c9913b41-4674-49f3-96c0-9d738998b494" />

- 이렇게 ApplicationCoor 내에서 홈과 솝트로그 플로우를 생성하는 기존 방식은 **해당 Coor들이 제거되지 않고 메모리에 남아있어** 누수의 원인이 되기도 했습니다.

**`TO-BE`**
```swift
private weak var tabBarController: UITabBarController?
private weak var homeCoordinator: HomeCoordinator?
private weak var soptlogCoordinator: SoptlogCoordinator?
```
- 그래서 위와 같이, **탭바의 VC와 홈, 솝트로그의 Coor들을 Applicaion Coor 내에서 하나로 공유**될 수 있도록 수정했습니다.
***
## ✅ 솝마디 메모리 최적화

### 첫번째 시도
<img width="1231" alt="스크린샷 2025-03-07 오후 6 03 36" src="https://github.com/user-attachments/assets/55675089-4fd2-4e81-8c72-b46d5e731595" />

- 또한 기존에 솝마디에서 홈으로 돌아가기 버튼을 눌렀을 때, **솝마디 관련 객체들이 메모리에 계속 남아있는** 문제를 발견했는데요.
- "홈으로 돌아가기"의 기존 구현 방식은, **ApplicationCoor까지 리프 Coor에서 클로저로 dismiss 요청을 전달하고 ApplicationCoor에서 딥링크로 "home"에 보내주는 방식**이었습니다.
- router의 popToRootModule을 사용하지 않고 이렇게 구현한 이유는, **솝마디를 띄워주는 router의 root가 다른 경우가 있어서**였습니다. (푸시 알림 목록에서 솝마디를 띄워줄 경우 문제가 발생합니다.)
- 따라서 딥링크를 통해 home으로의 전환을 시도하고 있었는데, 탭바가 생기면서 **home의 새로운 플로우를 생성할 경우 메모리에 계속해서 Coor가 쌓이는 문제**가 발생하고 있었습니다.
```swift
/// ApplicationCoor - runDailySoptuneFlow()
coordinator.requestCoordinating = { [weak self, weak coordinator] in
    self?.router.popToRootModule(animated: true)
    coordinator?.childCoordinators = []
}
```
- 이에 대한 해결방안으로, 기존 "ApplicationCoor까지 리프 Coor에서 클로저로 dismiss 요청을 전달"을 할 때 finishFlow를 부르는 것과 같이 **해당 모듈을 dismiss**시키고, ApplicationCoor에 도달하면 **popToRootModule로 탭바까지 pop되어 기존에 존재하던 홈에 도달할 수 있도록 구현**했습니다.

### 두번째 시도
<img width="1512" alt="스크린샷 2025-03-07 오후 5 06 13" src="https://github.com/user-attachments/assets/be99ec48-b7bf-4d59-899a-bb0bc2ce36f7" />

- 두번째로 발견한 것은 **DailySoptuneResult 부분에서의 순환 참조 문제**였습니다.

**`AS-IS`**
```swift 
// DailySoptuneResultCoor

dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
    guard let self else { return .empty() }
    return self.showMessageBottomSheet(userModel: userModel, on: dailySoptuneResult.vc.viewController)
}
```
- 이는 기존에 `showMessageBottomSheet`에서 **self의 vc를 강하게 참조하고 있어** 메모리에서 해제되지 못하고 있었던 문제였습니다.

**`TO-BE`**
```swift
// DailySoptuneResultCoor
private weak var viewController: UIViewController?

dailySoptuneResult.vm.onKokButtonTapped = { [weak self] userModel in
    guard let self else { return .empty() }
    return self.showMessageBottomSheet(userModel: userModel, on: self.viewController)
}

viewController = dailySoptuneResult.vc.viewController
```
- 따라서 해당 vc를 약하게 참조할 수 있도록 해결했습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #511 
