### PR TITLE
[Hotfix] #597 - 출석 중복 push 버그 해결

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -17,6 +17,7 @@ final class CalendarCardCVC: UICollectionViewCell {
     // MARK: - Properties
 
     private(set) lazy var attendanceButtonTap = attendanceButton.publisher(for: .touchUpInside)
+    private(set) var cancelBag = CancelBag()
     
     // MARK: - UI Components
 
@@ -81,6 +82,12 @@ final class CalendarCardCVC: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.cancelBag = CancelBag()
+        self.attendanceButtonTap = attendanceButton.publisher(for: .touchUpInside)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
@@ -17,6 +17,7 @@ final class SurveyCVC: UICollectionViewCell {
     // MARK: - Properties
     
     private(set) lazy var surveyButtonTap = surveyButton.publisher(for: .touchUpInside)
+    private(set) var cancelBag = CancelBag()
     
     private let surveyImageView = UIImageView().then {
         $0.image = DSKitAsset.Assets.imgGirlSurvey.image
@@ -43,6 +44,12 @@ final class SurveyCVC: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.cancelBag = CancelBag()
+//        surveyButtonTap = surveyButton.publisher(for: .touchUpInside)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
@@ -49,7 +49,7 @@ final class SurveyCVC: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.cancelBag = CancelBag()
-//        surveyButtonTap = surveyButton.publisher(for: .touchUpInside)
+        surveyButtonTap = surveyButton.publisher(for: .touchUpInside)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -61,7 +61,7 @@ extension HomeForMemberVC {
                 .sink { owner, _ in
                     owner.surveyButtonTapped.send()
                 }
-                .store(in: cancelBag)
+                .store(in: cell.cancelBag)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -29,7 +29,7 @@ extension HomeForMemberVC {
                 .sink { owner, _ in
                     owner.attendanceButtonTapped.send()
                 }
-                .store(in: cancelBag)
+                .store(in: cell.cancelBag)
         }
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치

#597 

## 🌱 PR Point

- 설문 섹션 > 설문 버튼을 누르는 횟수만큼 중복 push가 발생하는 문제가 있어 수정했습니다.

![스크린샷 2025-06-01 오후 10 48 58](https://github.com/user-attachments/assets/56396d5c-6a33-4495-8cfd-2ab606e73336)

- 셀 내부의 버튼에서 이벤트를 받아야 하는 경우, publisher를 활용해 해당 버튼의 터치 이벤트를 방출하는 방식을 사용합니다.
- 하지만 이 때, publisher가 셀 내부의 button을 참조하기 때문에, 셀이 재사용되어 새로운 publisher가 생겼음에도 이전의 퍼블리셔를 여전히 구독하고 있는 문제가 있었습니다.
- 홈 화면에서의 "출석" 버튼 또한 같은 방식으로 구현되어 있어, 두 셀에 대하여 prepareForReuse에서 구독자를 초기화 할 수 있도록 수정했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- 해당 부분까지 반영해서 3.0.5 ver로 심사 올리겠습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|홈화면|<img src = "https://github.com/user-attachments/assets/57ebece0-9b4f-4aef-9543-10f8ce0daffd" width = 300>|

## 📮 관련 이슈
- Resolved: #597 
