### PR TITLE
[Feat] #547 - 알림 리스트 필터 기능 구현

### DIFF
--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/Cells/NotificationFilterCVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/Cells/NotificationFilterCVC.swift
@@ -27,7 +27,7 @@ final class NotificationFilterCVC: UICollectionViewCell {
     
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
+        label.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
         label.textColor = DSKitAsset.Colors.white100.color
         label.textAlignment = .center
         return label
@@ -44,6 +44,11 @@ final class NotificationFilterCVC: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.cornerRadius = self.frame.height / 2
+    }
 }
 
 // MARK: - UI & Layouts
@@ -51,21 +56,22 @@ final class NotificationFilterCVC: UICollectionViewCell {
 extension NotificationFilterCVC {
     private func setUI() {
         self.backgroundColor = DSKitAsset.Colors.black60.color
-        self.layer.cornerRadius = 4
+        self.layer.borderWidth = 1
     }
     
     private func setLayout() {
         self.addSubviews(titleLabel)
-        
+
         titleLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(8)
+            make.leading.trailing.equalToSuperview().inset(14)
             make.centerY.equalToSuperview()
         }
     }
     
     func setSelectionStyle(isSelected: Bool) {
-        self.backgroundColor = isSelected ? DSKitAsset.Colors.white100.color : DSKitAsset.Colors.black60.color
-        self.titleLabel.textColor = isSelected ? DSKitAsset.Colors.black100.color : DSKitAsset.Colors.white100.color
+        self.backgroundColor = isSelected ? DSKitAsset.Colors.gray700.color : DSKitAsset.Colors.gray800.color
+        self.titleLabel.textColor = isSelected ? DSKitAsset.Colors.white100.color : DSKitAsset.Colors.gray300.color
+        self.layer.borderColor = isSelected ? DSKitAsset.Colors.gray100.color.cgColor : DSKitAsset.Colors.gray700.color.cgColor
     }
 }
 

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/CollectionViewLayout/NotificationListViewCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/CollectionViewLayout/NotificationListViewCompositionalLayout.swift
@@ -26,7 +26,7 @@ extension NotificationListVC {
         let itemSize = NSCollectionLayoutSize(widthDimension: .estimated(33), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0) , heightDimension: .absolute(23))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0) , heightDimension: .absolute(36))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         group.interItemSpacing = .fixed(8)
 

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/VC/NotificationListVC.swift
@@ -103,14 +103,20 @@ extension NotificationListVC {
     }
     
     private func setLayout() {
-        self.view.addSubviews(naviBar, notificationListCollectionView)
+        self.view.addSubviews(naviBar, notificationFilterCollectionView, notificationListCollectionView)
         
         naviBar.snp.makeConstraints { make in
             make.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
         }
         
-        notificationListCollectionView.snp.makeConstraints { make in
+        notificationFilterCollectionView.snp.makeConstraints { make in
             make.top.equalTo(naviBar.snp.bottom)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(60)
+        }
+        
+        notificationListCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(notificationFilterCollectionView.snp.bottom)
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationFilterType.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationFilterType.swift
@@ -12,4 +12,12 @@ enum NotificationFilterType: String {
     case all = "전체 알림"
     case notice = "공지"
     case news = "소식"
+    
+    var serverKey: String {
+        switch self {
+        case .all: return "ALL"
+        case .notice: return "NOTICE"
+        case .news: return "NEWS"
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -24,6 +24,7 @@ public class NotificationListViewModel: NotificationListViewModelType {
     let filterList: [NotificationFilterType] = [.all, .notice, .news]
     var notifications: [NotificationListModel] = [] // 리스트 뷰에서 snapshot을 사용하기 때문에 중복된 모델이 있으면 안 된다.
     
+    private var selectedCategory: NotificationFilterType = .all
     var page = 0
     var isPaging = false
     
@@ -114,7 +115,10 @@ extension NotificationListViewModel {
             .removeDuplicates()
             .withUnretained(self)
             .sink { owner, index in
-                print(index)
+                guard owner.filterList.indices.contains(index) else { return }
+                owner.selectedCategory = owner.filterList[index]
+                let filtered = owner.filterNotifications(owner.notifications, by: owner.selectedCategory)
+                output.notificationList.send(filtered)
             }.store(in: cancelBag)
         
         input.refreshRequest
@@ -139,8 +143,10 @@ extension NotificationListViewModel {
             .withUnretained(self)
             .sink { owner, notificationList in
                 owner.removeDuplicatesAndUpdateNotifications(contentsOf: notificationList)
-                output.notificationList.send(self.notifications)
+                let filtered = owner.filterNotifications(owner.notifications, by: owner.selectedCategory)
+                output.notificationList.send(filtered)
                 owner.endPaging(isEmptyResponse: notificationList.isEmpty)
+                
                 output.refreshLoading.send(false)
             }.store(in: cancelBag)
         
@@ -179,5 +185,21 @@ extension NotificationListViewModel {
     
     private func read(index: Int) {
         self.notifications[index].isRead = true
+    }
+    
+    private func filterNotifications(_ notifications: [NotificationListModel], by category: NotificationFilterType) -> [NotificationListModel] {
+        switch category {
+        case .all: return notifications
+        case .notice:
+            return notifications.filter {
+                guard let category = $0.category else { return false }
+                return category == NotificationFilterType.notice.serverKey
+            }
+        case .news:
+            return notifications.filter {
+                guard let category = $0.category else { return false }
+                return category == NotificationFilterType.news.serverKey
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

알림 리스트에 필터 기능을 구현합니다.

🌱 작업한 브랜치
- #547 

## 🌱 PR Point

- 안드는 저번 스프린트 때 같이 배포했다고 하길래 후다닥 구현해 왔습니ㄷ. .
- 라고 하려 했는데 why 이미 필터링 레이아웃까지 다 구현되어 있는 걸까요..?
  - 옛날에 모종의 이슈로 인해 필터 기능이 배포되지 못했던 이유가 있었던 듯 합니다..
- 그래서 기존의 코드에서 UI가 수정된 부분만 약간 바꾸었습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

생략

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|알림 리스트 필터|<video src = "https://github.com/user-attachments/assets/b683cec8-b614-424b-9ab4-f96b3851149f" width = 300>|

## 📮 관련 이슈
- Resolved: #547 
