### PR TITLE
[Add] #579 - infoplist에 구글 로그인 정보 추가

### DIFF
--- a/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
+++ b/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
@@ -25,15 +25,22 @@ public extension Project {
         "ITSAppUsesNonExemptEncryption": .boolean(false),
         "UIUserInterfaceStyle": .string("Dark"),
         "NSPhotoLibraryUsageDescription": .string("미션과 관련된 사진을 업로드하기 위해 갤러리 권한이 필요합니다."),
+        "UIBackgroundModes": .array([
+            .string("remote-notification")
+        ]),
+        "GIDClientID": .string("$(GOOGLE_IOS_CLIENT_ID)"),
+        "GIDServerClientID": .string("$(GOOGLE_SERVER_CLIENT_ID)"),
         "CFBundleURLTypes": .array([
             .dictionary([
                 "CFBundleTypeRole": .string("Editor"),
                 "CFBundleURLName": .string("sopt-makers"),
                 "CFBundleURLSchemes": .array([.string("sopt-makers")])
+            ]),
+            .dictionary([
+                "CFBundleTypeRole": .string("Editor"),
+                "CFBundleURLName": .string("Google"),
+                "CFBundleURLSchemes": .array([.string("$(GOOGLE_IOS_REVERSED_CLIENT_ID)")])
             ])
-        ]),
-        "UIBackgroundModes": .array([
-            .string("remote-notification")
         ])
     ]
     
@@ -61,15 +68,23 @@ public extension Project {
         "ITSAppUsesNonExemptEncryption": .boolean(false),
         "UIUserInterfaceStyle": .string("Dark"),
         "NSPhotoLibraryUsageDescription": .string("미션과 관련된 사진을 업로드하기 위해 갤러리 권한이 필요합니다."),
+        "UIBackgroundModes": .array([
+            .string("remote-notification")
+        ]),
+        "SENTRY_AUTH_TOKEN": .string("$(SENTRY_AUTH_TOKEN)"),
+        "GIDClientID": .string("$(GOOGLE_IOS_CLIENT_ID)"),
+        "GIDServerClientID": .string("$(GOOGLE_SERVER_CLIENT_ID)"),
         "CFBundleURLTypes": .array([
             .dictionary([
                 "CFBundleTypeRole": .string("Editor"),
                 "CFBundleURLName": .string("sopt-makers"),
                 "CFBundleURLSchemes": .array([.string("sopt-makers")])
+            ]),
+            .dictionary([
+                "CFBundleTypeRole": .string("Editor"),
+                "CFBundleURLName": .string("Google"),
+                "CFBundleURLSchemes": .array([.string("$(GOOGLE_IOS_REVERSED_CLIENT_ID)")])
             ])
-        ]),
-        "UIBackgroundModes": .array([
-            .string("remote-notification")
         ])
     ]
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#579

## 🌱 PR Point

- 구글 로그인을 하기 위해선 InfoPlist에 아래 3가지 정보를 추가해야합니다.
  - GOOGLE_IOS_CLIENT_ID
  - GOOGLE_IOS_REVERSED_CLIENT_ID
  - GOOGLE_SERVER_CLIENT_ID

저희 프로젝트에선 Tuist가 Info 파일을 생성합니다.

위 정보는 보안 키이기에 Tuist 파일에 직접 추가하면 git에 노출될 위험이 있습니다.

따라서 보안 키는 SOPT-iOS-Private 레포지토리의 xcconfig에 추가하고,

Tuist 에선 `$(GOOGLE_IOS_CLIENT_ID)` 형식 로 환경변수 값을 가져오는 방식으로 구현했습니다.

## 📌 참고 사항

해당 프로젝트를 클론 받은 후 `make download-privates`을 수행하여 보안 키에 대한 정보가 담긴 xcconfig가 프로젝트에 추가하세요 :)



## 📮 관련 이슈
- Resolved: #579
