### PR TITLE
[Refactor] #604 - MyPage의 뷰컨트롤러로부터 화면전환 로직 분리

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -340,6 +340,7 @@ public struct I18N {
             public static let title = "기타"
             public static let logout = "로그아웃"
             public static let withdrawal = "탈퇴하기"
+            public static let login = "로그인"
         }
         
         public static let resetMissionTitle = "미션을 초기화 하실건가요?"
@@ -349,9 +350,6 @@ public struct I18N {
         public static let logoutDialogTitle = "로그아웃"
         public static let logoutDialogDescription = "정말 로그아웃을 하실 건가요?"
         public static let logoutDialogGrantButtonTitle = "로그아웃"
-        public static let login = "로그인"
-
-        
     }
     
     public struct NotificationSettingsByFeature {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
@@ -15,8 +15,6 @@ public protocol AppMyPageUseCase {
     func deregisterPushToken()
     
     var resetSuccess: PassthroughSubject<Bool, Error> { get }
-    var originUserNotificationIsAllowedStatus: PassthroughSubject<Bool, Error> { get }
-    var optInPushNotificationResult: PassthroughSubject<Bool, Error> { get }
     var deregisterPushTokenSuccess: PassthroughSubject<Bool, Never> { get }
 }
 
@@ -24,8 +22,6 @@ public final class DefaultAppMyPageUseCase {
     private let repository: AppMyPageRepositoryInterface
     
     public let resetSuccess = PassthroughSubject<Bool, Error>()
-    public let originUserNotificationIsAllowedStatus = PassthroughSubject<Bool, Error>()
-    public let optInPushNotificationResult = PassthroughSubject<Bool, Error>()
     public let deregisterPushTokenSuccess = PassthroughSubject<Bool, Never>()
 
     private let cancelBag = CancelBag()

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPageFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPageFeatureBuildable.swift
@@ -9,7 +9,7 @@
 import Core
 
 public protocol MyPageFeatureBuildable {
-    func makeAppMyPage(userType: UserType) -> MyPageViewControllable
+    func makeAppMyPage(userType: UserType) -> LegacyMyPagePresentable
     func makeSentenceEditVC() -> SentenceEditViewControllable
     func makePrivacyPolicyVC() -> PrivacyPolicyViewControllable
     func makeTermsOfServiceVC() -> TermsOfServiceViewControllable

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
@@ -6,10 +6,12 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 
-public protocol MyPageViewControllable: LegacyViewControllable & MyPageCoordinatable { }
+public protocol MyPageViewControllable: LegacyViewControllable { }
 public protocol MyPageCoordinatable {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onPolicyItemTap: (() -> Void)? { get set }
@@ -17,6 +19,11 @@ public protocol MyPageCoordinatable {
     var onEditOnelineSentenceItemTap: (() -> Void)? { get set }
     var onWithdrawalItemTap: ((UserType) -> Void)? { get set }
     var onShowLogin: (() -> Void)? { get set }
+    var onShowLogout: (() -> Void)? { get set }
     var onAlertButtonTap: ((String) -> Void)? { get set }
+    var onResetSoptampTap: (() -> Void)? { get set }
 }
-public typealias MyPageViewModelType = ViewModelType
+public typealias MyPageViewModelType = ViewModelType & MyPageCoordinatable
+
+public typealias LegacyMyPagePresentable = (vc: MyPageViewControllable, vm: MyPageViewModelType)
+//public typealias MyPagePresentable = (vc: UIViewController, vm: MyPageViewModelType)

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
@@ -19,36 +19,12 @@ import BaseFeatureDependency
 
 public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     
-    // MARK: - Metric
-    
-    private enum Metric {
-        static let navigationbarHeight = 44.f
-        static let firstSectionGroupTop = 13.f
-        static let sectionGroupLeadingTrailing = 20.f
-        
-        static let sectionGroupSpacing = 16.f
-    }
-    
     // MARK: - Properties
     
     private let viewModel: AppMyPageViewModel
     private let userType: UserType
     private var dataSource: UICollectionViewDiffableDataSource<MyPageSectionLayoutKind, MyPageItem>! = nil
-    
-    // MARK: - MyPageCoordinatable
-    
-    public var onNaviBackButtonTap: (() -> Void)?
-    public var onPolicyItemTap: (() -> Void)?
-    public var onTermsOfUseItemTap: (() -> Void)?
-    public var onEditOnelineSentenceItemTap: (() -> Void)?
-    public var onWithdrawalItemTap: ((UserType) -> Void)?
-    public var onLoginItemTap: (() -> Void)?
-    public var onShowLogin: (() -> Void)?
-    public var onAlertButtonTap: ((String) -> Void)?
-    
-    // MARK: Combine
-    private let resetButtonTapped = PassthroughSubject<Bool, Never>()
-    private let logoutButtonTapped = PassthroughSubject<Void, Never>()
+    private var cellTapped = PassthroughSubject<MyPageItem, Never>()
     private let cancelBag = CancelBag()
     
     // MARK: - UI Components
@@ -79,6 +55,7 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
         setRegister()
         setDataSource()
         applySnapshot()
+        bindViewModels()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -167,161 +144,36 @@ extension AppMyPageVC {
     }
 }
 
+// MARK: - UICollectionViewDelegate
+
 extension AppMyPageVC: UICollectionViewDelegate {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        cellTapped.send(item)
+    }
 }
 
-//extension AppMyPageVC {
-//    private func setupLayouts() {
-//        self.view.addSubviews(self.navigationBar, self.scrollView)
-//        self.scrollView.addSubview(self.contentStackView)
-//
-//        switch self.userType {
-//        case .active, .inactive:
-//            self.contentStackView.addArrangedSubviews(
-//                self.servicePolicySectionGroup,
-//                self.alertSectionGroup,
-//                self.soptampSectionGroup,
-//                self.etcSectionGroup
-//            )
-//        case .visitor:
-//            self.contentStackView.addArrangedSubviews(
-//                self.servicePolicySectionGroup,
-//                self.etcForVisitorsSectionGroup
-//            )
-//        }
-//    }
-//
-//    private func setupConstraints() {
-//        self.navigationBar.snp.makeConstraints {
-//            $0.height.equalTo(Metric.navigationbarHeight)
-//            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
-//            $0.leading.trailing.equalToSuperview()
-//        }
-//        self.scrollView.snp.makeConstraints {
-//            $0.top.equalTo(self.navigationBar.snp.bottom)
-//            $0.leading.trailing.bottom.equalToSuperview()
-//        }
-//        self.contentStackView.snp.makeConstraints {
-//            $0.width.equalTo(self.view.frame.width - Metric.sectionGroupLeadingTrailing * 2)
-//            $0.top.equalToSuperview().inset(Metric.firstSectionGroupTop)
-//            $0.leading.trailing.equalToSuperview().inset(Metric.sectionGroupLeadingTrailing)
-//            $0.bottom.equalToSuperview()
-//        }
-//    }
-//
-//    // TODO: - (@승호): 적절히 객체에 위임하기
-//    private func addTabGestureOnListItems() {
-//        self.servicePolicySectionGroup.addTapGestureRecognizer { [weak self] in
-//            self?.onPolicyItemTap?()
-//        }
-//
-//        self.termsOfUseListItem.addTapGestureRecognizer { [weak self] in
-//            self?.onTermsOfUseItemTap?()
-//        }
-//
-//        self.sendFeedbackListItem.addTapGestureRecognizer {
-//            openExternalLink(urlStr: ExternalURL.KakaoTalk.serviceProposal)
-//        }
-//
-//        self.alertListItem.addTapGestureRecognizer { [weak self] in
-//            self?.onAlertButtonTap?(UIApplication.openSettingsURLString)
-//        }
-//
-//        self.editOnelineSentenceListItem.addTapGestureRecognizer { [weak self] in
-//            self?.onEditOnelineSentenceItemTap?()
-//        }
-//
-//        self.resetStampListItem.addTapGestureRecognizer { [weak self] in
-//            AlertUtils.presentAlertVC(
-//                type: .titleDescription,
-//                theme: .main,
-//                title: I18N.MyPage.resetMissionTitle,
-//                description: I18N.MyPage.resetMissionDescription,
-//                customButtonTitle: I18N.MyPage.reset,
-//                customAction: { [weak self] in
-//                    self?.resetButtonTapped.send(true)
-//                },
-//                animated: true
-//            )
-//        }
-//
-//        self.logoutListItem.addTapGestureRecognizer { [weak self] in
-//            AlertUtils.presentAlertVC(
-//                type: .titleDescription,
-//                theme: .main,
-//                title: I18N.MyPage.logoutDialogTitle,
-//                description: I18N.MyPage.logoutDialogDescription,
-//                customButtonTitle: I18N.MyPage.logoutDialogGrantButtonTitle,
-//                customAction: { [weak self] in
-//                    self?.logoutButtonTapped.send()
-//                },
-//                animated: true
-//            )
-//        }
-//
-//        self.withDrawalListItem.addTapGestureRecognizer { [weak self] in
-//            self?.onWithdrawalItemTap?(self?.userType ?? .visitor)
-//        }
-//
-//        self.loginListItem.addTapGestureRecognizer { [weak self] in
-//            self?.onShowLogin?()
-//        }
-//    }
-//}
-//
-//extension AppMyPageVC {
-//    private func bindViews() {
-//        self.navigationBar
-//            .leftButtonTapped
-//            .withUnretained(self)
-//            .sink { owner, _ in
-//                owner.onNaviBackButtonTap?()
-//            }.store(in: self.cancelBag)
-//    }
-//
-//    private func bindViewModels() {
-//        let input = AppMyPageViewModel.Input(
-//            resetButtonTapped: self.resetButtonTapped.asDriver(),
-//            logoutButtonTapped: self.logoutButtonTapped.asDriver()
-//        )
-//        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
-//
-//        output.originNotificationIsAllowed
-//            .withUnretained(self)
-//            .sink { owner, isAllowed in
-//                owner.alertListItem.configureSwitch(to: isAllowed)
-//            }.store(in: self.cancelBag)
-//
-//        output.alertSettingOptInEditedResult
-//            .withUnretained(self)
-//            .sink { owner, isAllowed in
-//                owner.alertListItem.configureSwitch(to: isAllowed)
-//            }.store(in: self.cancelBag)
-//
-//        output.resetSuccessed
-//            .filter { $0 }
-//            .withUnretained(self)
-//            .sink { owenr, _ in
-//                owenr.showToast(message: I18N.MyPage.resetSuccess)
-//            }.store(in: self.cancelBag)
-//
-//        output.deregisterPushTokenSuccess
-//            .withUnretained(self)
-//            .sink { owner, success in
-//                owner.logout()
-//                owner.onShowLogin?()
-//            }.store(in: self.cancelBag)
-//    }
-//}
-//
-//extension AppMyPageVC {
-//    private func logout() {
-//        UserDefaultKeyList.Auth.appAccessToken = nil
-//        UserDefaultKeyList.Auth.appRefreshToken = nil
-//        UserDefaultKeyList.Auth.playgroundToken = nil
-//        SFSafariViewController.DataStore.default.clearWebsiteData()
-//    }
-//}
+// MARK: - Methods
+
+extension AppMyPageVC {
+    private func bindViewModels() {
+        let input = AppMyPageViewModel.Input(
+            naviBackButtonTapped: navigationBar.leftButtonTapped.asDriver(),
+            cellTapped: cellTapped.asDriver()
+        )
+        
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+        
+        output.resetSuccessed
+            .filter { $0 }
+            .withUnretained(self)
+            .sink { owner, _ in
+                Toast.show(message: I18N.MyPage.resetSuccess, view: owner.view)
+            }.store(in: self.cancelBag)
+        
+    }
+}
+
 
 // MARK: - UIGestureRecognizerDelegate
 

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/CollectionView/Item/MyPageItem.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/CollectionView/Item/MyPageItem.swift
@@ -7,9 +7,58 @@
 //
 
 import Foundation
+import Core
+
+enum MyPageItemType: Hashable {
+    /// Service Policy 섹션
+    case privacyPolicy
+    case termsOfUse
+    case sendFeedback
+    
+    /// Notification Settings 섹션
+    case setNotification
+    
+    /// Soptamp Settings 섹션
+    case editOnelineSentence
+    case resetStamp
+    
+    /// Etc User 섹션
+    case logout
+    case withdrawal
+    
+    /// Etc Visitor 섹션
+    case login
+    
+    var title: String {
+        switch self {
+        case .privacyPolicy:
+            return I18N.MyPage.ServicePolicySection.privacyPolicy
+        case .termsOfUse:
+            return I18N.MyPage.ServicePolicySection.termsOfUse
+        case .sendFeedback:
+            return I18N.MyPage.ServicePolicySection.sendFeedback
+        case .setNotification:
+            return I18N.MyPage.NotificationSection.setNotification
+        case .editOnelineSentence:
+            return I18N.MyPage.SoptampSection.editOnelineSentence
+        case .resetStamp:
+            return I18N.MyPage.SoptampSection.resetStamp
+        case .logout:
+            return I18N.MyPage.EtcSection.logout
+        case .withdrawal:
+            return I18N.MyPage.EtcSection.withdrawal
+        case .login:
+            return I18N.MyPage.EtcSection.login
+        }
+    }
+}
 
 struct MyPageItem: Hashable {
     let id = UUID()
-    let title: String
+    let type: MyPageItemType
     let hasArrow: Bool = true
+    
+    var title: String {
+        return type.title
+    }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/CollectionView/SectionLayoutKind/MyPageSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/CollectionView/SectionLayoutKind/MyPageSectionLayoutKind.swift
@@ -28,27 +28,27 @@ enum MyPageSectionLayoutKind: Int, CaseIterable {
         switch self {
         case .servicePolicy:
             return [
-                MyPageItem(title: I18N.MyPage.ServicePolicySection.privacyPolicy),
-                MyPageItem(title: I18N.MyPage.ServicePolicySection.termsOfUse),
-                MyPageItem(title: I18N.MyPage.ServicePolicySection.sendFeedback)
+                MyPageItem(type: .privacyPolicy),
+                MyPageItem(type: .termsOfUse),
+                MyPageItem(type: .sendFeedback)
             ]
         case .notificationSettings:
             return [
-                MyPageItem(title: I18N.MyPage.NotificationSection.setNotification)
+                MyPageItem(type: .setNotification)
             ]
         case .soptampSettings:
             return [
-                MyPageItem(title: I18N.MyPage.SoptampSection.editOnelineSentence),
-                MyPageItem(title: I18N.MyPage.SoptampSection.resetStamp)
+                MyPageItem(type: .editOnelineSentence),
+                MyPageItem(type: .resetStamp)
             ]
         case .etcUser:
             return [
-                MyPageItem(title: I18N.MyPage.EtcSection.logout),
-                MyPageItem(title: I18N.MyPage.EtcSection.withdrawal),
+                MyPageItem(type: .logout),
+                MyPageItem(type: .withdrawal)
             ]
         case .etcVisitor:
             return [
-                MyPageItem(title: I18N.MyPage.EtcSection.logout),
+                MyPageItem(type: .login)
             ]
         }
     }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -6,27 +6,41 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+import Foundation
 import Combine
+import SafariServices
 
 import Core
 import Domain
 import AppMyPageFeatureInterface
+import BaseFeatureDependency
 
 public final class AppMyPageViewModel: MyPageViewModelType {
+    
+    public var onNaviBackButtonTap: (() -> Void)?
+    public var onPolicyItemTap: (() -> Void)?
+    public var onTermsOfUseItemTap: (() -> Void)?
+    public var onEditOnelineSentenceItemTap: (() -> Void)?
+    public var onWithdrawalItemTap: ((Core.UserType) -> Void)?
+    public var onShowLogin: (() -> Void)?
+    public var onShowLogout: (() -> Void)?
+    public var onAlertButtonTap: ((String) -> Void)?
+    public var onResetSoptampTap: (() -> Void)?
+    
+    let userType: UserType = UserDefaultKeyList.Auth.getUserType()
     
     // MARK: - Inputs
     
     public struct Input {
-        let resetButtonTapped: Driver<Bool>
-        let logoutButtonTapped: Driver<Void>
+        let naviBackButtonTapped: Driver<Void>
+        let cellTapped: Driver<MyPageItem>
     }
     
     // MARK: - Outputs
     
     public struct Output {
         let resetSuccessed = PassthroughSubject<Bool, Never>()
-        let originNotificationIsAllowed = PassthroughSubject<Bool, Never>()
-        let alertSettingOptInEditedResult = PassthroughSubject<Bool, Never>()
         let deregisterPushTokenSuccess = PassthroughSubject<Bool, Never>()
     }
     
@@ -44,16 +58,16 @@ extension AppMyPageViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
-        input.resetButtonTapped
+        input.naviBackButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                owner.useCase.resetStamp()
+                owner.onNaviBackButtonTap?()
             }.store(in: cancelBag)
         
-        input.logoutButtonTapped
+        input.cellTapped
             .withUnretained(self)
-            .sink { owner, _ in
-                owner.useCase.deregisterPushToken()
+            .sink { owner, item in
+                owner.handleCellTap(item: item)
             }.store(in: cancelBag)
         
         return output
@@ -61,31 +75,86 @@ extension AppMyPageViewModel {
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
         self.useCase
-            .originUserNotificationIsAllowedStatus
-            .asDriver()
-            .sink { isAllowed in
-                output.originNotificationIsAllowed.send(isAllowed)
-            }.store(in: cancelBag)
-        
-        self.useCase
             .resetSuccess
             .asDriver()
             .sink { success in
-                output.resetSuccessed.send(success)
-            }.store(in: cancelBag)
-        
-        self.useCase
-            .optInPushNotificationResult
-            .asDriver()
-            .sink { isOn in
-                output.alertSettingOptInEditedResult.send(isOn)
+                if success {
+                    output.resetSuccessed.send(success)
+                } else {
+                    AlertUtils.presentNetworkAlertVC()
+                }
             }.store(in: cancelBag)
         
         self.useCase
             .deregisterPushTokenSuccess
             .asDriver()
-            .sink { success in
-                output.deregisterPushTokenSuccess.send(success)
+            .withUnretained(self)
+            .sink { owner, success in
+                if success {
+                    owner.logout()
+                    owner.onShowLogin?()
+                }
             }.store(in: cancelBag)
+    }
+    
+    private func handleCellTap(item: MyPageItem) {
+        switch item.type {
+        case .privacyPolicy:
+            self.onPolicyItemTap?()
+        case .termsOfUse:
+            self.onTermsOfUseItemTap?()
+        case .sendFeedback:
+            openExternalLink(urlStr: ExternalURL.KakaoTalk.serviceProposal)
+        case .setNotification:
+            self.onAlertButtonTap?(UIApplication.openSettingsURLString)
+        case .editOnelineSentence:
+            self.onEditOnelineSentenceItemTap?()
+        case .resetStamp:
+            self.showResetSoptampAlert()
+        case .withdrawal:
+            self.onWithdrawalItemTap?(userType)
+        case .logout:
+            self.showLogoutAlert()
+        case .login:
+            self.onShowLogin?()
+        }
+    }
+}
+
+extension AppMyPageViewModel {
+    private func logout() {
+        UserDefaultKeyList.Auth.appAccessToken = nil
+        UserDefaultKeyList.Auth.appRefreshToken = nil
+        UserDefaultKeyList.Auth.playgroundToken = nil
+        SFSafariViewController.DataStore.default.clearWebsiteData()
+    }
+    
+    private func showResetSoptampAlert() {
+        AlertUtils.presentAlertVC(
+            type: .titleDescription,
+            theme: .main,
+            title: I18N.MyPage.resetMissionTitle,
+            description: I18N.MyPage.resetMissionDescription,
+            customButtonTitle: I18N.MyPage.reset,
+            customAction: { [weak self] in
+                self?.useCase.resetStamp()
+            },
+            animated: true
+        )
+    }
+    
+    private func showLogoutAlert() {
+        AlertUtils.presentAlertVC(
+            type: .titleDescription,
+            theme: .main,
+            title: I18N.MyPage.logoutDialogTitle,
+            description: I18N.MyPage.logoutDialogDescription,
+            customButtonTitle: I18N.MyPage.logoutDialogGrantButtonTitle,
+            customAction: { [weak self] in
+                self?.useCase.deregisterPushToken()
+                self?.onShowLogout?()
+            },
+            animated: true
+        )
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageBuilder.swift
@@ -47,11 +47,11 @@ extension MyPageBuilder: MyPageFeatureBuildable {
         return withdrawalVC
     }
     
-    public func makeAppMyPage(userType: UserType) -> MyPageViewControllable {
+    public func makeAppMyPage(userType: UserType) -> LegacyMyPagePresentable {
         let useCase = DefaultAppMyPageUseCase(repository: appMyPageRepository)
         let vm = AppMyPageViewModel(useCase: useCase)
         let vc = AppMyPageVC(userType: userType, viewModel: vm)
-        return vc
+        return (vc, vm)
     }
     
     public func makeAlertSettingByFeatures() -> NotificationSettingByFeaturesViewControllable {

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -21,7 +21,7 @@ public protocol MyPageCoordinatorFinishOutput {
 public typealias DefaultMyPageCoordinator = BaseCoordinator & MyPageCoordinatorFinishOutput
 public
 final class MyPageCoordinator: DefaultMyPageCoordinator {
-        
+    
     public var finishFlow: (() -> Void)?
     public var requestCoordinating: ((MyPageCoordinatorDestination) -> Void)?
     
@@ -37,34 +37,44 @@ final class MyPageCoordinator: DefaultMyPageCoordinator {
     
     public override func start() {
         var myPage = factory.makeAppMyPage(userType: userType)
-        myPage.onNaviBackButtonTap = { [weak self] in
+        
+        myPage.vm.onNaviBackButtonTap = { [weak self] in
             self?.router.popModule()
             self?.finishFlow?()
         }
-        myPage.onShowLogin = { [weak self] in
+        
+        myPage.vm.onShowLogout = { [weak self] in
             self?.requestCoordinating?(.signIn)
         }
-        myPage.onPolicyItemTap = { [weak self] in
+        
+        myPage.vm.onShowLogin = { [weak self] in
+            self?.requestCoordinating?(.signIn)
+        }
+        
+        myPage.vm.onPolicyItemTap = { [weak self] in
             let policyVC = self?.factory.makePrivacyPolicyVC()
             self?.router.push(policyVC)
         }
-        myPage.onTermsOfUseItemTap = { [weak self] in
+        
+        myPage.vm.onTermsOfUseItemTap = { [weak self] in
             let termsVC = self?.factory.makeTermsOfServiceVC()
             self?.router.push(termsVC)
         }
-        myPage.onEditOnelineSentenceItemTap = { [weak self] in
+        
+        myPage.vm.onEditOnelineSentenceItemTap = { [weak self] in
             let sentenceEditVC = self?.factory.makeSentenceEditVC()
             self?.router.push(sentenceEditVC)
         }
-        myPage.onWithdrawalItemTap = { [weak self] userType in
+        
+        myPage.vm.onWithdrawalItemTap = { [weak self] userType in
             self?.showWithdrawal(userType: userType)
         }
         
-        myPage.onAlertButtonTap = { [weak self] url in
+        myPage.vm.onAlertButtonTap = { [weak self] url in
             self?.showAlertSetting(url: url)
         }
-
-        router.push(myPage)
+        
+        router.push(myPage.vc)
     }
     
     private func showWithdrawal(userType: UserType) {

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/SOPTampScene/VC/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/SOPTampScene/VC/SentenceEditVC.swift
@@ -76,7 +76,10 @@ extension SentenceEditVC {
         
         let saveButtonTapped = self.saveButton
             .publisher(for: .touchUpInside)
-            .compactMap { _ in self.textView.text }
+            .withUnretained(self)
+            .compactMap({ owner, _ in
+                owner.textView.text
+            })
             .filter { !$0.isEmpty }
             .asDriver()
         


### PR DESCRIPTION
## 🌴 PR 요약
- MyPageVC에 존재하는 화면전환 분리했습니다.

🌱 작업한 브랜치
- feature/#604

## 🌱 PR Point

VC에 존재하는 화면전환 책임을 VM로 위임했습니다.

### AS-IS: VC와 Coordinator가 프로토콜 의존
<img width="868" alt="image" src="https://github.com/user-attachments/assets/2686f802-2b95-47b0-b1a7-e09f95cc991b" />

- 최근 Feature과 다르게 MyPage는 화면전환 로직이 VC에 위치해 있었습니다.  
- 특히 솝탬프 리셋, 로그아웃 등 **비즈니스 로직이 함께 수반되는 화면 전환의 경우** **VC가 로직과 전환을 모두 책임지는 구조로 역할이 과도하게 비대해진다고 판단**하여 리팩토링을 진행했습니다.


### TO-BE: VM과 Coordinator가 프로토콜 의존
<img width="849" alt="image" src="https://github.com/user-attachments/assets/1f610750-6fb1-4214-832f-80ff085824e6" />

- 뷰모델에게 화면 전환의 트리거 책임을 위임하고 VC는 뷰모델과의 바인딩 책임만 가지도록 변경했습니다.
- Coordinator는 전환 실행만 담당합니다.


### 💡 고민1) 오버프로그래밍 ?
- 리팩토링 과정에서 화면 전환이 **뷰모델의 상태나 서버 통신과 무관한 경우, 뷰모델을 거치는 것이 과한 분리가 아닌가** 하는 생각이 들었습니다.
- 특히 MyPage처럼 단순 push가 많은 경우 VC에서 Coordinator로 바로 연결하는 구조가 더 적합하지 않을까 ? 라는 의문이 들었지만, 일관성과 테스트 용이성을 고려하여 모든 화면 전환 트리거는 뷰모델을 통하도록 구현했습니다.


### 💡 고민2) Alert 후 로직 실행 흐름
- Alert를 띄우고 `확인`을 눌렀을 때 비즈니스 로직이 실행되어야하는 경우가 있었습니다.
- 초기에는 Coordinator에서 Alert를 띄웠지만, 위와 같은 경우 Coordinator가 뷰모델의 내부 구현에 접근한다는 점에서 결합도가 높아진다고 판단했습니다.
- 이에 따라, 현재는 Alert 화면전환을 ViewModel에서 처리하는 방식으로 구현해두었습니다.

하지만 Alert도 단순 화면전환이기 때문에 Coordinator가 책임지는 것이 자연스럽다고 생각합니다.
그래서 아래와 같은 방식을 떠올렸는데 이에 대한 의견 부탁드립니다 ! (도와줘요 선배들아 ,, )

1. ViewModel에서 subject 변수 생성,
2. Coordinator는 Alert을 띄운 후 `확인` 버튼 클릭 시 뷰모델의 subject 이벤트 방출
3. 뷰모델에서 비즈니스 로직 처리


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- #601 에서 분기처리한 작업으로, UI PR 머지 전 해당 PR 먼저 머지하겠습니다 ! 


## 📮 관련 이슈
- Resolved: #604
