### PR TITLE
[Feat] #567 - 홈 플로팅 버튼 API 연결

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -109,4 +109,10 @@ extension HomeRepository: HomeRepositoryInterface {
             .map{ $0.isNew }
             .eraseToAnyPublisher()
     }
+    
+    public func getFABInfo() -> AnyPublisher<HomeFABModel, any Error> {
+        homeService.getFABInfo()
+            .map{ $0.toDomain() }
+            .eraseToAnyPublisher()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeFABTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeFABTransform.swift
@@ -1,0 +1,23 @@
+//
+//  HomeFABTransform.swift
+//  Data
+//
+//  Created by 강윤서 on 5/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Domain
+import Networks
+
+extension HomeFABResponseEntity {
+    func toDomain() -> HomeFABModel {
+        return HomeFABModel(
+            title: self.title,
+            expandedSubTitle: self.expandedSubTitle,
+            collapsedSubTitle: self.collapsedSubTitle,
+            actionButtonName: self.actionButtonName,
+            imageUrl: self.imageUrl,
+            url: self.url,
+            isActive: self.isActive)
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeFABModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeFABModel.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 public struct HomeFABModel: Decodable {
-    public var title: String
-    public var expandedSubTitle: String
-    public var collapsedSubTitle: String
-    public var actionButtonName: String
-    public var imageUrl: String
-    public var url: String
-    public var isActive: Bool
+    public let title: String
+    public let expandedSubTitle: String
+    public let collapsedSubTitle: String
+    public let actionButtonName: String
+    public let imageUrl: String
+    public let url: String
+    public let isActive: Bool
     
     public init(title: String, expandedSubTitle: String, collapsedSubTitle: String, actionButtonName: String, imageUrl: String, url: String, isActive: Bool) {
         self.title = title

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeFABModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeFABModel.swift
@@ -1,0 +1,29 @@
+//
+//  HomeFABModel.swift
+//  Domain
+//
+//  Created by 강윤서 on 5/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct HomeFABModel: Decodable {
+    public var title: String
+    public var expandedSubTitle: String
+    public var collapsedSubTitle: String
+    public var actionButtonName: String
+    public var imageUrl: String
+    public var url: String
+    public var isActive: Bool
+    
+    public init(title: String, expandedSubTitle: String, collapsedSubTitle: String, actionButtonName: String, imageUrl: String, url: String, isActive: Bool) {
+        self.title = title
+        self.expandedSubTitle = expandedSubTitle
+        self.collapsedSubTitle = collapsedSubTitle
+        self.actionButtonName = actionButtonName
+        self.imageUrl = imageUrl
+        self.url = url
+        self.isActive = isActive
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -20,4 +20,5 @@ public protocol HomeRepositoryInterface {
     func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], Error>
     func getReportUrl() -> AnyPublisher<SoptampReportUrlModel, Error>
     func checkPokeNewUser() -> AnyPublisher<Bool, Error>
+    func getFABInfo() -> AnyPublisher<HomeFABModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -109,6 +109,7 @@ extension DefaultHomeUseCase: HomeUseCase {
     public func getFABInfo() -> AnyPublisher<HomeFABModel, Never> {
         repository.getFABInfo()
             .catch { error in
+                print("HomeUseCase getFABInfo에서 문제가 발생했습니다. \(error)")
                 return Empty<HomeFABModel, Never>()
             }
             .eraseToAnyPublisher()

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -20,6 +20,7 @@ public protocol HomeUseCase {
     func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], Never>
     func getReportURL()
     func checkPokeNewUser() -> AnyPublisher<Bool, Never>
+    func getFABInfo() -> AnyPublisher<HomeFABModel, Never>
 }
 
 public class DefaultHomeUseCase {
@@ -101,6 +102,14 @@ extension DefaultHomeUseCase: HomeUseCase {
             .catch { error in
                 print("HomeUseCase checkPokeNewUser에서 문제가 발생했습니다. \(error)")
                 return Empty<Bool, Never>()
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    public func getFABInfo() -> AnyPublisher<HomeFABModel, Never> {
+        repository.getFABInfo()
+            .catch { error in
+                return Empty<HomeFABModel, Never>()
             }
             .eraseToAnyPublisher()
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/ExtendedFAButton.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/ExtendedFAButton.swift
@@ -28,24 +28,19 @@ final class HomeFAButton: UIView {
         $0.layer.cornerRadius = 21
     }
     
-    private let serviceImageView = UIImageView().then {
-        $0.image = DSKitAsset.Assets.icBell.image.withRenderingMode(.alwaysOriginal)
-    }
+    private let serviceImageView = UIImageView()
     
-    private let title = UILabel().then {
-        $0.text = "점수 2배! 깜짝 미션 오픈"
+    private let extendedTitle = UILabel().then {
         $0.font = DSKitFontFamily.Suit.bold.font(size: 16)
         $0.textColor = DSKitAsset.Colors.gray950.color
     }
     
-    private let subTitle = UILabel().then {
-        $0.text = "지금 바로 미션에 도전해보세요"
+    private let extendedSubTitle = UILabel().then {
         $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
         $0.textColor = DSKitAsset.Colors.orange700.color
     }
     
     private let actionButton = UIButton().then {
-        $0.setTitle("미션 보기", for: .normal)
         $0.setTitleColor(DSKitAsset.Colors.white.color, for: .normal)
         $0.titleLabel?.font = DSKitFontFamily.Suit.medium.font(size: 13)
         $0.backgroundColor = DSKitAsset.Colors.black.color
@@ -53,13 +48,11 @@ final class HomeFAButton: UIView {
     }
     
     private let collapsedTitle = UILabel().then {
-        $0.text = "솝탬프"
         $0.textColor = DSKitAsset.Colors.orange800.color
         $0.font = DSKitFontFamily.Suit.medium.font(size: 12)
     }
     
     private let collapsedSubTitle = UILabel().then {
-        $0.text = "미션 보기"
         $0.textColor = DSKitAsset.Colors.gray900.color
         $0.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
     }
@@ -104,7 +97,7 @@ extension HomeFAButton {
     }
     
     private func setExpendedLayout() {
-        self.addSubviews(serviceBackgroundView, serviceImageView, subTitle, title, actionButton)
+        self.addSubviews(serviceBackgroundView, serviceImageView, extendedSubTitle, extendedTitle, actionButton)
         
         serviceBackgroundView.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(13)
@@ -114,16 +107,17 @@ extension HomeFAButton {
         
         serviceImageView.snp.makeConstraints { make in
             make.center.equalTo(serviceBackgroundView.snp.center)
+            make.leading.trailing.equalTo(serviceBackgroundView).inset(6)
         }
         
-        title.snp.makeConstraints { make in
+        extendedTitle.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(15)
             make.leading.equalTo(serviceBackgroundView.snp.trailing).offset(8)
         }
         
-        subTitle.snp.makeConstraints { make in
-            make.leading.equalTo(title.snp.leading)
-            make.top.equalTo(title.snp.bottom).offset(4)
+        extendedSubTitle.snp.makeConstraints { make in
+            make.leading.equalTo(extendedTitle.snp.leading)
+            make.top.equalTo(extendedTitle.snp.bottom).offset(4)
         }
         
         actionButton.snp.makeConstraints { make in
@@ -143,6 +137,7 @@ extension HomeFAButton {
         
         serviceImageView.snp.makeConstraints { make in
             make.center.equalTo(serviceBackgroundView)
+            make.leading.trailing.equalTo(serviceBackgroundView).inset(5)
         }
         
         collapsedTitle.snp.makeConstraints { make in
@@ -187,5 +182,19 @@ extension HomeFAButton {
 extension HomeFAButton {
     public func setStyle(_ style: ExtendedFAButtonType) {
         self.buttonType = style
+    }
+    
+    func configureUI(with model: HomeFABPresentationModel) {
+        // 공통 속성
+        serviceImageView.setImage(with: model.imageUrl)
+        
+        // 확장 버튼 속성
+        extendedTitle.text = model.extenedFAButton.title
+        extendedSubTitle.text = model.extenedFAButton.subTitle
+        actionButton.setTitle(model.actionButtonName, for: .normal)
+        
+        // 접힘 버튼 속성
+        collapsedTitle.text = model.collapsedFAButton.subTitle
+        collapsedSubTitle.text = model.actionButtonName
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -112,6 +112,11 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
             self.delegate?.homeCoordinator(self, to: .poke(isNewUser: isNewUser))
         }
         
+        homeForMember.vm.onExtendedFAButtonTapped = { [weak self] url in
+            guard let self else { return }
+            self.delegate?.homeCoordinator(self, to: .deepLink(url: url))
+        }
+        
         rootViewController = homeForMember.vc
         navigationController.pushViewController(homeForMember.vc, animated: true)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
@@ -90,6 +90,10 @@ public final class LegacyHomeCoordinator: DefaultHomeCoordinator {
             self?.requestCoordinating?(.poke(isNewUser: isNewUser))
         }
         
+        homeForMember.vm.onExtendedFAButtonTapped = { [weak self] url in
+            self?.requestCoordinating?(.deepLink(url: url))
+        }
+        
         rootViewController = homeForMember.vc.viewController
         
         router.push(homeForMember.vc)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomeFABPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomeFABPresentationModel.swift
@@ -1,0 +1,9 @@
+//
+//  HomeFABModel.swift
+//  HomeFeature
+//
+//  Created by 강윤서 on 5/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomeFABPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomeFABPresentationModel.swift
@@ -1,9 +1,38 @@
 //
-//  HomeFABModel.swift
+//  HomeFABPresentationModel.swift
 //  HomeFeature
 //
 //  Created by 강윤서 on 5/22/25.
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import Domain
 
+struct HomeFABPresentationModel {
+    
+    let imageUrl: String
+    let url: String
+    let actionButtonName: String
+    let extenedFAButton: ExtendedFAButton
+    let collapsedFAButton: CollapsedFAButton
+    
+    struct ExtendedFAButton {
+        let title: String
+        let subTitle: String
+    }
+    
+    struct CollapsedFAButton {
+        let subTitle: String
+    }
+}
+
+extension HomeFABModel {
+    func toPresentationModel() -> HomeFABPresentationModel {
+        return HomeFABPresentationModel(
+            imageUrl: self.imageUrl,
+            url: self.url,
+            actionButtonName: self.actionButtonName,
+            extenedFAButton: HomeFABPresentationModel.ExtendedFAButton(title: self.title, subTitle: self.expandedSubTitle),
+            collapsedFAButton: HomeFABPresentationModel.CollapsedFAButton(subTitle: self.collapsedSubTitle))
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -104,7 +104,6 @@ struct HomePresentationModel {
             self.isHotPost = isHotPost
         }
     }
-    
 }
 
 // MARK: - toPresentation

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -85,6 +85,7 @@ extension HomeForMemberVC {
     private func setUI() {
         self.navigationController?.isNavigationBarHidden = true
         view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
+        self.FAButton.isHidden = true
     }
     
     private func setLayout() {
@@ -250,8 +251,14 @@ extension HomeForMemberVC {
             .withUnretained(self)
             .sink { owner, isLoading in
                 isLoading ? owner.showLoading() : owner.stopLoading()
-            }
-            .store(in: cancelBag)
+            }.store(in: cancelBag)
+        
+        output.fabButtonInfo
+            .withUnretained(self)
+            .sink { owner, fabModel in
+                owner.FAButton.isHidden = false
+                owner.FAButton.configureUI(with: fabModel)
+            }.store(in: cancelBag)
     }
     
     private func updateUI(with data: HomePresentationModel) {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -25,6 +25,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     private var cancelBag = CancelBag()
     
     let userType: UserType = UserDefaultKeyList.Auth.getUserType()
+    private var fabuttonUrl: String = ""
     
     let productServiceList: [HomePresentationModel.ProductService] = [
         .init(product: .playgroundCommunity),
@@ -50,7 +51,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public struct Output {
         let homeItem = PassthroughSubject<HomePresentationModel, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
-        let needNetworkAlert = PassthroughSubject<Void, Never>()
+        let fabButtonInfo = PassthroughSubject<HomeFABPresentationModel, Never>()
     }
     
     // MARK: - HomeForMemberCoordinating
@@ -85,6 +86,16 @@ extension HomeForMemberViewModel {
                 owner.useCase.getReportURL()
                 owner.requestAuthorizationForNotification()
                 AmplitudeInstance.shared.trackWithUserType(event: .viewAppHomeNew)
+            }.store(in: cancelBag)
+        
+        input.viewDidLoad
+            .flatMap(useCase.getFABInfo)
+            .filter{ $0.isActive }
+            .withUnretained(self)
+            .sink { owner, fabModel in
+                let presentationModel = fabModel.toPresentationModel()
+                output.fabButtonInfo.send(presentationModel)
+                owner.fabuttonUrl = presentationModel.url
             }.store(in: cancelBag)
         
         input.viewWillAppear
@@ -201,8 +212,7 @@ extension HomeForMemberViewModel {
         input.extendedFAButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                print("버튼 클릭")
-                owner.onExtendedFAButtonTapped?("home/poke")
+                owner.onExtendedFAButtonTapped?(owner.fabuttonUrl)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/HomeAPI.swift
@@ -15,6 +15,7 @@ public enum HomeAPI {
     case getDescription
     case getAppServiceAccessStatus
     case getInsightPosts
+    case getFABInfo
 }
 
 extension HomeAPI: BaseAPI {
@@ -28,19 +29,21 @@ extension HomeAPI: BaseAPI {
             return "/app-service"
         case .getInsightPosts:
             return "/posts"
+        case .getFABInfo:
+            return "/floating-button"
         }
     }
     
     public var method: Moya.Method {
         switch self {
-        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts:
+        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts, .getFABInfo:
             return .get
         }
     }
     
     public var task: Moya.Task {
         switch self {
-        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts:
+        case .getDescription, .getAppServiceAccessStatus, .getInsightPosts, .getFABInfo:
             return .requestPlain
         }
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeFABResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeFABResponseEntity.swift
@@ -1,0 +1,25 @@
+//
+//  HomeFABResponseEntity.swift
+//  Networks
+//
+//  Created by 강윤서 on 5/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct HomeFABResponseEntity: Decodable {
+    public var title: String
+    public var expandedSubTitle: String
+    public var collapsedSubTitle: String
+    public var actionButtonName: String
+    public var imageUrl: String
+    public var url: String
+    public var isActive: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case title, expandedSubTitle, collapsedSubTitle, actionButtonName, imageUrl
+        case url = "linkUrl"
+        case isActive = "active"
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeFABResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeFABResponseEntity.swift
@@ -9,17 +9,17 @@
 import Foundation
 
 public struct HomeFABResponseEntity: Decodable {
-    public var title: String
-    public var expandedSubTitle: String
-    public var collapsedSubTitle: String
-    public var actionButtonName: String
-    public var imageUrl: String
-    public var url: String
-    public var isActive: Bool
+    public let title: String
+    public let expandedSubTitle: String
+    public let collapsedSubTitle: String
+    public let actionButtonName: String
+    public let imageUrl: String
+    public let url: String
+    public let isActive: Bool
     
     enum CodingKeys: String, CodingKey {
-        case title, expandedSubTitle, collapsedSubTitle, actionButtonName, imageUrl
+        case title, expandedSubTitle, actionButtonName, imageUrl, isActive
+        case collapsedSubTitle = "collapsedSubtitle"
         case url = "linkUrl"
-        case isActive = "active"
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-// MARK: - 한 줄 소개와 솝마디 추가되어야 함. 파트 방식 변경 요청 상태.
 public struct SoptlogResponseEntity: Decodable {
     public let userName: String?
     public let profileImage: String?
@@ -22,19 +21,4 @@ public struct SoptlogResponseEntity: Decodable {
     public let isFortuneChecked: Bool
     public let todayFortuneText: String
     public let isActive: Bool
-    
-    public init(userName: String?, profileImage: String?, part: String, soptampRank: String?, pokeCount: String, soptLevel: String, during: String, profileMessage: String, icons: [String], isFortuneChecked: Bool, todayFortuneText: String, isActive: Bool) {
-        self.userName = userName
-        self.profileImage = profileImage
-        self.part = part
-        self.soptampRank = soptampRank
-        self.pokeCount = pokeCount
-        self.soptLevel = soptLevel
-        self.during = during
-        self.profileMessage = profileMessage
-        self.icons = icons
-        self.isFortuneChecked = isFortuneChecked
-        self.todayFortuneText = todayFortuneText
-        self.isActive = isActive
-    }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -17,6 +17,7 @@ public protocol HomeService {
     func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
     func getAppServiceAccessStatus() -> AnyPublisher<[HomeAppServiceAccessStatusEntity], Error>
     func getInsightPosts() -> AnyPublisher<[HomeInsightPostsEntity], Error>
+    func getFABInfo() -> AnyPublisher<[HomeFABResponseEntity], Error>
 }
 
 extension DefaultHomeService: HomeService {
@@ -30,5 +31,9 @@ extension DefaultHomeService: HomeService {
     
     public func getInsightPosts() -> AnyPublisher<[HomeInsightPostsEntity], any Error> {
         requestObjectInCombine(.getInsightPosts)
+    }
+    
+    public func getFABInfo() -> AnyPublisher<[HomeFABResponseEntity], any Error> {
+        requestObjectInCombine(.getFABInfo)
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/HomeService.swift
@@ -17,7 +17,7 @@ public protocol HomeService {
     func getDescription() -> AnyPublisher<HomeDescriptionEntity, Error>
     func getAppServiceAccessStatus() -> AnyPublisher<[HomeAppServiceAccessStatusEntity], Error>
     func getInsightPosts() -> AnyPublisher<[HomeInsightPostsEntity], Error>
-    func getFABInfo() -> AnyPublisher<[HomeFABResponseEntity], Error>
+    func getFABInfo() -> AnyPublisher<HomeFABResponseEntity, Error>
 }
 
 extension DefaultHomeService: HomeService {
@@ -33,7 +33,7 @@ extension DefaultHomeService: HomeService {
         requestObjectInCombine(.getInsightPosts)
     }
     
-    public func getFABInfo() -> AnyPublisher<[HomeFABResponseEntity], any Error> {
+    public func getFABInfo() -> AnyPublisher<HomeFABResponseEntity, any Error> {
         requestObjectInCombine(.getFABInfo)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- 홈 확장 플로팅 버튼 API를 연결했습니다.

🌱 작업한 브랜치
- feature/#567

## 🌱 PR Point
**1. PresentationModel 사용**
- 하나의 컴포넌트 내에 확장 버튼과 접힘 버튼 UI가 혼재되어 있어, 가독성과 유지보수를 위해 `FABPresentationModel을` 새로 만들었습니다.
- 버튼 유형과 관계없이 공통으로 사용되는 속성은 `FABPresentationModel`에 정의하고, 버튼별 고유 속성은 `ExtendedFAButton`과 `CollapsedFAButton`으로 분리했습니다.

**2. 홈 뷰 로직 분리**
- 홈 뷰의 확장 가능성과 모델의 역할을 고려하여 `HomePresentationModel`과 `HomeFABPresentationModel`을 따로 구현했습니다.
- 같은 이유로, `ViewModel`의 로직도 분리했습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- prod 서버가 배포되지 않아 `LegacyCoor`의 화면전환은 확인하지 못했습니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/ce9de530-747f-4673-923a-d1fe8e34aa12



## 📮 관련 이슈
- Resolved: #567
