### PR TITLE
[Fix] #588 - 홈 플로팅 버튼의 인터랙션 스크롤 단위 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -382,12 +382,12 @@ extension HomeForMemberVC: UICollectionViewDelegate {
     private func animateFAButton(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         
-        if offsetY < 330 && isExtendedButtonHidden || offsetY >= 330 && !isExtendedButtonHidden {
+        if offsetY < 130 && isExtendedButtonHidden || offsetY >= 130 && !isExtendedButtonHidden {
             toggleFloatingButtonUI()
         }
     }
     
-    /// offsetY 값이 330을 지날 때 floating button의 UI를 변경하고 애니메이션을 실행하는 메서드
+    /// offsetY 기준 값을 지날 때 floating button의 UI를 변경하고 애니메이션을 실행하는 메서드
     private func toggleFloatingButtonUI() {
         animateExtendedFloatingButtonHide(floatingButtonType)
         isExtendedButtonHidden.toggle()


### PR DESCRIPTION
## 🌴 PR 요약
홈 플로팅 버튼의 타입이 변경되는 offset.y 기준값을 변경했습니다.

🌱 작업한 브랜치
- feature/#588

## 📸 스크린샷
https://github.com/user-attachments/assets/e3bb3866-5a33-440d-a5ee-9d55fc85889e


## 📮 관련 이슈
- Resolved: #588
