### PR TITLE
[Fix] #555 - FAB UX 라이팅 및 URL 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
@@ -50,5 +50,6 @@ public struct ExternalURL {
         public static let sopticle = "\(main)/sopticle"
         public static let makeGroup = "\(main)/group/make"
         public static let makeLightGroup = "\(main)/group/make/flash"
+        public static let makeGroupFeed = "\(main)/group?modal=create-feed"
     }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/ExternalURL.swift
@@ -47,7 +47,7 @@ public struct ExternalURL {
         public static let group = "\(main)/group?utm_source=playground_group&utm_medium=app_button&utm_campaign=app"
         public static let playgroundCommunity = main
         public static let feed = "\(main)/feed/upload"
-        public static let sopticle = "\(main)/sopticle"
+        public static let blog = "\(main)/blog"
         public static let makeGroup = "\(main)/group/make"
         public static let makeLightGroup = "\(main)/group/make/flash"
         public static let makeGroupFeed = "\(main)/group?modal=create-feed"

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -257,7 +257,7 @@ public struct I18N {
         }
         
         public struct Homepage {
-            public static let uploadArticle = "솝티클 올리기"
+            public static let reviewUpload = "활동후기 업로드"
         }
     }
     

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/CollectionView/TabBarMenuSection.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/CollectionView/TabBarMenuSection.swift
@@ -62,7 +62,7 @@ enum FABMenuSection: CaseIterable, FABMenuSectionProtocol {
             return [
                 MenuSectionItem(title: I18N.TabBar.Homepage.reviewUpload, 
                                 icon: DSKitAsset.Assets.icFabHomepage.image, 
-                                url: ExternalURL.SOPT.officialHomepage),
+                                url: ExternalURL.Playground.blog),
             ]
         }
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/CollectionView/TabBarMenuSection.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/CollectionView/TabBarMenuSection.swift
@@ -56,11 +56,11 @@ enum FABMenuSection: CaseIterable, FABMenuSectionProtocol {
                                 url: ExternalURL.Playground.makeLightGroup),
                 MenuSectionItem(title: I18N.TabBar.GroupAndStudy.writeFeed,
                                 icon: DSKitAsset.Assets.icFabFire.image, 
-                                url: ExternalURL.Playground.makeGroup)
+                                url: ExternalURL.Playground.makeGroupFeed)
             ]
         case .homepage:
             return [
-                MenuSectionItem(title: I18N.TabBar.Homepage.uploadArticle, 
+                MenuSectionItem(title: I18N.TabBar.Homepage.reviewUpload, 
                                 icon: DSKitAsset.Assets.icFabHomepage.image, 
                                 url: ExternalURL.SOPT.officialHomepage),
             ]


### PR DESCRIPTION
## 🌴 PR 요약
FAB의 메뉴 UX 라이팅과 URL을 수정했습니다.

🌱 작업한 브랜치
- fix/#555

## 🌱 PR Point
- 모임/스터디의 피드 작성 메뉴의 URL을 수정했습니다. [관련스레드](https://sopt-makers.slack.com/archives/C041WU3BMD4/p1744798708792479)
- '솝티클 업로드' 문구를 '활동후기 업로드'로 변경했습니다. (~URL은 플그팀에서 배포 후 전달해주신다고 합니다! 추후 반영하도록 할게요 -> 반영완료~) [관련스레드](https://sopt-makers.slack.com/archives/C041WU3BMD4/p1745818931437279)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|FAB 메뉴 수정|![Simulator Screen Recording - iPhone 16 Pro - 2025-04-30 at 23 52 33](https://github.com/user-attachments/assets/dd3a992a-a44d-4ede-992b-526e83fc213e)|

## 📮 관련 이슈
- Resolved: #555
