### PR TITLE
[Refactor] #529 - 앱 메모리 최적화(솝탬프, 콕찌르기, 마이페이지, 홈캘린더)

### DIFF
--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
@@ -49,6 +49,7 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     
     // MARK: - Views
     private lazy var navigationBar = OPNavigationBar(
+        self,
         type: .oneLeftButton,
         backgroundColor: DSKitAsset.Colors.black100.color,
         ignoreLeftButtonAction: true

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageViewController.swift
@@ -49,7 +49,6 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     
     // MARK: - Views
     private lazy var navigationBar = OPNavigationBar(
-        self,
         type: .oneLeftButton,
         backgroundColor: DSKitAsset.Colors.black100.color,
         ignoreLeftButtonAction: true
@@ -227,27 +226,27 @@ extension AppMyPageVC {
     
     // TODO: - (@승호): 적절히 객체에 위임하기
     private func addTabGestureOnListItems() {
-        self.servicePolicySectionGroup.addTapGestureRecognizer {
-            self.onPolicyItemTap?()
+        self.servicePolicySectionGroup.addTapGestureRecognizer { [weak self] in
+            self?.onPolicyItemTap?()
         }
 
-        self.termsOfUseListItem.addTapGestureRecognizer {
-            self.onTermsOfUseItemTap?()
+        self.termsOfUseListItem.addTapGestureRecognizer { [weak self] in
+            self?.onTermsOfUseItemTap?()
         }
 
         self.sendFeedbackListItem.addTapGestureRecognizer {
             openExternalLink(urlStr: ExternalURL.KakaoTalk.serviceProposal)
         }
         
-        self.alertListItem.addTapGestureRecognizer {
-            self.onAlertButtonTap?(UIApplication.openSettingsURLString)
+        self.alertListItem.addTapGestureRecognizer { [weak self] in
+            self?.onAlertButtonTap?(UIApplication.openSettingsURLString)
         }
 
-        self.editOnelineSentenceListItem.addTapGestureRecognizer {
-            self.onEditOnelineSentenceItemTap?()
+        self.editOnelineSentenceListItem.addTapGestureRecognizer { [weak self] in
+            self?.onEditOnelineSentenceItemTap?()
         }
 
-        self.resetStampListItem.addTapGestureRecognizer {
+        self.resetStampListItem.addTapGestureRecognizer { [weak self] in
             AlertUtils.presentAlertVC(
                 type: .titleDescription,
                 theme: .main,
@@ -261,7 +260,7 @@ extension AppMyPageVC {
             )
         }
 
-        self.logoutListItem.addTapGestureRecognizer {
+        self.logoutListItem.addTapGestureRecognizer { [weak self] in
             AlertUtils.presentAlertVC(
                 type: .titleDescription,
                 theme: .main,
@@ -275,12 +274,12 @@ extension AppMyPageVC {
             )
         }
 
-        self.withDrawalListItem.addTapGestureRecognizer {
-            self.onWithdrawalItemTap?(self.userType)
+        self.withDrawalListItem.addTapGestureRecognizer { [weak self] in
+            self?.onWithdrawalItemTap?(self?.userType ?? .visitor)
         }
         
-        self.loginListItem.addTapGestureRecognizer {
-            self.onShowLogin?()
+        self.loginListItem.addTapGestureRecognizer { [weak self] in
+            self?.onShowLogin?()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -26,8 +26,7 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
     
     // MARK: UI Components
     
-    private lazy var naviBar = OPNavigationBar(self,
-                                               type: .oneLeftButton,
+    private lazy var naviBar = OPNavigationBar(type: .oneLeftButton,
                                                backgroundColor: DSKitAsset.Colors.semanticBackground.color)
         .addMiddleLabel(title: I18N.Home.CalendarDetail.navigationTitle, font: DSKitFontFamily.Suit.medium.font(size: 16))
     
@@ -142,7 +141,7 @@ extension HomeCalendarDetailVC {
     private func bindViewModels() {
         let input = HomeCalendarDetailViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
-            naviBackButtonTap: self.naviBar.leftButtonTapped.asDriver(),
+            naviBackButtonTap: self.naviBar.leftButtonTapped,
             onAttendanceButtonTap: self.attendanceButton
                 .publisher(for: .touchUpInside)
                 .withUnretained(self)
@@ -157,7 +156,7 @@ extension HomeCalendarDetailVC {
             .sink { owner, calendarDetailInfo in
                 owner.calendarDetailInfo = calendarDetailInfo
                 owner.collectionView.reloadData()
-                self.scrollToRecentSchedule()
+                owner.scrollToRecentSchedule()
             }.store(in: cancelBag)
         
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -26,7 +26,7 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
     
     // MARK: UI Components
     
-    private lazy var naviBar = OPNavigationBar(type: .oneLeftButton,
+    private lazy var naviBar = OPNavigationBar(self, type: .oneLeftButton,
                                                backgroundColor: DSKitAsset.Colors.semanticBackground.color)
         .addMiddleLabel(title: I18N.Home.CalendarDetail.navigationTitle, font: DSKitFontFamily.Suit.medium.font(size: 16))
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -57,21 +57,21 @@ final class PokeCoordinator: DefaultCoordinator {
         
         pokeMain.vm.onPokeButtonTapped = { [weak self] userModel in
             guard let self else { return .empty() }
-            return self.showMessageBottomSheet(userModel: userModel, on: pokeMain.vc.viewController)
+            return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
         }
         
         pokeMain.vm.onNewFriendMade = { [weak self] friendName in
             guard let self else { return }
             let pokeMakingFriendCompletedVC = self.factory.makePokeMakingFriendCompleted(friendName: friendName).viewController
             pokeMakingFriendCompletedVC.modalPresentationStyle = .overFullScreen
-            pokeMain.vc.viewController.present(pokeMakingFriendCompletedVC, animated: false)
+            self.rootController?.present(pokeMakingFriendCompletedVC, animated: false)
         }
 
         pokeMain.vm.onAnonymousFriendUpgrade = { [weak self] user in
           guard let self else { return }
           let pokeAnonymousFriendUpgradeVC = self.factory.makePokeAnonymousFriendUpgrade(user: user).viewController
           pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
-          pokeMain.vc.viewController.present(pokeAnonymousFriendUpgradeVC, animated: false)
+          self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
         }
 
         pokeMain.vm.switchToOnboarding = { [weak self] in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -103,11 +103,11 @@ public final class PokeMainVC: UIViewController, PokeMainViewControllable {
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-    self.setUI()
-    self.setDelegate()
-    self.setStackView()
-    self.setLayout()
-    self.bindViewModel()
+    setUI()
+    setDelegate()
+    setStackView()
+    setLayout()
+    bindViewModel()
   }
 }
 
@@ -298,8 +298,9 @@ extension PokeMainVC {
       }.store(in: cancelBag)
 
     output.isLoading
-      .sink { [weak self] isLoading in
-        isLoading ? self?.showLoading() : self?.stopLoading()
-      }.store(in: self.cancelBag)
+      .withUnretained(self)
+      .sink { owner, isLoading in
+        isLoading ? owner.showLoading() : owner.stopLoading()
+      }.store(in: cancelBag)
   }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -23,7 +23,7 @@ extension StampBuilder: StampFeatureViewBuildable {
     public func makeMissionListVC(sceneType: MissionListSceneType) -> MissionListViewControllable {
         let useCase = DefaultMissionListUseCase(repository: missionListRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType)
-        let missionListVC = MissionListVC()
+        let missionListVC = MissionListVC(viewModel: viewModel)
         missionListVC.viewModel = viewModel
         return missionListVC
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/CollectionView/MissionListCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/CollectionView/MissionListCompositionalLayout.swift
@@ -12,10 +12,10 @@ extension MissionListVC {
     static let standardWidth = UIScreen.main.bounds.width - 40.adjusted
     
     func createLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
             switch MissionListSection.type(sectionIndex) {
-            case .sentence: return self.createSentenceSection()
-            case .missionList: return self.createMissionListSection()
+            case .sentence: return self?.createSentenceSection()
+            case .missionList: return self?.createMissionListSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -20,150 +20,150 @@ import StampFeatureInterface
 import BaseFeatureDependency
 
 public class MissionListVC: UIViewController, MissionListViewControllable {
-
-  // MARK: - Properties
-
-  public var viewModel: MissionListViewModel
-  public var sceneType: MissionListSceneType {
-    return self.viewModel.missionListsceneType
-  }
-  private var cancelBag = CancelBag()
-
-  private var missionTypeMenuSelected = CurrentValueSubject<MissionListFetchType, Never>(.all)
-  private var viewWillAppear = PassthroughSubject<Void, Never>()
-  private let swipeHandler = PassthroughSubject<Void, Never>()
-
-  lazy var dataSource: UICollectionViewDiffableDataSource<MissionListSection, MissionListModel>! = nil
-
-  // MARK: - MissionListCoordinatable
-
-  public var onSwiped: (() -> Void)?
-  public var onNaviBackTap: (() -> Void)?
-  public var onPartRankingButtonTap: ((RankingViewType) -> Void)?
-  public var onCurrentGenerationRankingButtonTap: ((RankingViewType) -> Void)?
-  public var onGuideTap: (() -> Void)?
-  public var onCellTap: ((MissionListModel, String?) -> Void)?
-  public var onReportButtonTap: (() -> Void)?
-
-  private var usersActiveGenerationStatus: UsersActiveGenerationStatusViewResponse?
-
-  // MARK: - UI Components
-
-  lazy var naviBar: STNavigationBar = {
-    switch sceneType {
-    case .default:
-        return STNavigationBar(type: .title)
-        .setTitle("전체 미션")
-        .setTitleTypoStyle(.SoptampFont.h2)
-        .setTitleButtonMenu(menuItems: self.menuItems)
-        .addLeftButtonToTitleMenu()
-    case .ranking(let username, _):
-        return STNavigationBar(type: .titleWithLeftButton)
-        .setTitle(username)
-        .setRightButton(.none)
-        .setTitleTypoStyle(.SoptampFont.h2)
+    
+    // MARK: - Properties
+    
+    public var viewModel: MissionListViewModel
+    public var sceneType: MissionListSceneType {
+        return self.viewModel.missionListsceneType
     }
-  }()
-
-  private lazy var menuItems: [UIAction] = {
-    var menuItems: [UIAction] = []
-    [("전체 미션", MissionListFetchType.all),
-     ("완료 미션", MissionListFetchType.complete),
-     ("미완료 미션", MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
-      menuItems.append(UIAction(title: menuTitle,
-                                handler: { [weak self] _ in
-        self?.missionTypeMenuSelected.send(fetchType)
-        self?.naviBar.setTitle(menuTitle)
-      }))
+    private var cancelBag = CancelBag()
+    
+    private var missionTypeMenuSelected = CurrentValueSubject<MissionListFetchType, Never>(.all)
+    private var viewWillAppear = PassthroughSubject<Void, Never>()
+    private let swipeHandler = PassthroughSubject<Void, Never>()
+    
+    lazy var dataSource: UICollectionViewDiffableDataSource<MissionListSection, MissionListModel>! = nil
+    
+    // MARK: - MissionListCoordinatable
+    
+    public var onSwiped: (() -> Void)?
+    public var onNaviBackTap: (() -> Void)?
+    public var onPartRankingButtonTap: ((RankingViewType) -> Void)?
+    public var onCurrentGenerationRankingButtonTap: ((RankingViewType) -> Void)?
+    public var onGuideTap: (() -> Void)?
+    public var onCellTap: ((MissionListModel, String?) -> Void)?
+    public var onReportButtonTap: (() -> Void)?
+    
+    private var usersActiveGenerationStatus: UsersActiveGenerationStatusViewResponse?
+    
+    // MARK: - UI Components
+    
+    lazy var naviBar: STNavigationBar = {
+        switch sceneType {
+        case .default:
+            return STNavigationBar(type: .title)
+                .setTitle("전체 미션")
+                .setTitleTypoStyle(.SoptampFont.h2)
+                .setTitleButtonMenu(menuItems: self.menuItems)
+                .addLeftButtonToTitleMenu()
+        case .ranking(let username, _):
+            return STNavigationBar(type: .titleWithLeftButton)
+                .setTitle(username)
+                .setRightButton(.none)
+                .setTitleTypoStyle(.SoptampFont.h2)
+        }
+    }()
+    
+    private lazy var menuItems: [UIAction] = {
+        var menuItems: [UIAction] = []
+        [("전체 미션", MissionListFetchType.all),
+         ("완료 미션", MissionListFetchType.complete),
+         ("미완료 미션", MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
+            menuItems.append(UIAction(title: menuTitle,
+                                      handler: { [weak self] _ in
+                self?.missionTypeMenuSelected.send(fetchType)
+                self?.naviBar.setTitle(menuTitle)
+            }))
+        }
+        return menuItems
+    }()
+    
+    private lazy var sentenceLabel: SentencePaddingLabel = {
+        let lb = SentencePaddingLabel()
+        if case let .ranking(_, sentence) = sceneType {
+            lb.text = sentence
+        }
+        lb.setTypoStyle(.SoptampFont.subtitle1)
+        lb.textColor = DSKitAsset.Colors.soptampGray900.color
+        lb.numberOfLines = 2
+        lb.textAlignment = .center
+        lb.backgroundColor = DSKitAsset.Colors.soptampPurple100.color
+        lb.layer.cornerRadius = 9.adjustedH
+        lb.clipsToBounds = true
+        lb.setCharacterSpacing(0)
+        return lb
+    }()
+    
+    private lazy var missionListCollectionView: UICollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
+        cv.showsVerticalScrollIndicator = true
+        cv.backgroundColor = .white
+        cv.bounces = false
+        return cv
+    }()
+    
+    private let missionListEmptyView = MissionListEmptyView()
+    
+    private lazy var floatingButtonStackView = UIStackView(frame: self.view.frame).then {
+        $0.axis = .horizontal
+        $0.spacing = 0.f
     }
-    return menuItems
-  }()
-
-  private lazy var sentenceLabel: SentencePaddingLabel = {
-    let lb = SentencePaddingLabel()
-    if case let .ranking(_, sentence) = sceneType {
-      lb.text = sentence
+    
+    private lazy var currentGenerationRankFloatingButton: UIButton = {
+        let bt = UIButton()
+        bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+        bt.layer.cornerRadius = 27.adjustedH
+        bt.setBackgroundColor(DSKitAsset.Colors.soptampPurple300.color, for: .normal)
+        bt.setBackgroundColor(DSKitAsset.Colors.soptampPurple300.color.withAlphaComponent(0.2), for: .selected)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
+        bt.tintColor = .white
+        bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
+        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
+        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        return bt
+    }()
+    
+    private lazy var partRankingFloatingButton: UIButton = {
+        let bt = UIButton()
+        bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+        bt.layer.cornerRadius = 27.adjustedH
+        bt.setBackgroundColor(DSKitAsset.Colors.soptampPink300.color, for: .normal)
+        bt.setBackgroundColor(DSKitAsset.Colors.soptampPink300.color.withAlphaComponent(0.2), for: .selected)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
+        bt.tintColor = .white
+        bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
+        let attributedStr = NSMutableAttributedString(string: "파트별 랭킹")
+        let style = NSMutableParagraphStyle()
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
+        bt.setAttributedTitle(attributedStr, for: .normal)
+        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
+        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        return bt
+    }()
+    
+    // MARK: - View Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setUI()
+        self.setLayout()
+        self.setDelegate()
+        self.setGesture()
+        self.registerCells()
+        self.setDataSource()
+        self.bindViews()
+        self.bindViewModels()
     }
-    lb.setTypoStyle(.SoptampFont.subtitle1)
-    lb.textColor = DSKitAsset.Colors.soptampGray900.color
-    lb.numberOfLines = 2
-    lb.textAlignment = .center
-    lb.backgroundColor = DSKitAsset.Colors.soptampPurple100.color
-    lb.layer.cornerRadius = 9.adjustedH
-    lb.clipsToBounds = true
-    lb.setCharacterSpacing(0)
-    return lb
-  }()
-
-  private lazy var missionListCollectionView: UICollectionView = {
-    let cv = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
-    cv.showsVerticalScrollIndicator = true
-    cv.backgroundColor = .white
-    cv.bounces = false
-    return cv
-  }()
-
-  private let missionListEmptyView = MissionListEmptyView()
-
-  private lazy var floatingButtonStackView = UIStackView(frame: self.view.frame).then {
-    $0.axis = .horizontal
-    $0.spacing = 0.f
-  }
-
-  private lazy var currentGenerationRankFloatingButton: UIButton = {
-    let bt = UIButton()
-    bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-    bt.layer.cornerRadius = 27.adjustedH
-    bt.setBackgroundColor(DSKitAsset.Colors.soptampPurple300.color, for: .normal)
-    bt.setBackgroundColor(DSKitAsset.Colors.soptampPurple300.color.withAlphaComponent(0.2), for: .selected)
-    bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
-    bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
-    bt.tintColor = .white
-    bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
-    bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-    bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-    return bt
-  }()
-
-  private lazy var partRankingFloatingButton: UIButton = {
-    let bt = UIButton()
-    bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-    bt.layer.cornerRadius = 27.adjustedH
-    bt.setBackgroundColor(DSKitAsset.Colors.soptampPink300.color, for: .normal)
-    bt.setBackgroundColor(DSKitAsset.Colors.soptampPink300.color.withAlphaComponent(0.2), for: .selected)
-    bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
-    bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .highlighted)
-    bt.tintColor = .white
-    bt.titleLabel?.setTypoStyle(.SoptampFont.h2)
-    let attributedStr = NSMutableAttributedString(string: "파트별 랭킹")
-    let style = NSMutableParagraphStyle()
-    attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-    attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
-    bt.setAttributedTitle(attributedStr, for: .normal)
-    bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-    bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-    return bt
-  }()
-
-  // MARK: - View Life Cycle
-
-  public override func viewDidLoad() {
-    super.viewDidLoad()
-    self.setUI()
-    self.setLayout()
-    self.setDelegate()
-    self.setGesture()
-    self.registerCells()
-    self.setDataSource()
-    self.bindViews()
-    self.bindViewModels()
-  }
-
-  public override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    self.viewWillAppear.send(())
-    self.navigationController?.interactivePopGestureRecognizer?.delegate = self
-  }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.viewWillAppear.send(())
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
     
     init(viewModel: MissionListViewModel) {
         self.viewModel = viewModel
@@ -178,290 +178,290 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
 // MARK: - UI & Layouts
 
 extension MissionListVC {
-
-  private func setUI() {
-    self.view.backgroundColor = .white
-    self.navigationController?.isNavigationBarHidden = true
-  }
-
-  private func setLayout() {
-    self.view.addSubviews(naviBar, missionListCollectionView)
-
-    naviBar.snp.makeConstraints { make in
-      make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+    
+    private func setUI() {
+        self.view.backgroundColor = .white
+        self.navigationController?.isNavigationBarHidden = true
     }
-
-    missionListCollectionView.snp.makeConstraints { make in
-      make.top.equalTo(naviBar.snp.bottom).offset(20.adjustedH)
-      make.leading.trailing.equalToSuperview()
-      make.bottom.equalToSuperview()
+    
+    private func setLayout() {
+        self.view.addSubviews(naviBar, missionListCollectionView)
+        
+        naviBar.snp.makeConstraints { make in
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        missionListCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(naviBar.snp.bottom).offset(20.adjustedH)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalToSuperview()
+        }
+        
+        switch sceneType {
+        case .default:
+            self.view.addSubview(self.floatingButtonStackView)
+            
+            self.floatingButtonStackView.snp.makeConstraints { make in
+                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+                make.centerX.equalToSuperview()
+            }
+            
+            self.partRankingFloatingButton.snp.makeConstraints {
+                $0.width.equalTo(143.adjusted)
+                $0.height.equalTo(54.adjustedH)
+            }
+            
+            self.currentGenerationRankFloatingButton.snp.makeConstraints {
+                $0.width.equalTo(143.adjusted)
+                $0.height.equalTo(54.adjustedH)
+            }
+            
+        case .ranking:
+            self.view.addSubview(sentenceLabel)
+            
+            sentenceLabel.snp.makeConstraints { make in
+                make.top.equalTo(naviBar.snp.bottom).offset(10.adjustedH)
+                make.leading.trailing.equalToSuperview().inset(20.adjusted)
+                make.height.equalTo(64.adjustedH)
+            }
+            
+            missionListCollectionView.snp.remakeConstraints { make in
+                make.top.equalTo(sentenceLabel.snp.bottom).offset(16.adjustedH)
+                make.leading.trailing.equalToSuperview()
+                make.bottom.equalToSuperview()
+            }
+        }
     }
-
-    switch sceneType {
-    case .default:
-      self.view.addSubview(self.floatingButtonStackView)
-
-      self.floatingButtonStackView.snp.makeConstraints { make in
-        make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
-        make.centerX.equalToSuperview()
-      }
-
-      self.partRankingFloatingButton.snp.makeConstraints {
-        $0.width.equalTo(143.adjusted)
-        $0.height.equalTo(54.adjustedH)
-      }
-
-      self.currentGenerationRankFloatingButton.snp.makeConstraints {
-        $0.width.equalTo(143.adjusted)
-        $0.height.equalTo(54.adjustedH)
-      }
-
-    case .ranking:
-      self.view.addSubview(sentenceLabel)
-
-      sentenceLabel.snp.makeConstraints { make in
-        make.top.equalTo(naviBar.snp.bottom).offset(10.adjustedH)
-        make.leading.trailing.equalToSuperview().inset(20.adjusted)
-        make.height.equalTo(64.adjustedH)
-      }
-
-      missionListCollectionView.snp.remakeConstraints { make in
-        make.top.equalTo(sentenceLabel.snp.bottom).offset(16.adjustedH)
-        make.leading.trailing.equalToSuperview()
-        make.bottom.equalToSuperview()
-      }
-    }
-  }
 }
 
 // MARK: - Methods
 
 extension MissionListVC {
-  private func bindViews() {
-
-    naviBar.rightButtonTapped
-      .asDriver()
-      .withUnretained(self)
-      .sink { owner, _ in
-        owner.onGuideTap?()
-      }.store(in: self.cancelBag)
-
-    naviBar.leftButtonTapped
-      .withUnretained(self)
-      .sink { owner, _ in
-        owner.onNaviBackTap?()
-      }.store(in: self.cancelBag)
-
-    partRankingFloatingButton.publisher(for: .touchUpInside)
-      .withUnretained(self)
-      .sink { owner, _ in
-        owner.onPartRankingButtonTap?(.partRanking)
-      }.store(in: self.cancelBag)
-
-    currentGenerationRankFloatingButton.publisher(for: .touchUpInside)
-      .withUnretained(self)
-      .sink { owner, _ in
-        guard let usersActiveGenerationStatus = owner.usersActiveGenerationStatus else { return }
-
-        owner.onCurrentGenerationRankingButtonTap?(.currentGeneration(info: usersActiveGenerationStatus))
-      }.store(in: self.cancelBag)
-
-    swipeHandler
-      .first()
-      .withUnretained(self)
-      .sink { owner, _ in
-        owner.onSwiped?()
-      }.store(in: self.cancelBag)
-  }
+    private func bindViews() {
+        
+        naviBar.rightButtonTapped
+            .asDriver()
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onGuideTap?()
+            }.store(in: self.cancelBag)
+        
+        naviBar.leftButtonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onNaviBackTap?()
+            }.store(in: self.cancelBag)
+        
+        partRankingFloatingButton.publisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onPartRankingButtonTap?(.partRanking)
+            }.store(in: self.cancelBag)
+        
+        currentGenerationRankFloatingButton.publisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                guard let usersActiveGenerationStatus = owner.usersActiveGenerationStatus else { return }
+                
+                owner.onCurrentGenerationRankingButtonTap?(.currentGeneration(info: usersActiveGenerationStatus))
+            }.store(in: self.cancelBag)
+        
+        swipeHandler
+            .first()
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onSwiped?()
+            }.store(in: self.cancelBag)
+    }
     
-  private func bindViewModels() {
-    let input = MissionListViewModel.Input(
-      viewDidLoad: Driver<Void>.just(()),
-      viewWillAppear: viewWillAppear.asDriver(),
-      missionTypeSelected: missionTypeMenuSelected
-    )
-      
-    let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
-
-    naviBar.reportButtonTapped
-      .withUnretained(self)
-      .sink { owner, _ in
-          owner.onReportButtonTap?()
-      }.store(in: cancelBag)
-      
-    output.$missionListModel
-      .compactMap { $0 }
-      .sink { [weak self] model in
-          self?.setCollectionView(model: model)
-      }.store(in: self.cancelBag)
-
-    output.$usersActivateGenerationStatus
-      .compactMap { $0 }
-      .sink { [weak self] generationStatus in
-        guard generationStatus.status == .ACTIVE else { return }
-
-        self?.usersActiveGenerationStatus = generationStatus
-        self?.remakeButtonConstraint()
-        self?.configureCurrentGenerationButton(with: String(describing: generationStatus.currentGeneration))
-      }.store(in: self.cancelBag)
-
-    output.needNetworkAlert
-      .withUnretained(self)
-      .sink { owner, _ in
-          owner.showNetworkAlert()
-      }.store(in: self.cancelBag)
-  }
+    private func bindViewModels() {
+        let input = MissionListViewModel.Input(
+            viewDidLoad: Driver<Void>.just(()),
+            viewWillAppear: viewWillAppear.asDriver(),
+            missionTypeSelected: missionTypeMenuSelected
+        )
+        
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
+        
+        naviBar.reportButtonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onReportButtonTap?()
+            }.store(in: cancelBag)
+        
+        output.$missionListModel
+            .compactMap { $0 }
+            .sink { [weak self] model in
+                self?.setCollectionView(model: model)
+            }.store(in: self.cancelBag)
+        
+        output.$usersActivateGenerationStatus
+            .compactMap { $0 }
+            .sink { [weak self] generationStatus in
+                guard generationStatus.status == .ACTIVE else { return }
+                
+                self?.usersActiveGenerationStatus = generationStatus
+                self?.remakeButtonConstraint()
+                self?.configureCurrentGenerationButton(with: String(describing: generationStatus.currentGeneration))
+            }.store(in: self.cancelBag)
+        
+        output.needNetworkAlert
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.showNetworkAlert()
+            }.store(in: self.cancelBag)
+    }
 }
 
 extension MissionListVC {
-
-  private func setDelegate() {
-    missionListCollectionView.delegate = self
-  }
-
-  private func setGesture() {
-    self.setGesture(to: missionListCollectionView)
-    self.setGesture(to: missionListEmptyView)
-  }
-
-  private func setGesture(to view: UIView) {
-    let swipeGesture = UIPanGestureRecognizer(target: self, action: #selector(swipeBack(_:)))
-    swipeGesture.delegate = self
-    view.addGestureRecognizer(swipeGesture)
-  }
-
-  @objc
-  private func swipeBack(_ sender: UIPanGestureRecognizer) {
-    let velocity = sender.velocity(in: self.view)
-    let velocityMinimum: CGFloat = 1000
-    guard let navigation = self.navigationController else { return }
-    let isScrollY: Bool = abs(velocity.x) > abs(velocity.y) + 200
-    let isNotRootView = navigation.viewControllers.count >= 2
-    if velocity.x >= velocityMinimum
-        && isNotRootView
-        && isScrollY {
-      self.missionListCollectionView.isScrollEnabled = false
-      swipeHandler.send(())
+    
+    private func setDelegate() {
+        missionListCollectionView.delegate = self
     }
-  }
-
-  private func registerCells() {
-    MissionListCVC.register(target: missionListCollectionView)
-  }
-
-  private func setDataSource() {
-    dataSource = UICollectionViewDiffableDataSource(collectionView: missionListCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
-      switch MissionListSection.type(indexPath.section) {
-      case .sentence:
-        guard let sentenceCell = collectionView.dequeueReusableCell(withReuseIdentifier: MissionListCVC.className, for: indexPath) as? MissionListCVC else { return UICollectionViewCell() }
-        return sentenceCell
-
-      case .missionList:
-        guard let missionListCell = collectionView.dequeueReusableCell(withReuseIdentifier: MissionListCVC.className, for: indexPath) as? MissionListCVC else { return UICollectionViewCell() }
-        let missionListModel = itemIdentifier
-        missionListCell.initCellType = missionListModel.toCellType()
-        missionListCell.setData(model: missionListModel)
-        return missionListCell
-      }
-    })
-  }
-
-  func setCollectionView(model: [MissionListModel]) {
-    if model.isEmpty {
-      self.missionListCollectionView.isHidden = true
-      self.missionListEmptyView.isHidden = false
-      self.setEmptyView()
-    } else {
-      self.missionListCollectionView.isHidden = false
-      self.missionListEmptyView.isHidden = true
-      self.applySnapshot(model: model)
+    
+    private func setGesture() {
+        self.setGesture(to: missionListCollectionView)
+        self.setGesture(to: missionListEmptyView)
     }
-  }
-
-  private func setEmptyView() {
-    missionListEmptyView.snp.removeConstraints()
-    missionListEmptyView.removeFromSuperview()
-    self.view.addSubviews(missionListEmptyView)
-    missionListEmptyView.snp.makeConstraints { make in
-      make.top.equalTo(naviBar.snp.bottom).offset(145.adjustedH)
-      make.centerX.equalToSuperview()
-      make.width.equalToSuperview()
-      make.bottom.equalToSuperview().priority(.low)
+    
+    private func setGesture(to view: UIView) {
+        let swipeGesture = UIPanGestureRecognizer(target: self, action: #selector(swipeBack(_:)))
+        swipeGesture.delegate = self
+        view.addGestureRecognizer(swipeGesture)
     }
-    bringRankingFloatingButtonToFront()
-  }
-
-  private func bringRankingFloatingButtonToFront() {
-    self.view.subviews.forEach { view in
-      if view == self.partRankingFloatingButton {
-        self.view.bringSubviewToFront(partRankingFloatingButton)
-      }
+    
+    @objc
+    private func swipeBack(_ sender: UIPanGestureRecognizer) {
+        let velocity = sender.velocity(in: self.view)
+        let velocityMinimum: CGFloat = 1000
+        guard let navigation = self.navigationController else { return }
+        let isScrollY: Bool = abs(velocity.x) > abs(velocity.y) + 200
+        let isNotRootView = navigation.viewControllers.count >= 2
+        if velocity.x >= velocityMinimum
+            && isNotRootView
+            && isScrollY {
+            self.missionListCollectionView.isScrollEnabled = false
+            swipeHandler.send(())
+        }
     }
-  }
-
-  private func applySnapshot(model: [MissionListModel]) {
-    var snapshot = NSDiffableDataSourceSnapshot<MissionListSection, MissionListModel>()
-    snapshot.appendSections([.sentence, .missionList])
-    snapshot.appendItems(model, toSection: .missionList)
-    dataSource.apply(snapshot, animatingDifferences: false)
-    self.view.setNeedsLayout()
-  }
-
-  private func remakeButtonConstraint() {
-    self.floatingButtonStackView.addArrangedSubviews(self.currentGenerationRankFloatingButton, self.partRankingFloatingButton)
-  }
-
-  private func configureCurrentGenerationButton(with generation: String) {
-    let attributedStr = NSMutableAttributedString(string: "\(generation)기 랭킹")
-    let style = NSMutableParagraphStyle()
-    attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-    attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
-    self.currentGenerationRankFloatingButton.setAttributedTitle(attributedStr, for: .normal)
-  }
-  
-  private func showNetworkAlert() {
-    AlertUtils.presentNetworkAlertVC(
-        theme: .soptamp,
-        animated: true
-    )
-  }
+    
+    private func registerCells() {
+        MissionListCVC.register(target: missionListCollectionView)
+    }
+    
+    private func setDataSource() {
+        dataSource = UICollectionViewDiffableDataSource(collectionView: missionListCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            switch MissionListSection.type(indexPath.section) {
+            case .sentence:
+                guard let sentenceCell = collectionView.dequeueReusableCell(withReuseIdentifier: MissionListCVC.className, for: indexPath) as? MissionListCVC else { return UICollectionViewCell() }
+                return sentenceCell
+                
+            case .missionList:
+                guard let missionListCell = collectionView.dequeueReusableCell(withReuseIdentifier: MissionListCVC.className, for: indexPath) as? MissionListCVC else { return UICollectionViewCell() }
+                let missionListModel = itemIdentifier
+                missionListCell.initCellType = missionListModel.toCellType()
+                missionListCell.setData(model: missionListModel)
+                return missionListCell
+            }
+        })
+    }
+    
+    func setCollectionView(model: [MissionListModel]) {
+        if model.isEmpty {
+            self.missionListCollectionView.isHidden = true
+            self.missionListEmptyView.isHidden = false
+            self.setEmptyView()
+        } else {
+            self.missionListCollectionView.isHidden = false
+            self.missionListEmptyView.isHidden = true
+            self.applySnapshot(model: model)
+        }
+    }
+    
+    private func setEmptyView() {
+        missionListEmptyView.snp.removeConstraints()
+        missionListEmptyView.removeFromSuperview()
+        self.view.addSubviews(missionListEmptyView)
+        missionListEmptyView.snp.makeConstraints { make in
+            make.top.equalTo(naviBar.snp.bottom).offset(145.adjustedH)
+            make.centerX.equalToSuperview()
+            make.width.equalToSuperview()
+            make.bottom.equalToSuperview().priority(.low)
+        }
+        bringRankingFloatingButtonToFront()
+    }
+    
+    private func bringRankingFloatingButtonToFront() {
+        self.view.subviews.forEach { view in
+            if view == self.partRankingFloatingButton {
+                self.view.bringSubviewToFront(partRankingFloatingButton)
+            }
+        }
+    }
+    
+    private func applySnapshot(model: [MissionListModel]) {
+        var snapshot = NSDiffableDataSourceSnapshot<MissionListSection, MissionListModel>()
+        snapshot.appendSections([.sentence, .missionList])
+        snapshot.appendItems(model, toSection: .missionList)
+        dataSource.apply(snapshot, animatingDifferences: false)
+        self.view.setNeedsLayout()
+    }
+    
+    private func remakeButtonConstraint() {
+        self.floatingButtonStackView.addArrangedSubviews(self.currentGenerationRankFloatingButton, self.partRankingFloatingButton)
+    }
+    
+    private func configureCurrentGenerationButton(with generation: String) {
+        let attributedStr = NSMutableAttributedString(string: "\(generation)기 랭킹")
+        let style = NSMutableParagraphStyle()
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
+        self.currentGenerationRankFloatingButton.setAttributedTitle(attributedStr, for: .normal)
+    }
+    
+    private func showNetworkAlert() {
+        AlertUtils.presentNetworkAlertVC(
+            theme: .soptamp,
+            animated: true
+        )
+    }
 }
 
 // MARK: - UICollectionViewDelegate
 
 extension MissionListVC: UICollectionViewDelegate {
-  public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-    switch indexPath.section {
-    case 0:
-      return false
-    case 1:
-      switch self.sceneType {
-      case .default:
-        return true
-      case .ranking:
-        return true
-      }
-    default:
-      return false
+    public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        switch indexPath.section {
+        case 0:
+            return false
+        case 1:
+            switch self.sceneType {
+            case .default:
+                return true
+            case .ranking:
+                return true
+            }
+        default:
+            return false
+        }
     }
-  }
-
-  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    switch indexPath.section {
-    case 0:
-      return
-    case 1:
-      guard let tappedCell = collectionView.cellForItem(at: indexPath) as? MissionListCVC,
-            let model = tappedCell.model else { return }
-      onCellTap?(model, sceneType.usrename)
-    default:
-      return
+    
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        switch indexPath.section {
+        case 0:
+            return
+        case 1:
+            guard let tappedCell = collectionView.cellForItem(at: indexPath) as? MissionListCVC,
+                  let model = tappedCell.model else { return }
+            onCellTap?(model, sceneType.usrename)
+        default:
+            return
+        }
     }
-  }
 }
 
 extension MissionListVC: UIGestureRecognizerDelegate {
-  public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-    return true
-  }
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -23,7 +23,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
 
   // MARK: - Properties
 
-  public var viewModel: MissionListViewModel!
+  public var viewModel: MissionListViewModel
   public var sceneType: MissionListSceneType {
     return self.viewModel.missionListsceneType
   }
@@ -69,11 +69,11 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
     var menuItems: [UIAction] = []
     [("전체 미션", MissionListFetchType.all),
      ("완료 미션", MissionListFetchType.complete),
-     ("미완료 미션", MissionListFetchType.incomplete)].forEach { menuTitle, fetchType in
+     ("미완료 미션", MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
       menuItems.append(UIAction(title: menuTitle,
-                                handler: { _ in
-        self.missionTypeMenuSelected.send(fetchType)
-        self.naviBar.setTitle(menuTitle)
+                                handler: { [weak self] _ in
+        self?.missionTypeMenuSelected.send(fetchType)
+        self?.naviBar.setTitle(menuTitle)
       }))
     }
     return menuItems
@@ -164,6 +164,15 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
     self.viewWillAppear.send(())
     self.navigationController?.interactivePopGestureRecognizer?.delegate = self
   }
+    
+    init(viewModel: MissionListViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
 // MARK: - UI & Layouts

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -101,7 +101,7 @@ extension MissionListViewModel {
       .asDriver()
       .sink { usersActivateGenerationStatus in
         output.usersActivateGenerationStatus = usersActivateGenerationStatus
-      }.store(in: self.cancelBag)
+      }.store(in: cancelBag)
     
     self.useCase.errorOccurred
       .asDriver()

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -10,7 +10,6 @@ import Foundation
 import Combine
 
 import Core
-import TabBarFeatureInterface
 
 final public class TabBarViewModel: TabBarViewModelType {
     

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
@@ -29,7 +29,6 @@ public class STNavigationBar: UIView {
     
     // MARK: - UI Component
     
-    private var vc: UIViewController?
     private let titleLabel = UILabel()
     private let titleButton = UIButton()
     private let leftButton = UIButton()


### PR DESCRIPTION
## 🌴 PR 요약
앱 전체적으로 발생하고 있는 메모리 누수 최적화를 진행했습니다.

🌱 작업한 브랜치
- feature/#529

## 🌱 PR Point
### 문제 발생
#528 이슈를 해결하던 도중, 솝탬프 진입 횟수만큼 `MissionListRepository`가 메모리에 남아있는 현상을 발견했습니다.
메모리 그래프를 살펴보니, `MissionListVC`가 `deinit` 되지 않아 `ViewModel -> UseCase -> Repository`까지 모두 메모리에 남아 누수가 발생하고 있었습니다.

앱의 다른 부분도 확인해보았는데 4개의 화면에서 동일한 누수가 발생하고 있었습니다. 첨부한 이미지는 마이페이지, 홈캘린더, 콕찌르기, 솝탬프를 각각 5회 진입 한 후 메모리 사용량입니다.
<img width="1178" alt="memory누수" src="https://github.com/user-attachments/assets/54407de3-eb80-4855-8bfe-50bb22359119" />

|SOPT-iOS-Demo Repository |TabBarFeatureInterface|
|:--:|:--:|
|<img width="472" alt="스크린샷 2025-04-02 오후 3 53 45" src="https://github.com/user-attachments/assets/5e87078a-7cfb-4b18-892a-9198d39ebc7c" />|<img width="451" alt="스크린샷 2025-04-02 오후 3 58 04" src="https://github.com/user-attachments/assets/a92d55ae-b204-4d1f-9774-c652b74ae57d" />|

각 플로우의 진입 횟수만큼 객체가 쌓이는 것을 확인할 수 있었습니다.


### 문제 해결
**1️⃣ HomeCalendarDetail**
- `self`를 직접 캡처하고 있던 클로저 1곳을 `[weak self]`로 수정했습니다.

**2️⃣ MyPage**
![image](https://github.com/user-attachments/assets/342f8df1-ec3a-4f9d-bddf-f238a1608b45)
- 메모리 그래프에서 **총 8개의 클로저가 VC를 캡처**하고 있는 것을 확인했습니다.
- 해당 클로저들에서 `self`를 `[weak self]`로 수정하여 순환 참조를 끊었습니다.

**3️⃣ MissionList**
![image](https://github.com/user-attachments/assets/1be58a9c-0286-4562-8572-7eb6e7401161)
- menuItems 구성 시 self를 직접 캡처하고 있어 [weak self]로 변경했습니다.
- 하지만 여전히 메모리 그래프에서 1개의 클로저가 VC를 참조하고 있었습니다.

![MissionListVC](https://github.com/user-attachments/assets/5536ef06-1f17-4ed3-b5ea-967103902448)
- 메모리 그래프를 확인해보니, `UICollectionViewCompositionalLayout`에서 누수 원인을 찾을 수 있었고, 관련 코드를 찾아 수정했습니다.

**4️⃣ PokeMainVC**
<img width="1512" alt="Poke" src="https://github.com/user-attachments/assets/bacd02bc-e27e-463b-bae3-d488333c7438" />
<img width="500" src="https://github.com/user-attachments/assets/935ce687-b8c6-4696-aab0-dba09c86056e" />

- 아래와 같이 VC가 클로저 내에서 직접 사용되고 있어 순환 참조가 발생하고 있었습니다.
```swift
 pokeMain.vm.onNewFriendMade = { [weak self] friendName in
            ...
            // Coordinator의 rootController를 사용하지 않고 vc를 생성하고 있음
            let pokeMakingFriendCompletedVC = self.factory.makePokeMakingFriendCompleted(friendName: friendName).viewController
            pokeMain.vc.viewController.present(pokeMakingFriendCompletedVC, animated: false)
            ...
        }
```
- 해당 부분도 `[weak self]`로 캡처하도록 수정한 뒤, `deinit`이 정상적으로 동작하는 것을 확인했습니다.

### 결과
<img width="1512" alt="스크린샷 2025-04-02 오후 4 33 45" src="https://github.com/user-attachments/assets/ac5531a5-fa4e-4760-83e6-7baddfdbec09" />
<img width="497" alt="스크린샷 2025-04-02 오후 4 35 13" src="https://github.com/user-attachments/assets/b18a3259-1976-486e-a1b7-1623cc1de5c5" />

- 코드 수정 후 메모리 그래프와 deinit 로그로 **VC 메모리가 더 이상 남아있지 않는 것을 확인할 수 있었습니다!**
- 코드 수정 부분의 기능이 정상적으로 동작하는 것도 확인했습니다.
- 하지만 여전히 **Poke에서 사용되는 일부 View가 메모리에 남아있어**, #533 이슈에서 이어서 수정해보도록 하겠습니다!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `MissionListVC`의 `space` 간격을 4로 수정했습니다.
- `OPNavigationBar`에서도 VC를 주입받고 있어서 VC를 제거하려고 했으나, 너무 많은 플로우에서 해당 `navigationBar`를 사용하고 있고 메모리 누수와 직접적인 연관이 없어 수정하지 않았습니다. (#515 에서 함께 진행해보아요)
- 일부 레거시 코드에서 `VC에서 클로저 호출 -> Coordinator에서 클로저 구현` 방식으로 화면전환을 하고 있는 부분이 있는데, 
View는 UI만, ViewModel은 상태 관리, Coordinator가 화면전환의 역할을 갖고 있는만큼 `VC -> VM -> Coordinator흐름`으로 리팩토링 하는 걸 제안드립니다 ! 


## 📮 관련 이슈
- Resolved: #529
