### PR TITLE
[Fix] #536 - tabbar UI

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -241,6 +241,7 @@ public struct I18N {
     
     public struct Home {
         public static let viewAll = "전체보기"
+        public static let title = "홈"
         
         public struct PopUp {
             public static let login = "로그인"

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Components/TabBarItem.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Components/TabBarItem.swift
@@ -22,8 +22,17 @@ extension TabBarItemType {
         }
     }
     
+    private var title: String {
+        switch self {
+        case .home:
+            return I18N.Home.title
+        case .soptlog:
+            return I18N.Soptlog.navigationTitle
+        }
+    }
+    
     func makeTabBarItem() -> UITabBarItem {
-        return UITabBarItem(title: nil,
+        return UITabBarItem(title: self.title,
                             image: self.itemImage,
                             selectedImage: nil)
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
@@ -63,7 +63,7 @@ extension TabBarController {
     /// setting tabbar height
     private func configureTabBarHeight() {
         var tabFrame = tabBar.frame
-        tabFrame.size.height = 72
+        tabFrame.size.height = 82
         tabFrame.origin.y = view.frame.size.height - tabFrame.size.height
         
         tabBar.frame = tabFrame

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
@@ -73,7 +73,9 @@ extension TabBarController {
         TabBarItemType.allCases.forEach {
             tabList[$0.rawValue].tabBarItem = $0.makeTabBarItem()
             tabList[$0.rawValue].tabBarItem.tag = $0.rawValue
-            tabList[$0.rawValue].tabBarItem.imageInsets = UIEdgeInsets(top: 18, left: 0, bottom: -18, right: 0)
+            tabList[$0.rawValue].tabBarItem.imageInsets = UIEdgeInsets(top: 5, left: 0, bottom: -5, right: 0)
+            tabList[$0.rawValue].tabBarItem.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: 3)
+            tabList[$0.rawValue].tabBarItem.setTitleTextAttributes([NSAttributedString.Key.font: DSKitFontFamily.Suit.medium.font(size: 10)], for: .normal)
         }
 
         setViewControllers(tabList, animated: true)


### PR DESCRIPTION
## 🌴 PR 요약
TabBar UI 수정 요청사항을 반영했습니다.

🌱 작업한 브랜치
- feature/#536

## 🌱 PR Point

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="185" height="140" alt="image" src="https://github.com/user-attachments/assets/228bbc45-0057-450e-9bbf-4453914ec8f8" />
<img width="185" alt="image" src="https://github.com/user-attachments/assets/b38f8834-6261-429c-a9d7-ebaf2a637ba1" />    

`title`과 `icon` 간격은 2인데, 구현하면 피그마보다 간격이 좁아보여
두 번째 이미지처럼 TabBar의 top을 기준으로 위치 조정했습니다.


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|TabBar UI 수정|<img width="375" src="https://github.com/user-attachments/assets/434bdfd2-2841-432a-91c1-ecbb3e624f61">|

## 📮 관련 이슈
- Resolved: #536
