### PR TITLE
[Refactor] #516 - SplashCoor에서의 Router 의존성 제거

### DIFF
--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -22,6 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let notificationHandler = NotificationHandler()
     
     lazy var appCoordinator: ApplicationCoordinator = ApplicationCoordinator(
+        rootNavigationController: rootController,
         router: LegacyRouter(rootController: rootController),
         notificationHandler: self.notificationHandler
     )

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let notificationHandler = NotificationHandler()
     
     lazy var appCoordinator: ApplicationCoordinator = ApplicationCoordinator(
-        router: Router(rootController: rootController),
+        router: LegacyRouter(rootController: rootController),
         notificationHandler: self.notificationHandler
     )
     

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/AlertSettingByFeatures/NotificationSettingByFeaturesPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/AlertSettingByFeatures/NotificationSettingByFeaturesPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 
 public protocol NotificationSettingByFeaturesViewControllable:
-    ViewControllable & NotificationSettingByFeaturesCoordiatable { }
+    LegacyViewControllable & NotificationSettingByFeaturesCoordiatable { }
 public protocol NotificationSettingByFeaturesCoordiatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPageFeatureControllables.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPageFeatureControllables.swift
@@ -9,10 +9,10 @@
 import Core
 import BaseFeatureDependency
 
-public protocol SentenceEditViewControllable: ViewControllable { }
-public protocol PrivacyPolicyViewControllable: ViewControllable { }
-public protocol TermsOfServiceViewControllable: ViewControllable { }
-public protocol WithdrawalViewControllable: ViewControllable & WithdrawalViewCoordinatable {
+public protocol SentenceEditViewControllable: LegacyViewControllable { }
+public protocol PrivacyPolicyViewControllable: LegacyViewControllable { }
+public protocol TermsOfServiceViewControllable: LegacyViewControllable { }
+public protocol WithdrawalViewControllable: LegacyViewControllable & WithdrawalViewCoordinatable {
     var userType: UserType { get set }
 }
 public protocol WithdrawalViewCoordinatable {

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
@@ -9,7 +9,7 @@
 import BaseFeatureDependency
 import Core
 
-public protocol MyPageViewControllable: ViewControllable & MyPageCoordinatable { }
+public protocol MyPageViewControllable: LegacyViewControllable & MyPageCoordinatable { }
 public protocol MyPageCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onPolicyItemTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -26,10 +26,10 @@ final class MyPageCoordinator: DefaultMyPageCoordinator {
     public var requestCoordinating: ((MyPageCoordinatorDestination) -> Void)?
     
     private let factory: MyPageFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let userType: UserType
     
-    public init(router: Router, factory: MyPageFeatureBuildable, userType: UserType) {
+    public init(router: LegacyRouter, factory: MyPageFeatureBuildable, userType: UserType) {
         self.factory = factory
         self.router = router
         self.userType = userType

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureViewControllable.swift
@@ -10,9 +10,9 @@ import BaseFeatureDependency
 
 import Domain
 
-public protocol ShowAttendanceViewControllable: ViewControllable & ShowAttendanceCoordinatable { }
+public protocol ShowAttendanceViewControllable: LegacyViewControllable & ShowAttendanceCoordinatable { }
 public protocol ShowAttendanceCoordinatable {
     var onAttendanceButtonTap: ((AttendanceRoundModel, (() -> Void)?) -> Void)? { get set }
     var onNaviBackTap: (() -> Void)? { get set }
 }
-public protocol AttendanceViewControllable: ViewControllable { }
+public protocol AttendanceViewControllable: LegacyViewControllable { }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
@@ -17,9 +17,9 @@ final class AttendanceCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: AttendanceFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     
-    public init(router: Router, factory: AttendanceFeatureViewBuildable) {
+    public init(router: LegacyRouter, factory: AttendanceFeatureViewBuildable) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/Demo.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/Demo.swift
@@ -54,7 +54,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         return self.window!.rootViewController as? UINavigationController ?? UINavigationController(rootViewController: UIViewController())
     }
     
-    lazy var authCoordinator: AuthCoordinator = AuthCoordinator(router: Router(rootController: rootController), factory: AuthBuilder())
+    lazy var authCoordinator: AuthCoordinator = AuthCoordinator(router: LegacyRouter(rootController: rootController), factory: AuthBuilder())
     
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/LoginHelpBottomSheetPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/LoginHelpBottomSheetPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol LoginHelpBottomSheetViewControllable: ViewControllable { 
+public protocol LoginHelpBottomSheetViewControllable: LegacyViewControllable { 
     var onWantToKnowLoginAccountButtonDidTap: (() -> Void)? { get set }
     var onResetSocialAccountButtonDidTap: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/UserNotFoundBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/UserNotFoundBuildable.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import BaseFeatureDependency
 
-public protocol UserNotFoundViewControllable: ViewControllable {
+public protocol UserNotFoundViewControllable: LegacyViewControllable {
     var onLoginHelpButtonTapped: (() -> Void)? { get set }
     var onLoginRetryButtonTapped: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol SignInViewControllable: ViewControllable {
+public protocol SignInViewControllable: LegacyViewControllable {
     var skipAnimation: Bool { get set }
     var accessCode: String? { get set }
     var requestState: String? { get set }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/Coordinator/AuthCoordinator.swift
@@ -25,10 +25,10 @@ final class AuthCoordinator: DefaultAuthCoordinator {
     public var finishFlow: ((UserType) -> Void)?
     
     private let factory: AuthFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private var url: String?
     
-    public init(router: Router, factory: AuthFeatureViewBuildable, url: String? = nil) {
+    public init(router: LegacyRouter, factory: AuthFeatureViewBuildable, url: String? = nil) {
         self.factory = factory
         self.router = router
         self.url = url

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/Coordinator/Refactor/AuthCoordiantor_Refactor.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/Coordinator/Refactor/AuthCoordiantor_Refactor.swift
@@ -24,10 +24,10 @@
 //    public var finishFlow: ((UserType) -> Void)?
 //    
 //    private let factory: AuthFeatureViewBuildable
-//    private let router: Router
+//    private let router: LegacyRouter
 //    private var url: String?
 //    
-//    public init(router: Router, factory: AuthFeatureViewBuildable, url: String? = nil) {
+//    public init(router: LegacyRouter, factory: AuthFeatureViewBuildable, url: String? = nil) {
 //        self.factory = factory
 //        self.router = router
 //        self.url = url

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertViewControllable.swift
@@ -8,7 +8,7 @@
 
 import Core
 
-public protocol AlertViewControllable: ViewControllable { }
+public protocol AlertViewControllable: LegacyViewControllable { }
 
 public protocol AlertViewBuildable {
     func makeAlertVC(type: AlertType,

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Foundation/CoordinatorFlag.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Foundation/CoordinatorFlag.swift
@@ -1,0 +1,28 @@
+//
+//  CoordinatorFlag.swift
+//  BaseFeatureDependency
+//
+//  Created by Jae Hyun Lee on 5/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+
+public enum CoordinatorFlag {
+    case legacy
+    case new
+}
+
+/// 배포용 스킴에서는 기존에 사용하던 레거시 Coor로,
+/// 디버그용 스킴에서는 새로 생성한 Coor를 사용합니다.
+extension Config {
+    public static let coordinatorFlag: CoordinatorFlag = {
+        #if DEV || PROD
+        return .legacy
+        #else
+        return .new
+        #endif
+    }()
+}

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Router/LegacyRouter.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Router/LegacyRouter.swift
@@ -1,5 +1,5 @@
 //
-//  Router.swift
+//  LegacyRouter.swift
 //  BaseFeatureDependency
 //
 //  Created by Junho Lee on 2023/06/03.
@@ -12,7 +12,7 @@ import Core
 import SafariServices
 
 /// RouterProtocol은 Coordinator에서 화면전환의 종류를 지정합니다.
-public protocol RouterProtocol: ViewControllable {
+public protocol LegacyRouterProtocol: ViewControllable {
     
     var topViewController: UIViewController? { get }
     
@@ -65,7 +65,7 @@ public protocol RouterProtocol: ViewControllable {
 
 /// RouterProtocol을 채택하여 Coordinator가 모르는 화면전환의 기능을 수행합니다. RootController를 가지고 다양한 기능을 수행합니다.
 public
-final class Router: NSObject, RouterProtocol {
+final class LegacyRouter: NSObject, LegacyRouterProtocol {
 
     
     // MARK: - Vars & Lets
@@ -87,7 +87,7 @@ final class Router: NSObject, RouterProtocol {
         return rootController ?? UINavigationController(rootViewController: viewController)
     }
     
-    // MARK: - RouterProtocol
+    // MARK: - LegacyRouterProtocol
     
     public func present(_ module: ViewControllable?) {
         self.present(module, animated: true)
@@ -277,7 +277,7 @@ final class Router: NSObject, RouterProtocol {
 
 // MARK: - Alert
 
-extension Router {
+extension LegacyRouter {
     public func presentAlertVC(
         type: AlertType,
         theme: AlertVC.AlertTheme = .main,
@@ -310,7 +310,7 @@ extension Router {
     }
 }
 
-extension Router: UINavigationControllerDelegate {
+extension LegacyRouter: UINavigationControllerDelegate {
     public func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return self.transition
     }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Router/LegacyRouter.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Router/LegacyRouter.swift
@@ -12,20 +12,20 @@ import Core
 import SafariServices
 
 /// RouterProtocol은 Coordinator에서 화면전환의 종류를 지정합니다.
-public protocol LegacyRouterProtocol: ViewControllable {
+public protocol LegacyRouterProtocol: LegacyViewControllable {
     
     var topViewController: UIViewController? { get }
     
-    func present(_ module: ViewControllable?)
-    func present(_ module: ViewControllable?, animated: Bool)
-    func present(_ module: ViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle)
-    func present(_ module: ViewControllable?, animated: Bool, completion: (() -> Void)?)
+    func present(_ module: LegacyViewControllable?)
+    func present(_ module: LegacyViewControllable?, animated: Bool)
+    func present(_ module: LegacyViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle)
+    func present(_ module: LegacyViewControllable?, animated: Bool, completion: (() -> Void)?)
     func presentSafari(url: String)
     
-    func push(_ module: ViewControllable?)
-    func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?)
-    func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool)
-    func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool, completion: (() -> Void)?)
+    func push(_ module: LegacyViewControllable?)
+    func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?)
+    func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool)
+    func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool, completion: (() -> Void)?)
     
     func popModule()
     func popModule(transition: UIViewControllerAnimatedTransitioning?)
@@ -34,13 +34,13 @@ public protocol LegacyRouterProtocol: ViewControllable {
     func dismissModule(animated: Bool)
     func dismissModule(animated: Bool, completion: (() -> Void)?)
     
-    func setRootModule(_ module: ViewControllable?, animated: Bool)
-    func setRootModule(_ module: ViewControllable?, hideBar: Bool, animated: Bool)
+    func setRootModule(_ module: LegacyViewControllable?, animated: Bool)
+    func setRootModule(_ module: LegacyViewControllable?, hideBar: Bool, animated: Bool)
     
-    func replaceRootWindow(_ module: ViewControllable, withAnimation: Bool, hideBar: Bool, completion: ((UIWindow) -> Void)?)
+    func replaceRootWindow(_ module: LegacyViewControllable, withAnimation: Bool, hideBar: Bool, completion: ((UIWindow) -> Void)?)
     
     func popToRootModule(animated: Bool)
-    func popToModule(module: ViewControllable?, animated: Bool)
+    func popToModule(module: LegacyViewControllable?, animated: Bool)
     
     func showTitles()
     func hideTitles()
@@ -89,29 +89,29 @@ final class LegacyRouter: NSObject, LegacyRouterProtocol {
     
     // MARK: - LegacyRouterProtocol
     
-    public func present(_ module: ViewControllable?) {
+    public func present(_ module: LegacyViewControllable?) {
         self.present(module, animated: true)
     }
     
-    public func present(_ module: ViewControllable?, animated: Bool) {
+    public func present(_ module: LegacyViewControllable?, animated: Bool) {
         guard let controller = module?.viewController else { return }
         self.rootController?.present(controller, animated: animated, completion: nil)
     }
     
-    public func present(_ module: ViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle) {
+    public func present(_ module: LegacyViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle) {
         guard let controller = module?.viewController else { return }
         controller.modalPresentationStyle = modalPresentationSytle
         self.rootController?.present(controller, animated: animated, completion: nil)
     }
     
-    public func present(_ module: ViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle, modalTransitionStyle: UIModalTransitionStyle) {
+    public func present(_ module: LegacyViewControllable?, animated: Bool, modalPresentationSytle: UIModalPresentationStyle, modalTransitionStyle: UIModalTransitionStyle) {
         guard let controller = module?.viewController else { return }
         controller.modalPresentationStyle = modalPresentationSytle
         controller.modalTransitionStyle = modalTransitionStyle
         self.rootController?.present(controller, animated: animated, completion: nil)
     }
     
-    public func present(_ module: ViewControllable?, animated: Bool, completion: (() -> Void)?) {
+    public func present(_ module: LegacyViewControllable?, animated: Bool, completion: (() -> Void)?) {
         guard let controller = module?.viewController else { return }
         self.rootController?.present(controller, animated: animated, completion: completion)
     }
@@ -122,19 +122,19 @@ final class LegacyRouter: NSObject, LegacyRouterProtocol {
         self.rootController?.present(safariViewController, animated: true)
     }
     
-    public func push(_ module: ViewControllable?)  {
+    public func push(_ module: LegacyViewControllable?)  {
         self.push(module, transition: nil)
     }
     
-    public func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?) {
+    public func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?) {
         self.push(module, transition: transition, animated: true)
     }
     
-    public func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool)  {
+    public func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool)  {
         self.push(module, transition: transition, animated: animated, completion: nil)
     }
     
-    public func push(_ module: ViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool, completion: (() -> Void)?) {
+    public func push(_ module: LegacyViewControllable?, transition: UIViewControllerAnimatedTransitioning?, animated: Bool, completion: (() -> Void)?) {
         self.transition = transition
         
         guard let controller = module?.viewController,
@@ -167,7 +167,7 @@ final class LegacyRouter: NSObject, LegacyRouterProtocol {
         self.transition = nil
     }
     
-    public func popToModule(module: ViewControllable?, animated: Bool = true) {
+    public func popToModule(module: LegacyViewControllable?, animated: Bool = true) {
         if let controllers = self.rootController?.viewControllers , let module = module {
             for controller in controllers {
                 if controller == module as! UIViewController {
@@ -187,17 +187,17 @@ final class LegacyRouter: NSObject, LegacyRouterProtocol {
         self.rootController?.dismiss(animated: animated, completion: completion)
     }
     
-    public func setRootModule(_ module: ViewControllable?, animated: Bool) {
+    public func setRootModule(_ module: LegacyViewControllable?, animated: Bool) {
         self.setRootModule(module, hideBar: false, animated: animated)
     }
     
-    public func setRootModule(_ module: ViewControllable?, hideBar: Bool, animated: Bool) {
+    public func setRootModule(_ module: LegacyViewControllable?, hideBar: Bool, animated: Bool) {
         guard let controller = module?.viewController else { return }
         self.rootController?.setViewControllers([controller], animated: animated)
         self.rootController?.isNavigationBarHidden = hideBar
     }
     
-    public func replaceRootWindow(_ module: any ViewControllable, withAnimation: Bool, hideBar: Bool = false, completion: ((UIWindow) -> Void)? = nil) {
+    public func replaceRootWindow(_ module: any LegacyViewControllable, withAnimation: Bool, hideBar: Bool = false, completion: ((UIWindow) -> Void)? = nil) {
         let viewController = module.viewController
         let window = UIWindow.keyWindowGetter!
         let navigation = UINavigationController(rootViewController: viewController)
@@ -227,7 +227,7 @@ final class LegacyRouter: NSObject, LegacyRouterProtocol {
     }
     
     
-    public func setRootWindow(_ module: ViewControllable) {
+    public func setRootWindow(_ module: LegacyViewControllable) {
         let viewController = module.viewController
         let window = UIWindow.keyWindowGetter!
         let navigation = UINavigationController(rootViewController: viewController)

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/LegacyViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/LegacyViewControllable.swift
@@ -1,5 +1,5 @@
 //
-//  ViewControllable.swift
+//  LegacyViewControllable.swift
 //  BaseFeatureDependency
 //
 //  Created by 김영인 on 2023/03/16.
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public protocol ViewControllable {
+public protocol LegacyViewControllable {
     var viewController: UIViewController { get }
     var asNavigationController: UINavigationController { get }
 }
-public extension ViewControllable where Self: UIViewController {
+public extension LegacyViewControllable where Self: UIViewController {
     var viewController: UIViewController {
         return self
     }
@@ -23,4 +23,4 @@ public extension ViewControllable where Self: UIViewController {
     }
 }
 
-extension UIViewController: ViewControllable {}
+extension UIViewController: LegacyViewControllable {}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneCardPresentable.swift
@@ -9,7 +9,7 @@
 import BaseFeatureDependency
 import Core
 
-public protocol DailySoptuneCardViewControllable: ViewControllable { }
+public protocol DailySoptuneCardViewControllable: LegacyViewControllable { }
 
 public protocol DailySoptuneCardCoordinatable {
     var onGoToHomeButtonTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneMainPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol DailySoptuneMainViewControllable: ViewControllable {}
+public protocol DailySoptuneMainViewControllable: LegacyViewControllable {}
 
 public protocol DailySoptuneMainCoordinatable {
     var onNaviBackTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Interface/Sources/DailySoptuneResultPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol DailySoptuneResultViewControllable: ViewControllable { }
+public protocol DailySoptuneResultViewControllable: LegacyViewControllable { }
 
 public protocol DailySoptuneResultCoordinatable {
     var onNaviBackButtonTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCardCoordinator.swift
@@ -20,13 +20,13 @@ public final class DailySoptuneCardCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
         
     private let factory: DailySoptuneFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     
     private let cardModel: DailySoptuneCardModel
 
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: DailySoptuneFeatureBuildable, cardModel: DailySoptuneCardModel) {
+    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, cardModel: DailySoptuneCardModel) {
         self.router = router
         self.factory = factory
         self.cardModel = cardModel

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -22,11 +22,11 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     
     private let factory: DailySoptuneFeatureBuildable
     private let pokeFactory: PokeFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable) {
         self.router = router
         self.factory = factory
         self.pokeFactory = pokeFactory
@@ -54,7 +54,7 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     }
     
     internal func runDailySoptuneResultFlow(resultModel: DailySoptuneResultModel) {
-        let dailySoptuneResultCoordinator = DailySoptuneResultCoordinator(router: Router(
+        let dailySoptuneResultCoordinator = DailySoptuneResultCoordinator(router: LegacyRouter(
             rootController: rootController ?? self.router.asNavigationController
         ),
                                                                           factory: factory,

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -24,11 +24,11 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     private let factory: DailySoptuneFeatureBuildable
     private let pokeFactory: PokeFeatureBuildable
     private let resultModel: DailySoptuneResultModel
-    private let router: Router
+    private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     private weak var viewController: UIViewController?
 
-    public init(router: Router, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
+    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
         self.router = router
         self.factory = factory
         self.pokeFactory = pokeFactory
@@ -71,7 +71,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     
     internal func runDailySoptuneCardFlow(cardModel: DailySoptuneCardModel) {
         let dailySoptuneCardCoordinator = DailySoptuneCardCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: rootController ?? self.router.asNavigationController
             ), factory: factory
             , cardModel: cardModel

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeCalendarDetailPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeCalendarDetailPresentable.swift
@@ -11,7 +11,7 @@ import Foundation
 import BaseFeatureDependency
 import Core
 
-public protocol HomeCalendarDetailViewControllable: ViewControllable {}
+public protocol HomeCalendarDetailViewControllable: LegacyViewControllable {}
 public protocol HomeCalendarDetailCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onAttendanceButtonTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
@@ -11,7 +11,7 @@ import Foundation
 import BaseFeatureDependency
 import Core
 
-public protocol HomeForMemberViewControllable: ViewControllable { }
+public protocol HomeForMemberViewControllable: LegacyViewControllable { }
 public protocol HomeForMemberCoordinatable {
     var onDashBoardCellTapped: (() -> Void)? { get set }
     var onCalendarCellTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForVisitorPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForVisitorPresentable.swift
@@ -11,7 +11,7 @@ import Foundation
 import BaseFeatureDependency
 import Core
 
-public protocol HomeForVisitorViewControllable: ViewControllable { }
+public protocol HomeForVisitorViewControllable: LegacyViewControllable { }
 public protocol HomeForVisitorCoordinatable {
     var onMainProductCellTapped: ((String) -> Void)? { get set }
     var onAppServiceCellTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -41,14 +41,14 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: HomeFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let userType: UserType
     
     public private(set) var rootViewController: UIViewController?
     private weak var rootController: UINavigationController?
     
     public init(
-        router: Router,
+        router: LegacyRouter,
         factory: HomeFeatureBuildable,
         userType: UserType
     ) {

--- a/SOPT-iOS/Projects/Features/NoticeFeature/Interface/Sources/NoticeFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/NoticeFeature/Interface/Sources/NoticeFeatureViewControllable.swift
@@ -8,6 +8,6 @@
 
 import BaseFeatureDependency
 
-public protocol NoticeFeatureViewControllable: ViewControllable { }
+public protocol NoticeFeatureViewControllable: LegacyViewControllable { }
 
 public protocol NoticeFeatureViewBuildable { }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationDetailPresentable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationDetailPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol NotificationDetailViewControllable: ViewControllable { }
+public protocol NotificationDetailViewControllable: LegacyViewControllable { }
 
 public protocol NotificationDetailCoordinatable {
     var onShortCutButtonTap: ((ShortCutLink) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol NotificationListViewControllable: ViewControllable { }
+public protocol NotificationListViewControllable: LegacyViewControllable { }
 public protocol NotificationListCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onNotificationTap: ((String) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
@@ -30,9 +30,9 @@ final class NotificationCoordinator: DefaultNotificationCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: NotificationFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     
-    public init(router: Router, factory: NotificationFeatureBuildable) {
+    public init(router: LegacyRouter, factory: NotificationFeatureBuildable) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeAnonymousFriendUpgradePresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeAnonymousFriendUpgradePresentable.swift
@@ -9,4 +9,4 @@
 import BaseFeatureDependency
 import Core
 
-public protocol PokeAnonymousFriendUpgradePresentable: ViewControllable { }
+public protocol PokeAnonymousFriendUpgradePresentable: LegacyViewControllable { }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMainViewControllable: ViewControllable { }
+public protocol PokeMainViewControllable: LegacyViewControllable { }
 
 public protocol PokeMainCoordinatable {
   var onNaviBackTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMaingFriendCompletedPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMaingFriendCompletedPresentable.swift
@@ -10,4 +10,4 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMakingFriendCompletedPresentable: ViewControllable { }
+public protocol PokeMakingFriendCompletedPresentable: LegacyViewControllable { }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
@@ -11,7 +11,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMessageTemplatesViewControllable: ViewControllable {
+public protocol PokeMessageTemplatesViewControllable: LegacyViewControllable {
     var minimumContentHeight: CGFloat { get }
     
     func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)>

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMyFriendsListViewControllable: ViewControllable { }
+public protocol PokeMyFriendsListViewControllable: LegacyViewControllable { }
 
 public protocol PokeMyFriendsListCoordinatable {
     var onCloseButtonTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMyFriendsViewControllable: ViewControllable { }
+public protocol PokeMyFriendsViewControllable: LegacyViewControllable { }
 
 public protocol PokeMyFriendsCoordinatable {
     var showFriendsListButtonTap: ((PokeRelation) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeNotificationViewControllable: ViewControllable { }
+public protocol PokeNotificationViewControllable: LegacyViewControllable { }
 
 public protocol PokeNotificationCoordinatable {
     var onNaviBackTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
@@ -10,7 +10,7 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeOnboardingViewControllable: ViewControllable { }
+public protocol PokeOnboardingViewControllable: LegacyViewControllable { }
 
 public protocol PokeOnboardingCoordinatable {
     var onNaviBackTapped: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -20,10 +20,10 @@ final class PokeCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: PokeFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }
@@ -85,7 +85,7 @@ final class PokeCoordinator: DefaultCoordinator {
     
     internal func runPokeOnboardingFlow() {
         let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: rootController ?? self.router.asNavigationController
             ),
             factory: factory
@@ -102,7 +102,7 @@ final class PokeCoordinator: DefaultCoordinator {
     
     internal func runPokeNotificationListFlow() {
         let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: rootController ?? self.router.asNavigationController
             ),
             factory: factory
@@ -119,7 +119,7 @@ final class PokeCoordinator: DefaultCoordinator {
     
     private func runPokeMyFriendsFlow() {
         let pokeMyFriendsCoordinator = PokeMyFriendsCoordinator(factory: factory,
-                                                                router: Router(rootController: rootController!))
+                                                                router: LegacyRouter(rootController: rootController!))
         
         pokeMyFriendsCoordinator.finishFlow = { [weak self, weak pokeMyFriendsCoordinator] in
             self?.removeDependency(pokeMyFriendsCoordinator)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
@@ -20,10 +20,10 @@ final class PokeMyFriendsCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: PokeFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     
-    public init(factory: PokeFeatureBuildable, router: Router) {
+    public init(factory: PokeFeatureBuildable, router: LegacyRouter) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -17,11 +17,11 @@ import WebFeature
 public final class PokeNotificationListCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
-    private let router: Router
+    private let router: LegacyRouter
     private let factory: PokeFeatureBuildable
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -17,11 +17,11 @@ import WebFeature
 public final class PokeOnboardingCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
-    private let router: Router
+    private let router: LegacyRouter
     private let factory: PokeFeatureBuildable
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -31,13 +31,20 @@ final class ApplicationCoordinator: BaseCoordinator {
     private var cancelBag = CancelBag()
     private let notificationHandler: NotificationHandler
     
+    private let rootNavigationController: UINavigationController
+    
     private weak var rootController: UINavigationController?
     private weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: HomeCoordinator?
     private weak var soptlogCoordinator: SoptlogCoordinator?
     
-    public init(router: LegacyRouter, notificationHandler: NotificationHandler) {
+    public init(
+        rootNavigationController: UINavigationController,
+        router: LegacyRouter,
+        notificationHandler: NotificationHandler
+    ) {
+        self.rootNavigationController = rootNavigationController
         self.router = router
         self.notificationHandler = notificationHandler
         super.init()
@@ -125,11 +132,26 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     private func runSplashFlow() {
-        let coordinator = LegacySplashCoordinator(router: router, factory: SplashBuilder())
+        var coordinator: DefaultCoordinator
+        
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator = LegacySplashCoordinator(
+                router: router,
+                factory: SplashBuilder()
+            )
+        case .new:
+            coordinator = SplashCoordinator(
+                navigationController: rootNavigationController,
+                factory: SplashBuilder()
+            )
+        }
+        
         coordinator.finishFlow = { [weak self, weak coordinator] in
             self?.checkDidSignIn()
             self?.removeDependency(coordinator)
         }
+        
         addDependency(coordinator)
         coordinator.start()
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -138,7 +138,7 @@ extension ApplicationCoordinator {
         case .legacy:
             coordinator = LegacySplashCoordinator(
                 router: router,
-                factory: SplashBuilder()
+                factory: LegacySplashBuilder()
             )
         case .new:
             coordinator = SplashCoordinator(

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -27,7 +27,7 @@ import TabBarFeature
 public
 final class ApplicationCoordinator: BaseCoordinator {
     
-    private let router: Router
+    private let router: LegacyRouter
     private var cancelBag = CancelBag()
     private let notificationHandler: NotificationHandler
     
@@ -37,7 +37,7 @@ final class ApplicationCoordinator: BaseCoordinator {
     private weak var homeCoordinator: HomeCoordinator?
     private weak var soptlogCoordinator: SoptlogCoordinator?
     
-    public init(router: Router, notificationHandler: NotificationHandler) {
+    public init(router: LegacyRouter, notificationHandler: NotificationHandler) {
         self.router = router
         self.notificationHandler = notificationHandler
         super.init()
@@ -125,7 +125,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     private func runSplashFlow() {
-        let coordinator = SplashCoordinator(router: router, factory: SplashBuilder())
+        let coordinator = LegacySplashCoordinator(router: router, factory: SplashBuilder())
         coordinator.finishFlow = { [weak self, weak coordinator] in
             self?.checkDidSignIn()
             self?.removeDependency(coordinator)
@@ -255,7 +255,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runHomeFlow(type: UserType) -> HomeCoordinator {
         let coordinator = HomeCoordinator(
-            router: Router(rootController: self.rootController ?? self.router.asNavigationController),
+            router: LegacyRouter(rootController: self.rootController ?? self.router.asNavigationController),
             factory: HomeBuilder(),
             userType: type
         )
@@ -307,7 +307,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runAttendanceFlow() -> AttendanceCoordinator {
         let coordinator = AttendanceCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: AttendanceBuilder()
@@ -325,7 +325,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runStampFlow() -> StampCoordinator {
         let coordinator = StampCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: StampBuilder()
@@ -353,7 +353,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func makePokeCoordinator() -> PokeCoordinator {
         let coordinator = PokeCoordinator(
-            router: Router(rootController: UIWindow.getRootNavigationController),
+            router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
             factory: PokeBuilder()
         )
         
@@ -370,7 +370,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runPokeOnboardingFlow() -> PokeOnboardingCoordinator {
         let coordinator = PokeOnboardingCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: PokeBuilder()
@@ -388,7 +388,7 @@ extension ApplicationCoordinator {
     
     internal func runPokeNotificationListFlow() -> PokeNotificationListCoordinator {
         let coordinator = PokeNotificationListCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: PokeBuilder()
@@ -409,7 +409,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runMyPageFlow(of userType: UserType) -> MyPageCoordinator {
         let coordinator = MyPageCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: MyPageBuilder(),
@@ -437,7 +437,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runNotificationFlow() -> NotificationCoordinator {
         let coordinator = NotificationCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: NotificationBuilder()
@@ -465,7 +465,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runDailySoptuneFlow() -> DailySoptuneCoordinator {
         let coordinator = DailySoptuneCoordinator(
-            router: Router(
+            router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: DailySoptuneBuilder(), 
@@ -490,7 +490,7 @@ extension ApplicationCoordinator {
     @discardableResult
     internal func runSoptlogFlow(type: UserType) -> SoptlogCoordinator {
         let coordinator = SoptlogCoordinator(
-            router: Router(rootController: self.rootController ?? self.router.asNavigationController),
+            router: LegacyRouter(rootController: self.rootController ?? self.router.asNavigationController),
             factory: SoptlogBuilder(), 
             userType: type
         )

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -11,7 +11,7 @@ import Foundation
 import BaseFeatureDependency
 import Core
 
-public protocol SoptlogViewControllable: ViewControllable { }
+public protocol SoptlogViewControllable: LegacyViewControllable { }
 public protocol SoptlogCoordinatable {
     var onProfileEditTapped: (() -> Void)? { get set }
     var onToolTipTapped: ((CGRect) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogToolTipPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogToolTipPresentable.swift
@@ -11,7 +11,7 @@ import Foundation
 import BaseFeatureDependency
 import Core
 
-public protocol SoptlogToolTipViewControllable: ViewControllable { }
+public protocol SoptlogToolTipViewControllable: LegacyViewControllable { }
 public protocol SoptlogToolTipCoordinatable {
     var onDismissButtonTap: (() -> Void)? { get set }
     var onDimmingBackgroundTap: (() -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -28,13 +28,13 @@ public final class SoptlogCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: SoptlogFeatureBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let userType: UserType
     
     private weak var rootController: UINavigationController?
     public private(set) var rootViewController: UIViewController?
     
-    public init(router: Router, factory: SoptlogFeatureBuildable, userType: UserType) {
+    public init(router: LegacyRouter, factory: SoptlogFeatureBuildable, userType: UserType) {
         self.router = router
         self.factory = factory
         self.userType = userType

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacyNoticePopUpViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacyNoticePopUpViewControllable.swift
@@ -1,5 +1,5 @@
 //
-//  NoticePopUpViewControllable.swift
+//  LegacyNoticePopUpViewControllable.swift
 //  SplashFeatureInterface
 //
 //  Created by Junho Lee on 2023/06/20.
@@ -10,6 +10,6 @@ import Combine
 
 import BaseFeatureDependency
 
-public protocol NoticePopUpViewControllable: ViewControllable {
+public protocol LegacyNoticePopUpViewControllable: LegacyViewControllable {
     var closeButtonTappedWithCheck: PassthroughSubject<Bool, Never> { get }
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacySplashFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacySplashFeatureBuildable.swift
@@ -1,0 +1,14 @@
+//
+//  LegacySplashFeatureBuildable.swift
+//  SplashFeatureInterface
+//
+//  Created by Junho Lee on 2023/06/20.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Core
+
+public protocol LegacySplashFeatureViewBuildable {
+    func makeSplash() -> LegacySplashPresentable
+    func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> LegacyNoticePopUpViewControllable
+}

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/NoticePopUpPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/NoticePopUpPresentable.swift
@@ -1,0 +1,18 @@
+//
+//  NoticePopUpPresentable.swift
+//  SplashFeature
+//
+//  Created by Jae Hyun Lee on 5/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import BaseFeatureDependency
+
+public protocol NoticePopUpViewControllable {
+    var closeButtonTappedWithCheck: PassthroughSubject<Bool, Never> { get }
+}
+
+public typealias NoticePopUpPresentable = (UIViewController & NoticePopUpViewControllable)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashFeatureBuildable.swift
@@ -1,14 +1,16 @@
 //
 //  SplashFeatureBuildable.swift
-//  SplashFeatureInterface
+//  SplashFeature
 //
-//  Created by Junho Lee on 2023/06/20.
-//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//  Created by Jae Hyun Lee on 5/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
+
+import UIKit
 
 import Core
 
-public protocol SplashFeatureViewBuildable {
+public protocol SplashFeatureBuildable {
     func makeSplash() -> SplashPresentable
-    func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> NoticePopUpViewControllable
+    func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> NoticePopUpPresentable
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashPresentable.swift
@@ -1,19 +1,23 @@
 //
-//  SplashFeatureViewControllable.swift
+//  SplashPresentable.swift
 //  SplashFeatureInterface
 //
 //  Created by 김영인 on 2023/03/16.
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import Core
 import Domain
 import BaseFeatureDependency
 
-public protocol SplashViewControllable: ViewControllable { }
+public protocol SplashViewControllable: LegacyViewControllable { }
 public protocol SplashCoordinatable {
     var onNoticeSkipped: (() -> Void)? { get set }
     var onNoticeExist: ((AppNoticeModel) -> Void)? { get set }
 }
 public typealias SplashViewModelType = ViewModelType & SplashCoordinatable
-public typealias SplashPresentable = (vc: SplashViewControllable, vm: any SplashViewModelType)
+public typealias LegacySplashPresentable = (vc: SplashViewControllable, vm: any SplashViewModelType)
+
+public typealias SplashPresentable = (vc: UIViewController, vm: any SplashViewModelType)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashBuilder.swift
@@ -1,0 +1,35 @@
+//
+//  LegacySplashBuilder.swift
+//  SplashFeatureInterface
+//
+//  Created by Junho Lee on 2023/06/20.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Core
+import Domain
+@_exported import SplashFeatureInterface
+
+public
+final class LegacySplashBuilder {
+    @Injected public var repository: SplashRepositoryInterface
+    
+    public init() { }
+}
+
+extension LegacySplashBuilder: LegacySplashFeatureViewBuildable {
+    public func makeSplash() -> LegacySplashPresentable {
+        let useCase = DefaultSplashUseCase(repository: repository)
+        let vm = SplashViewModel(useCase: useCase)
+        let vc = SplashVC()
+        vc.viewModel = vm
+        return (vc, vm)
+    }
+    
+    public func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> LegacyNoticePopUpViewControllable {
+        let noticePopUpVC = NoticePopUpVC()
+        noticePopUpVC.setData(type: noticeType, content: content)
+        noticePopUpVC.modalPresentationStyle = .overFullScreen
+        return noticePopUpVC
+    }
+}

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
@@ -16,11 +16,11 @@ final class LegacySplashCoordinator: DefaultCoordinator {
     
     public var finishFlow: (() -> Void)?
     
-    private let factory: SplashFeatureViewBuildable
+    private let factory: LegacySplashFeatureViewBuildable
     private let router: LegacyRouter
     private let cancelBag = CancelBag()
     
-    public init(router: LegacyRouter, factory: SplashFeatureViewBuildable) {
+    public init(router: LegacyRouter, factory: LegacySplashFeatureViewBuildable) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  SplashCoordinator.swift
+//  LegacySplashCoordinator.swift
 //  SplashFeature
 //
 //  Created by Junho Lee on 2023/06/20.
@@ -12,15 +12,15 @@ import Core
 import Domain
 
 public
-final class SplashCoordinator: DefaultCoordinator {
+final class LegacySplashCoordinator: DefaultCoordinator {
     
     public var finishFlow: (() -> Void)?
     
     private let factory: SplashFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let cancelBag = CancelBag()
     
-    public init(router: Router, factory: SplashFeatureViewBuildable) {
+    public init(router: LegacyRouter, factory: SplashFeatureViewBuildable) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashBuilder.swift
@@ -1,23 +1,23 @@
 //
 //  SplashBuilder.swift
-//  SplashFeatureInterface
+//  SplashFeature
 //
-//  Created by Junho Lee on 2023/06/20.
-//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//  Created by Jae Hyun Lee on 5/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
 import Core
 import Domain
 @_exported import SplashFeatureInterface
 
-public
-final class SplashBuilder {
+public final class SplashBuilder {
     @Injected public var repository: SplashRepositoryInterface
     
     public init() { }
 }
 
-extension SplashBuilder: SplashFeatureViewBuildable {
+extension SplashBuilder: SplashFeatureBuildable {
+    
     public func makeSplash() -> SplashPresentable {
         let useCase = DefaultSplashUseCase(repository: repository)
         let vm = SplashViewModel(useCase: useCase)
@@ -26,7 +26,7 @@ extension SplashBuilder: SplashFeatureViewBuildable {
         return (vc, vm)
     }
     
-    public func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> NoticePopUpViewControllable {
+    public func makeNoticePopUpVC(noticeType: Core.NoticePopUpType, content: String) -> NoticePopUpPresentable {
         let noticePopUpVC = NoticePopUpVC()
         noticePopUpVC.setData(type: noticeType, content: content)
         noticePopUpVC.modalPresentationStyle = .overFullScreen

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
@@ -20,14 +20,14 @@ public final class SplashCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let navigationController: UINavigationController
-    private let factory: LegacySplashFeatureViewBuildable
+    private let factory: SplashFeatureBuildable
     private let cancelBag = CancelBag()
     
     // MARK: - Init
     
     public init(
         navigationController: UINavigationController,
-        factory: LegacySplashFeatureViewBuildable
+        factory: SplashFeatureBuildable
     ) {
         self.factory = factory
         self.navigationController = navigationController
@@ -44,14 +44,16 @@ public final class SplashCoordinator: DefaultCoordinator {
     
     private func showSplash() {
         var splash = factory.makeSplash()
+        
         splash.vm.onNoticeExist = { [weak self] appNoticeModel in
             self?.presentNoticePopUp(model: appNoticeModel)
         }
+        
         splash.vm.onNoticeSkipped = { [weak self] in
             self?.finishFlow?()
         }
         
-        navigationController.setViewControllers([splash.vc.viewController], animated: true)
+        navigationController.setViewControllers([splash.vc], animated: true)
     }
     
     private func presentNoticePopUp(model: AppNoticeModel) {
@@ -59,12 +61,12 @@ public final class SplashCoordinator: DefaultCoordinator {
         
         let popUpType: NoticePopUpType = isForcedUpdate ? .forceUpdate : .recommendUpdate
         
-        let noticePopUp = factory.makeNoticePopUpVC(
+        let noticePopUpVC = factory.makeNoticePopUpVC(
             noticeType: popUpType,
             content: model.notice
         )
         
-        noticePopUp.closeButtonTappedWithCheck.sink { [weak self] didCheck in
+        noticePopUpVC.closeButtonTappedWithCheck.sink { [weak self] didCheck in
             if didCheck {
                 UserDefaultKeyList.AppNotice.checkedAppVersion = model.recommendVersion
             }
@@ -72,6 +74,6 @@ public final class SplashCoordinator: DefaultCoordinator {
             self?.finishFlow?()
         }.store(in: cancelBag)
         
-        navigationController.present(noticePopUp.viewController, animated: false)
+        navigationController.present(noticePopUpVC, animated: false)
     }
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
@@ -1,0 +1,77 @@
+//
+//  SplashCoordinator.swift
+//  SplashFeature
+//
+//  Created by Jae Hyun Lee on 5/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import BaseFeatureDependency
+import SplashFeatureInterface
+import Core
+import Domain
+
+public final class SplashCoordinator: DefaultCoordinator {
+    
+    // MARK: - Properties
+    
+    public var finishFlow: (() -> Void)?
+    
+    private let navigationController: UINavigationController
+    private let factory: LegacySplashFeatureViewBuildable
+    private let cancelBag = CancelBag()
+    
+    // MARK: - Init
+    
+    public init(
+        navigationController: UINavigationController,
+        factory: LegacySplashFeatureViewBuildable
+    ) {
+        self.factory = factory
+        self.navigationController = navigationController
+        super.init()
+    }
+    
+    // MARK: - Coordinator Life Cycle
+    
+    public override func start() {
+        showSplash()
+    }
+    
+    // MARK: - Navigation
+    
+    private func showSplash() {
+        var splash = factory.makeSplash()
+        splash.vm.onNoticeExist = { [weak self] appNoticeModel in
+            self?.presentNoticePopUp(model: appNoticeModel)
+        }
+        splash.vm.onNoticeSkipped = { [weak self] in
+            self?.finishFlow?()
+        }
+        
+        navigationController.setViewControllers([splash.vc.viewController], animated: true)
+    }
+    
+    private func presentNoticePopUp(model: AppNoticeModel) {
+        guard let isForcedUpdate = model.isForced else { return }
+        
+        let popUpType: NoticePopUpType = isForcedUpdate ? .forceUpdate : .recommendUpdate
+        
+        let noticePopUp = factory.makeNoticePopUpVC(
+            noticeType: popUpType,
+            content: model.notice
+        )
+        
+        noticePopUp.closeButtonTappedWithCheck.sink { [weak self] didCheck in
+            if didCheck {
+                UserDefaultKeyList.AppNotice.checkedAppVersion = model.recommendVersion
+            }
+            self?.navigationController.dismiss(animated: true)
+            self?.finishFlow?()
+        }.store(in: cancelBag)
+        
+        navigationController.present(noticePopUp.viewController, animated: false)
+    }
+}

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/NoticePopUpVC.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/NoticePopUpVC.swift
@@ -18,7 +18,7 @@ import Then
 import BaseFeatureDependency
 import SplashFeatureInterface
 
-public class NoticePopUpVC: UIViewController, NoticePopUpViewControllable {
+public class NoticePopUpVC: UIViewController, LegacyNoticePopUpViewControllable, NoticePopUpViewControllable {
     
     // MARK: - Properties
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureViewControllable.swift
@@ -10,7 +10,7 @@ import Core
 import BaseFeatureDependency
 import Domain
 
-public protocol MissionListViewControllable: ViewControllable & MissionListCoordinatable { }
+public protocol MissionListViewControllable: LegacyViewControllable & MissionListCoordinatable { }
 public protocol MissionListCoordinatable {
   var onSwiped: (() -> Void)? { get set }
   var onNaviBackTap: (() -> Void)? { get set }
@@ -20,13 +20,13 @@ public protocol MissionListCoordinatable {
   var onCellTap: ((MissionListModel, _ username: String?) -> Void)? { get set }
   var onReportButtonTap: (() -> Void)? { get set }
 }
-public protocol ListDetailViewControllable: ViewControllable & ListDetailCoordinatable { }
+public protocol ListDetailViewControllable: LegacyViewControllable & ListDetailCoordinatable { }
 public protocol ListDetailCoordinatable {
   var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)? { get set }
   var onNaviBackTap: (() -> Void)? { get set }
 }
-public protocol MissionCompletedViewControllable: ViewControllable { }
-public protocol RankingViewControllable: ViewControllable & RankingCoordinatable { }
+public protocol MissionCompletedViewControllable: LegacyViewControllable { }
+public protocol RankingViewControllable: LegacyViewControllable & RankingCoordinatable { }
 public protocol RankingCoordinatable {
   var onCellTap: ((_ username: String, _ sentence: String) -> Void)? { get set }
   var onNaviBackTap: (() -> Void)? { get set }
@@ -36,7 +36,7 @@ public protocol PartRankingCoordinatable {
   var onCellTap: ((_ part: Part) -> Void)? { get set }
   var onNaviBackTap: (() -> Void)? { get set }
 }
-public protocol PartRankingViewControllable: ViewControllable & PartRankingCoordinatable { }
-public protocol StampGuideViewControllable: ViewControllable {
+public protocol PartRankingViewControllable: LegacyViewControllable & PartRankingCoordinatable { }
+public protocol StampGuideViewControllable: LegacyViewControllable {
     var onNaviBackTap: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/MissionDetailCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/MissionDetailCoordinator.swift
@@ -17,11 +17,11 @@ final class MissionDetailCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: StampFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let model: MissionListModel
     private let username: String?
     
-    public init(router: Router, factory: StampFeatureViewBuildable, model: MissionListModel, username: String?) {
+    public init(router: LegacyRouter, factory: StampFeatureViewBuildable, model: MissionListModel, username: String?) {
         self.factory = factory
         self.router = router
         self.model = model

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/RankingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/RankingCoordinator.swift
@@ -17,11 +17,11 @@ final class RankingCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: StampFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     private let rankingViewType: RankingViewType
     
     public init(
-        router: Router,
+        router: LegacyRouter,
         factory: StampFeatureViewBuildable,
         rankingViewType: RankingViewType
     ) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -20,11 +20,11 @@ final class StampCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: StampFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     // Note: @준호 - Soptamp는 Present되기 때문에 최상위 NavController의 참조를 유지해야 함
     private weak var rootController: UINavigationController?
     
-    public init(router: Router, factory: StampFeatureViewBuildable) {
+    public init(router: LegacyRouter, factory: StampFeatureViewBuildable) {
         self.factory = factory
         self.router = router
     }
@@ -63,7 +63,7 @@ final class StampCoordinator: DefaultCoordinator {
     
     private func showGuide() {
         let guideCoordinator = StampGuideCoordinator(
-            router: Router(rootController: rootController!),
+            router: LegacyRouter(rootController: rootController!),
             factory: factory
         )
         guideCoordinator.finishFlow = { [weak self, weak guideCoordinator] in
@@ -75,7 +75,7 @@ final class StampCoordinator: DefaultCoordinator {
     
     internal func runRankingFlow(rankingViewType: RankingViewType) {
         let rankingCoordinator = RankingCoordinator(
-            router: Router(rootController: rootController!),
+            router: LegacyRouter(rootController: rootController!),
             factory: factory,
             rankingViewType: rankingViewType
         )
@@ -88,7 +88,7 @@ final class StampCoordinator: DefaultCoordinator {
 
     private func runMissionDetailFlow(_ model: MissionListModel, _ username: String?) {
         let missionDetailCoordinator = MissionDetailCoordinator(
-            router: Router(rootController: rootController!),
+            router: LegacyRouter(rootController: rootController!),
             factory: factory,
             model: model,
             username: username

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampGuideCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampGuideCoordinator.swift
@@ -16,9 +16,9 @@ final class StampGuideCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: StampFeatureViewBuildable
-    private let router: Router
+    private let router: LegacyRouter
     
-    public init(router: Router, factory: StampFeatureViewBuildable) {
+    public init(router: LegacyRouter, factory: StampFeatureViewBuildable) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -28,10 +28,10 @@ public final class TabBarCoordinator: DefaultCoordinator {
     public var requestCoordinating: ((TabBarCoordinatorDestination) -> Void)?
         
     private let factory: TabBarPresentable
-    private let router: Router
+    private let router: LegacyRouter
     private let items: [UIViewController]
     
-    public init(router: Router, factory: TabBarPresentable, items: [UIViewController]) {
+    public init(router: LegacyRouter, factory: TabBarPresentable, items: [UIViewController]) {
         self.router = router
         self.factory = factory
         self.items = items

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -22,7 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let notificationHandler = NotificationHandler()
     
     lazy var appCoordinator: ApplicationCoordinator = ApplicationCoordinator(
-        router: Router(rootController: rootController), notificationHandler: self.notificationHandler
+        router: LegacyRouter(rootController: rootController), notificationHandler: self.notificationHandler
     )
     
     func scene(_ scene: UIScene,


### PR DESCRIPTION
## 🌴 PR 요약

- **SplashCoor에서의 Router를 제거**했습니다.
- Router를 제거함에 따라, **불필요해진 추상화 관련 코드를 Legacy로 변경**하고 (prefix에 Legacy를 붙이고) 새 파일을 생성했습니다. 

🌱 작업한 브랜치
- #516 

## 🌱 PR Point

### 1. 적용 패턴 - Strangler Fig Pattern

저번 논의에서 **리팩토링 시 기존 코드에 미치는 영향을 최소화하며, 점진적으로 새로운 구현 코드를 완성함으로써 안정성이 확인되면 Router를 최종적으로 제거하자**는 결론이 났는데, 해당 방식에 `Strangler Fig Pattern`이 적절할 것 같아 적용했습니다. ([스트랭글러 패턴 참고](https://docs.aws.amazon.com/ko_kr/prescriptive-guidance/latest/modernization-decomposing-monoliths/strangler-fig.html)) 

리팩토링 순서는 다음과 같습니다.

> 1. 기존 코드(파일) 명칭의 prefix에 Legacy 키워드를 붙입니다. (e.g., `SplashCoordinator -> LegacySplashCoordinator`)
> 2. 새로운 파일을 생성하고, 기존 코드와 병렬로 구현합니다.
> 3. 점진적으로 기존 코드를 새로운 코드로 변경합니다.
> 4. 최종적으로 Legacy 코드들을 제거합니다. 

- 1.에서 **기존 파일의 명칭을 변경할지 (Legacy -)**, 
- **새로 생성하는 파일의 명칭을 변경할지 (- refactor)** 에 관해서 고민을 해보았는데
- 변경이 완료된 이후 모든 레거시 코드를 한 번에 제거하기 위해서는 **전자의 방식이 편리할 것**이라고 생각해, 레거시 코드의 네이밍을 변경하는 쪽으로 결정했습니다. (새로 생성하는 파일의 명칭을 변경할 경우, 모든 변경이 완료된 이후 refactor가 붙은 명칭들을 변경 + 삭제해야 하는 파일들을 선별하는 것의 번거로움이 있을 듯해서 입니다.)
- 이와 관련해서 관행적으로 어떻게 변경하는지, 자료를 찾아보려 했는데 찾지 못해서, 혹시 참고 자료 있으시면 첨부해주심 감사하겠습니다!

***

### 2. Flag 도입

**디버그용 스킴에서는 리팩토링 중인 코드로, 배포용 스킴에는 레거시 코드를 적용**하기 위해서 `CoordinatorFlag`를 만들었습니다.

```swift
public enum CoordinatorFlag {
    case legacy
    case new
}

/// 배포용 스킴에서는 기존에 사용하던 레거시 Coor로,
/// 디버그용 스킴에서는 새로 생성한 Coor를 사용합니다.
extension Config {
    public static let coordinatorFlag: CoordinatorFlag = {
        #if DEV || PROD
        return .legacy
        #else
        return .new
        #endif
    }()
}
```

해당 flag는 아래와 같이 **ApplicationCoor에서 (레거시 / 리팩 파일을) 분기하는 등의 용도**로 사용할 수 있습니다.

```swift
private func runSplashFlow() {
    var coordinator: DefaultCoordinator
    
    switch Config.coordinatorFlag {
    case .legacy:
        coordinator = LegacySplashCoordinator(
            router: router,
            factory: LegacySplashBuilder()
        )
    case .new:
        coordinator = SplashCoordinator(
            navigationController: rootNavigationController,
            factory: SplashBuilder()
        )
    }
    
    ... (생략)
}
```

flag를 서버 드리븐으로 전환할 수도 있을 것 같긴 하지만, 일단은 이렇게 진행하면 좋을 것 같아요!

***

### 3. 불필요한 추상화 계층 제거 (ViewControllable 제거)

Router를 사용할 경우, Router가 다양한 타입의 VC들을 다루어야 하기 때문에 `bar.vc.viewController`와 같이 추상화 계층을 두어야만 했습니다. 기존 코드에서의 이러한 불필요한 추상화 때문에, 화면 전환을 구현할 시 혼란스럽기도 하고 래핑을 위해 작성해야 하는 코드의 양이 많았습니다.

하지만 Router 대신 `UINavigationController`에게 화면 전환을 직접 맡기는 방식으로 리팩토링을 하면, 더 이상 이러한 추상화가 필요하지 않습니다. 따라서 **기존에 존재하는 Builder 관련 Legacy 코드 또한 네이밍을 변경하고, 새로운 코드를 구현**했습니다.

***

### 4. 결론

리팩토링을 진행하실 때, 아래와 같은 단계로 진행해주시면 될 듯 합니다!

> 1. 레거시 파일들의 네이밍을 변경합니다. (Coordinator, Builder, Presentable)
> 2. 새로 파일을 생성해 Router에 대한 의존성을 제거한 코드를 구현합니다. 
> 3. ApplicationCoor의 해당 Flow에서 분기 코드를 작성합니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- 제가 작성한 코드들 중에서 수정해야 하거나, 잘못된 부분이 있다면 마구 리뷰 부탁드립니다!!

## 📸 스크린샷

생략

## 📮 관련 이슈
- Resolved: #516 
