### PR TITLE
[Hotfix] #595 - 런치 스크린 설정 방식 변경

### DIFF
--- a/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
+++ b/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
@@ -7,7 +7,7 @@ public extension Project {
         "CFBundleVersion": .string("1"),
         "CFBundleIdentifier": .string("com.sopt-stamp-iOS.release"),
         "CFBundleDisplayName": .string("SOPT"),
-        "UILaunchStoryboardName": .string("LaunchScreen"),
+        "UILaunchScreen": .dictionary([:]),
         "UIApplicationSceneManifest": .dictionary([
                 "UIApplicationSupportsMultipleScenes": .boolean(false),
                 "UISceneConfigurations": .dictionary([
@@ -43,7 +43,7 @@ public extension Project {
         "CFBundleVersion": .string("1"),
         "CFBundleIdentifier": .string("com.sopt-stamp-iOS.alpha"),
         "CFBundleDisplayName": .string("SOPT-Test"),
-        "UILaunchStoryboardName": .string("LaunchScreen"),
+        "UILaunchScreen": .dictionary([:]),
         "UIApplicationSceneManifest": .dictionary([
             "UIApplicationSupportsMultipleScenes": .boolean(false),
             "UISceneConfigurations": .dictionary([


### PR DESCRIPTION
## 🌴 PR 요약

런치 스크린 설정 방식 변경

🌱 작업한 브랜치
- #595 

## 🌱 PR Point
> Invalid bundle. Because your app supports Multitasking on iPad, you need to include the LaunchScreen launch storyboard file in your com.sopt-stamp-iOS.alpha bundle. Use UILaunchScreen instead if the app’s MinimumOSVersion is 14 or higher and you prefer to configure the launch screen without storyboards. For details, see: https://developer.apple.com/documentation/bundleresources/information_property_list/uilaunchstoryboardname

- 해당 문제로 인해 테플 업로드가 되지 않았습니다.
- manifests > InfoPlists에서 LaunchScreen을 `UILaunchStoryboardName": .string("LaunchScreen")`로 지정하고 있었는데, 
- "UILaunchScreen"으로 런치 스크린 설정 방식을 변경해 해결했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #595 
