### PR TITLE
[Hotfix] #599 - tuist destination 수정

### DIFF
--- a/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
+++ b/SOPT-iOS/Plugins/EnvPlugin/ProjectDescriptionHelpers/InfoPlists.swift
@@ -7,7 +7,7 @@ public extension Project {
         "CFBundleVersion": .string("1"),
         "CFBundleIdentifier": .string("com.sopt-stamp-iOS.release"),
         "CFBundleDisplayName": .string("SOPT"),
-        "UILaunchScreen": .dictionary([:]),
+        "UILaunchStoryboardName": .string("LaunchScreen"),
         "UIApplicationSceneManifest": .dictionary([
                 "UIApplicationSupportsMultipleScenes": .boolean(false),
                 "UISceneConfigurations": .dictionary([
@@ -43,7 +43,7 @@ public extension Project {
         "CFBundleVersion": .string("1"),
         "CFBundleIdentifier": .string("com.sopt-stamp-iOS.alpha"),
         "CFBundleDisplayName": .string("SOPT-Test"),
-        "UILaunchScreen": .dictionary([:]),
+        "UILaunchStoryboardName": .string("LaunchScreen"),
         "UIApplicationSceneManifest": .dictionary([
             "UIApplicationSupportsMultipleScenes": .boolean(false),
             "UISceneConfigurations": .dictionary([

--- a/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/SOPT-iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -34,7 +34,7 @@ public extension Project {
             
             let target = Target.target(
                 name: name,
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: .app,
                 bundleId: "\(Environment.bundlePrefix).\(bundleSuffix)",
                 deploymentTargets: deploymentTarget,
@@ -62,7 +62,7 @@ public extension Project {
             
             let target = Target.target(
                 name: "\(name)Interface",
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: .framework,
                 bundleId: "\(Environment.bundlePrefix).\(name)Interface",
                 deploymentTargets: deploymentTarget,
@@ -85,7 +85,7 @@ public extension Project {
             
             let target = Target.target(
                 name: name,
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: hasDynamicFramework ? .framework : .staticFramework,
                 bundleId: "\(Environment.bundlePrefix).\(name)",
                 deploymentTargets: deploymentTarget,
@@ -106,7 +106,7 @@ public extension Project {
             
             let target = Target.target(
                 name: "\(name)Demo",
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: .app,
                 bundleId: "\(Environment.bundlePrefix).\(name)Demo",
                 deploymentTargets: deploymentTarget,
@@ -133,7 +133,7 @@ public extension Project {
             
             let target = Target.target(
                 name: "\(name)Tests",
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: .unitTests,
                 bundleId: "\(Environment.bundlePrefix).\(name)Tests",
                 deploymentTargets: deploymentTarget,
@@ -162,7 +162,7 @@ public extension Project {
             
             let target = Target.target(
                 name: "\(name)UITests",
-                destinations: .iOS,
+                destinations: [.iPhone],
                 product: .uiTests,
                 bundleId: "\(Environment.bundlePrefix).\(name)UITests",
                 deploymentTargets: deploymentTarget,


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- #599

## 🌱 PR Point

- target의 destination이 iOS로 되어 있어서, 아카이빙하니 기기들이 iPhone, iPad까지 지원되고 있었어유.
- 따라서 iOS -> iPhone으로 수정했습니다!
- #595 도 이 때문에 생겼던 문제 같어요. 해당 부분 롤백했습니닷.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #599
