### PR TITLE
[Refactor] #567 - PokeFlow에서의 Router 의존성 제거

### DIFF
--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneCoordinator.swift
@@ -21,12 +21,12 @@ public final class DailySoptuneCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: DailySoptuneFeatureBuildable
-    private let pokeFactory: PokeFeatureBuildable
+    private let pokeFactory: LegacyPokeFeatureBuildable
     private let router: LegacyRouter
     
     private weak var rootController: UINavigationController?
     
-    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: LegacyPokeFeatureBuildable) {
         self.router = router
         self.factory = factory
         self.pokeFactory = pokeFactory

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -22,13 +22,13 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: DailySoptuneFeatureBuildable
-    private let pokeFactory: PokeFeatureBuildable
+    private let pokeFactory: LegacyPokeFeatureBuildable
     private let resultModel: DailySoptuneResultModel
     private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     private weak var viewController: UIViewController?
 
-    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: PokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
+    public init(router: LegacyRouter, factory: DailySoptuneFeatureBuildable, pokeFactory: LegacyPokeFeatureBuildable, resultModel: DailySoptuneResultModel) {
         self.router = router
         self.factory = factory
         self.pokeFactory = pokeFactory
@@ -98,7 +98,7 @@ public final class DailySoptuneResultCoordinator: DefaultCoordinator {
         guard let bottomSheet = self.pokeFactory
             .makePokeMessageTemplateBottomSheet(messageType: messageType)
             .vc
-            .viewController as? PokeMessageTemplatesViewControllable
+            .viewController as? LegacyPokeMessageTemplatesViewControllable
         else { return .empty() }
         
         let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: bottomSheet.minimumContentHeight))

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/DefaultPokeCoordinatorOutput.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/DefaultPokeCoordinatorOutput.swift
@@ -1,0 +1,15 @@
+//
+//  DefaultPokeCoordinatorOutput.swift
+//  PokeFeature
+//
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import BaseFeatureDependency
+
+public protocol DefaultPokeCoordinatorOutput {
+    func showPokeMain(isRouteFromRoot: Bool)
+}
+
+public typealias DefaultPokeCoordinator = DefaultPokeCoordinatorOutput & DefaultCoordinator

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
@@ -1,0 +1,22 @@
+//
+//  LegacyPokeFeatureBuildable.swift
+//  PokeFeatureInterface
+//
+//  Created by sejin on 12/7/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+public protocol LegacyPokeFeatureBuildable {
+    func makePokeMain(isRouteFromRoot: Bool) -> LegacyPokeMainPresentable
+    func makePokeMyFriends() -> LegacyPokeMyFriendsPresentable
+    func makePokeMyFriendsList(relation: PokeRelation) -> LegacyPokeMyFriendsListPresentable
+    func makePokeOnboarding() -> LegacyPokeOnboardingPresentable
+    func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable
+    func makePokeNotificationList() -> LegacyPokeNotificationPresentable
+    func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable
+    func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> LegacyPokeAnonymousFriendUpgradePresentable
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeAnonymousFriendUpgradePresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeAnonymousFriendUpgradePresentable.swift
@@ -6,7 +6,10 @@
 //  Copyright © 2024 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 
-public protocol PokeAnonymousFriendUpgradePresentable: LegacyViewControllable { }
+public protocol LegacyPokeAnonymousFriendUpgradePresentable: LegacyViewControllable { }
+public protocol PokeAnonymousFriendUpgradePresentable: UIViewController { }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -2,8 +2,8 @@
 //  PokeFeatureBuildable.swift
 //  PokeFeatureInterface
 //
-//  Created by sejin on 12/7/23.
-//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
 import Foundation

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -24,4 +26,6 @@ public protocol PokeMainCoordinatable {
 }
 
 public typealias PokeMainViewModelType = ViewModelType & PokeMainCoordinatable
-public typealias PokeMainPresentable = (vc: PokeMainViewControllable, vm: any PokeMainViewModelType)
+public typealias LegacyPokeMainPresentable = (vc: PokeMainViewControllable, vm: any PokeMainViewModelType)
+
+public typealias PokeMainPresentable = (vc: UIViewController, vm: any PokeMainViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
@@ -6,12 +6,18 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol PokeMessageTemplatesViewControllable: LegacyViewControllable {
+public protocol LegacyPokeMessageTemplatesViewControllable: LegacyViewControllable {
+    var minimumContentHeight: CGFloat { get }
+    
+    func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)>
+}
+public protocol PokeMessageTemplatesViewControllable: UIViewController {
     var minimumContentHeight: CGFloat { get }
     
     func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)>
@@ -22,5 +28,5 @@ public protocol PokeMessageTemplatesCoordinatable { }
 public protocol PokeMessageTemplatesViewModelType: ViewModelType & PokeMessageTemplatesCoordinatable {
     var messageType: PokeMessageType { get }
 }
+public typealias LegacyPokeMessageTemplatesPresentable = (vc: LegacyPokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesCoordinatable)
 public typealias PokeMessageTemplatesPresentable = (vc: PokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesCoordinatable)
-

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -23,4 +25,5 @@ public protocol PokeMyFriendsListViewModelType: ViewModelType & PokeMyFriendsLis
     var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)? { get set }
 }
 
-public typealias PokeMyFriendsListPresentable = (vc: PokeMyFriendsListViewControllable, vm: any PokeMyFriendsListViewModelType)
+public typealias LegacyPokeMyFriendsListPresentable = (vc: PokeMyFriendsListViewControllable, vm: any PokeMyFriendsListViewModelType)
+public typealias PokeMyFriendsListPresentable = (vc: UIViewController, vm: any PokeMyFriendsListViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -20,4 +22,6 @@ public protocol PokeMyFriendsCoordinatable {
 }
 
 public typealias PokeMyFriendsViewModelType = ViewModelType & PokeMyFriendsCoordinatable
-public typealias PokeMyFriendsPresentable = (vc: PokeMyFriendsViewControllable, vm: any PokeMyFriendsViewModelType)
+public typealias LegacyPokeMyFriendsPresentable = (vc: PokeMyFriendsViewControllable, vm: any PokeMyFriendsViewModelType)
+
+public typealias PokeMyFriendsPresentable = (vc: UIViewController, vm: any PokeMyFriendsViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -21,5 +23,6 @@ public protocol PokeNotificationCoordinatable {
 }
 
 public typealias PokeNotificationViewModelType = ViewModelType & PokeNotificationCoordinatable
-public typealias PokeNotificationPresentable = (vc: PokeNotificationViewControllable, vm: any PokeNotificationViewModelType)
+public typealias LegacyPokeNotificationPresentable = (vc: PokeNotificationViewControllable, vm: any PokeNotificationViewModelType)
 
+public typealias PokeNotificationPresentable = (vc: UIViewController, vm: any PokeNotificationViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2023 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
@@ -21,5 +21,7 @@ public protocol PokeOnboardingCoordinatable {
 }
 
 public typealias PokeOnboardingViewModelType = ViewModelType & PokeOnboardingCoordinatable
-public typealias PokeOnboardingPresentable = (vc: PokeOnboardingViewControllable, vm: any PokeOnboardingViewModelType)
+public typealias LegacyPokeOnboardingPresentable = (vc: PokeOnboardingViewControllable, vm: any PokeOnboardingViewModelType)
+
+public typealias PokeOnboardingPresentable = (vc: UIViewController, vm: any PokeOnboardingViewModelType)
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/DeepLinks/PokeNotificationListDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/DeepLinks/PokeNotificationListDeepLink.swift
@@ -17,7 +17,7 @@ public struct PokeNotificationListDeepLink: DeepLinkExecutable {
     public init() {}
     
     public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
-        guard let coordinator = coordinator as? PokeCoordinator else { return nil }
+        guard let coordinator = coordinator as? LegacyPokeCoordinator else { return nil }
         
         coordinator.runPokeNotificationListFlow()
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -1,0 +1,80 @@
+//
+//  LegacyPokeBuilder.swift
+//  PokeFeatureInterface
+//
+//  Created by sejin on 12/7/23.
+//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//
+
+import Core
+import Domain
+@_exported import PokeFeatureInterface
+
+public final class LegacyPokeBuilder {
+    @Injected public var pokeMainRepository: PokeMainRepositoryInterface
+    @Injected public var pokeMyFriendsRepository: PokeMyFriendsRepositoryInterface
+    @Injected public var pokeOnboardingRepository: PokeOnboardingRepositoryInterface
+    @Injected public var pokeNotificationListRepository: PokeNotificationRepositoryInterface
+   
+    public init() {}
+}
+
+extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
+    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.LegacyPokeMainPresentable {
+        let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
+        let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
+        let pokeMainVC = PokeMainVC(viewModel: viewModel)
+        return (pokeMainVC, viewModel)
+    }
+    
+    public func makePokeMyFriends() -> PokeFeatureInterface.LegacyPokeMyFriendsPresentable {
+        let useCase = DefaultPokeMyFriendsUseCase(repository: pokeMyFriendsRepository)
+        let viewModel = PokeMyFriendsViewModel(useCase: useCase)
+        let pokeMyFriendsVC = PokeMyFriendsVC(viewModel: viewModel)
+        
+        return (pokeMyFriendsVC, viewModel)
+    }
+    
+    public func makePokeOnboarding() -> PokeFeatureInterface.LegacyPokeOnboardingPresentable {
+        let usecase = DefaultPokeOnboardingUsecase(repository: self.pokeOnboardingRepository)
+        let viewModel = PokeOnboardingViewModel(usecase: usecase)
+        let viewController = PokeOnboardingVC(viewModel: viewModel)
+        
+        return (viewController, viewModel)
+    }
+    
+    public func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable {
+        let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
+        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
+        let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
+        
+        return (viewController, viewModel)
+    }
+    
+    public func makePokeNotificationList() -> LegacyPokeNotificationPresentable {
+        let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
+        let viewModel = PokeNotificationViewModel(usecase: usecase)
+        let viewController = PokeNotificationViewController(viewModel: viewModel)
+        
+        return (viewController, viewModel)
+    }
+    
+    public func makePokeMyFriendsList(relation: PokeRelation) -> PokeFeatureInterface.LegacyPokeMyFriendsListPresentable {
+        let useCase = DefaultPokeMyFriendsUseCase(repository: self.pokeMyFriendsRepository)
+        let viewModel = PokeMyFriendsListViewModel(relation: relation, useCase: useCase)
+        let pokeMyFriendsListVC = PokeMyFriendsListVC(viewModel: viewModel)
+        
+        return (pokeMyFriendsListVC, viewModel)
+    }
+    
+    public func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable {
+        let vc = PokeMakingFriendCompletedVC(friendName: friendName)
+        
+        return vc
+    }
+
+    public func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> LegacyPokeAnonymousFriendUpgradePresentable {
+      let vc = PokeAnonymousFriendUpgradeVC(user: user)
+      return vc
+    }
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  PokeCoordinator.swift
+//  LegacyPokeCoordinator.swift
 //  PokeFeature
 //
 //  Created by sejin on 12/7/23.
@@ -16,7 +16,7 @@ import Domain
 import WebFeature
 
 public
-final class PokeCoordinator: DefaultCoordinator {
+final class LegacyPokeCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: LegacyPokeFeatureBuildable
@@ -84,7 +84,7 @@ final class PokeCoordinator: DefaultCoordinator {
     }
     
     internal func runPokeOnboardingFlow() {
-        let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
+        let pokeOnboardingCoordinator = LegacyPokeOnboardingCoordinator(
             router: LegacyRouter(
                 rootController: rootController ?? self.router.asNavigationController
             ),
@@ -101,7 +101,7 @@ final class PokeCoordinator: DefaultCoordinator {
     }
     
     internal func runPokeNotificationListFlow() {
-        let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
+        let pokeNotificationListCoordinator = LegacyPokeNotificationListCoordinator(
             router: LegacyRouter(
                 rootController: rootController ?? self.router.asNavigationController
             ),
@@ -118,7 +118,7 @@ final class PokeCoordinator: DefaultCoordinator {
     }
     
     private func runPokeMyFriendsFlow() {
-        let pokeMyFriendsCoordinator = PokeMyFriendsCoordinator(factory: factory,
+        let pokeMyFriendsCoordinator = LegacyPokeMyFriendsCoordinator(factory: factory,
                                                                 router: LegacyRouter(rootController: rootController!))
         
         pokeMyFriendsCoordinator.finishFlow = { [weak self, weak pokeMyFriendsCoordinator] in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
@@ -16,7 +16,7 @@ import Domain
 import WebFeature
 
 public
-final class LegacyPokeCoordinator: DefaultCoordinator {
+final class LegacyPokeCoordinator: DefaultPokeCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: LegacyPokeFeatureBuildable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeMyFriendsCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  PokeMyFriendsCoordinator.swift
+//  LegacyPokeMyFriendsCoordinator.swift
 //  PokeFeature
 //
 //  Created by sejin on 12/14/23.
@@ -16,7 +16,7 @@ import PokeFeatureInterface
 import WebFeature
 
 public
-final class PokeMyFriendsCoordinator: DefaultCoordinator {
+final class LegacyPokeMyFriendsCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: LegacyPokeFeatureBuildable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  PokeNotificationListCoordinator.swift
+//  LegacyPokeNotificationListCoordinator.swift
 //  PokeFeature
 //
 //  Created by Ian on 12/23/23.
@@ -14,7 +14,7 @@ import BaseFeatureDependency
 import PokeFeatureInterface
 import WebFeature
 
-public final class PokeNotificationListCoordinator: DefaultCoordinator {
+public final class LegacyPokeNotificationListCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let router: LegacyRouter
@@ -31,7 +31,7 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
     }
 }
 
-extension PokeNotificationListCoordinator {
+extension LegacyPokeNotificationListCoordinator {
     private func showPokeNotificationListView() {
         var pokeNotiListVC = self.factory.makePokeNotificationList()
                     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeOnboardingCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  PokeOnboardingCoordinator.swift
+//  LegacyPokeOnboardingCoordinator.swift
 //  PokeFeatureInterface
 //
 //  Created by Ian on 12/22/23.
@@ -14,7 +14,7 @@ import BaseFeatureDependency
 import PokeFeatureInterface
 import WebFeature
 
-public final class PokeOnboardingCoordinator: DefaultCoordinator {
+public final class LegacyPokeOnboardingCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let router: LegacyRouter
@@ -31,7 +31,7 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
     }
 }
 
-extension PokeOnboardingCoordinator {
+extension LegacyPokeOnboardingCoordinator {
     private func showPokeOnboardingView() {
         let pokeOnboarding = makePokeOnboardingView()
                 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -2,8 +2,8 @@
 //  PokeBuilder.swift
 //  PokeFeatureInterface
 //
-//  Created by sejin on 12/7/23.
-//  Copyright © 2023 SOPT-iOS. All rights reserved.
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
 import Core
@@ -19,23 +19,8 @@ public final class PokeBuilder {
     public init() {}
 }
 
-extension PokeBuilder: LegacyPokeFeatureBuildable {
-    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.LegacyPokeMainPresentable {
-        let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
-        let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
-        let pokeMainVC = PokeMainVC(viewModel: viewModel)
-        return (pokeMainVC, viewModel)
-    }
-    
-    public func makePokeMyFriends() -> PokeFeatureInterface.LegacyPokeMyFriendsPresentable {
-        let useCase = DefaultPokeMyFriendsUseCase(repository: pokeMyFriendsRepository)
-        let viewModel = PokeMyFriendsViewModel(useCase: useCase)
-        let pokeMyFriendsVC = PokeMyFriendsVC(viewModel: viewModel)
-        
-        return (pokeMyFriendsVC, viewModel)
-    }
-    
-    public func makePokeOnboarding() -> PokeFeatureInterface.LegacyPokeOnboardingPresentable {
+extension PokeBuilder: PokeFeatureBuildable {
+    public func makePokeOnboarding() -> PokeFeatureInterface.PokeOnboardingPresentable {
         let usecase = DefaultPokeOnboardingUsecase(repository: self.pokeOnboardingRepository)
         let viewModel = PokeOnboardingViewModel(usecase: usecase)
         let viewController = PokeOnboardingVC(viewModel: viewModel)
@@ -43,23 +28,23 @@ extension PokeBuilder: LegacyPokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable {
-        let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
-        let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
+    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.PokeMainPresentable {
+        let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
+        let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
+        let pokeMainVC = PokeMainVC(viewModel: viewModel)
         
-        return (viewController, viewModel)
+        return (pokeMainVC, viewModel)
     }
     
-    public func makePokeNotificationList() -> LegacyPokeNotificationPresentable {
-        let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
-        let viewModel = PokeNotificationViewModel(usecase: usecase)
-        let viewController = PokeNotificationViewController(viewModel: viewModel)
+    public func makePokeMyFriends() -> PokeFeatureInterface.PokeMyFriendsPresentable {
+        let useCase = DefaultPokeMyFriendsUseCase(repository: pokeMyFriendsRepository)
+        let viewModel = PokeMyFriendsViewModel(useCase: useCase)
+        let pokeMyFriendsVC = PokeMyFriendsVC(viewModel: viewModel)
         
-        return (viewController, viewModel)
+        return (pokeMyFriendsVC, viewModel)
     }
     
-    public func makePokeMyFriendsList(relation: PokeRelation) -> PokeFeatureInterface.LegacyPokeMyFriendsListPresentable {
+    public func makePokeMyFriendsList(relation: PokeFeatureInterface.PokeRelation) -> PokeFeatureInterface.PokeMyFriendsListPresentable {
         let useCase = DefaultPokeMyFriendsUseCase(repository: self.pokeMyFriendsRepository)
         let viewModel = PokeMyFriendsListViewModel(relation: relation, useCase: useCase)
         let pokeMyFriendsListVC = PokeMyFriendsListVC(viewModel: viewModel)
@@ -67,14 +52,30 @@ extension PokeBuilder: LegacyPokeFeatureBuildable {
         return (pokeMyFriendsListVC, viewModel)
     }
     
-    public func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable {
+    public func makePokeMessageTemplateBottomSheet(messageType: Domain.PokeMessageType) -> PokeFeatureInterface.PokeMessageTemplatesPresentable {
+        let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
+        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
+        let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
+        
+        return (viewController, viewModel)
+    }
+    
+    public func makePokeNotificationList() -> PokeFeatureInterface.PokeNotificationPresentable {
+        let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
+        let viewModel = PokeNotificationViewModel(usecase: usecase)
+        let viewController = PokeNotificationViewController(viewModel: viewModel)
+        
+        return (viewController, viewModel)
+    }
+    
+    public func makePokeMakingFriendCompleted(friendName: String) -> any PokeFeatureInterface.PokeMakingFriendCompletedPresentable {
         let vc = PokeMakingFriendCompletedVC(friendName: friendName)
         
         return vc
     }
-
-    public func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> LegacyPokeAnonymousFriendUpgradePresentable {
-      let vc = PokeAnonymousFriendUpgradeVC(user: user)
-      return vc
+    
+    public func makePokeAnonymousFriendUpgrade(user: Domain.PokeUserModel) -> any PokeFeatureInterface.PokeAnonymousFriendUpgradePresentable {
+        let vc = PokeAnonymousFriendUpgradeVC(user: user)
+        return vc
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -19,15 +19,15 @@ public final class PokeBuilder {
     public init() {}
 }
 
-extension PokeBuilder: PokeFeatureBuildable {
-    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.PokeMainPresentable {
+extension PokeBuilder: LegacyPokeFeatureBuildable {
+    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.LegacyPokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
         let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
         let pokeMainVC = PokeMainVC(viewModel: viewModel)
         return (pokeMainVC, viewModel)
     }
     
-    public func makePokeMyFriends() -> PokeFeatureInterface.PokeMyFriendsPresentable {
+    public func makePokeMyFriends() -> PokeFeatureInterface.LegacyPokeMyFriendsPresentable {
         let useCase = DefaultPokeMyFriendsUseCase(repository: pokeMyFriendsRepository)
         let viewModel = PokeMyFriendsViewModel(useCase: useCase)
         let pokeMyFriendsVC = PokeMyFriendsVC(viewModel: viewModel)
@@ -35,7 +35,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (pokeMyFriendsVC, viewModel)
     }
     
-    public func makePokeOnboarding() -> PokeFeatureInterface.PokeOnboardingPresentable {
+    public func makePokeOnboarding() -> PokeFeatureInterface.LegacyPokeOnboardingPresentable {
         let usecase = DefaultPokeOnboardingUsecase(repository: self.pokeOnboardingRepository)
         let viewModel = PokeOnboardingViewModel(usecase: usecase)
         let viewController = PokeOnboardingVC(viewModel: viewModel)
@@ -43,7 +43,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable {
+    public func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable {
         let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
         let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
         let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
@@ -51,7 +51,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeNotificationList() -> PokeNotificationPresentable {
+    public func makePokeNotificationList() -> LegacyPokeNotificationPresentable {
         let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
         let viewModel = PokeNotificationViewModel(usecase: usecase)
         let viewController = PokeNotificationViewController(viewModel: viewModel)
@@ -59,7 +59,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMyFriendsList(relation: PokeRelation) -> PokeFeatureInterface.PokeMyFriendsListPresentable {
+    public func makePokeMyFriendsList(relation: PokeRelation) -> PokeFeatureInterface.LegacyPokeMyFriendsListPresentable {
         let useCase = DefaultPokeMyFriendsUseCase(repository: self.pokeMyFriendsRepository)
         let viewModel = PokeMyFriendsListViewModel(relation: relation, useCase: useCase)
         let pokeMyFriendsListVC = PokeMyFriendsListVC(viewModel: viewModel)
@@ -73,7 +73,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         return vc
     }
 
-    public func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> PokeAnonymousFriendUpgradePresentable {
+    public func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> LegacyPokeAnonymousFriendUpgradePresentable {
       let vc = PokeAnonymousFriendUpgradeVC(user: user)
       return vc
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -1,0 +1,161 @@
+//
+//  PokeCoordinator.swift
+//  PokeFeature
+//
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import Domain
+import BaseFeatureDependency
+import PokeFeatureInterface
+import WebFeature
+
+public final class PokeCoordinator: DefaultPokeCoordinator {
+    
+    // MARK: - Properties
+    
+    public var finishFlow: (() -> Void)?
+    
+    private let factory: PokeFeatureBuildable
+    private let navigationController: UINavigationController
+    private weak var rootController: UINavigationController?
+    
+    // MARK: - Init
+    
+    public init(
+        navigationController: UINavigationController,
+        factory: PokeFeatureBuildable
+    ) {
+        self.navigationController = navigationController
+        self.factory = factory
+    }
+    
+    // MARK: - Coordinator Life Cycle
+    
+    public override func start() {
+        showPokeMain(isRouteFromRoot: false)
+    }
+    
+    // MARK: - Navigation
+    
+    public func showPokeMain(isRouteFromRoot: Bool) {
+        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot)
+        
+        pokeMain.vm.onNaviBackTap = { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+            self?.finishFlow?()
+        }
+        
+        pokeMain.vm.onPokeNotificationsTap = { [weak self] in
+            self?.runPokeNotificationListFlow()
+        }
+        
+        pokeMain.vm.onMyFriendsTap = { [weak self] in
+            self?.runPokeMyFriendsFlow()
+        }
+        
+        pokeMain.vm.onProfileImageTapped = { [weak self] playgroundId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.rootController?.pushViewController(webView, animated: true)
+        }
+        
+        pokeMain.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let self else { return .empty() }
+            return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
+        }
+        
+        pokeMain.vm.onNewFriendMade = { [weak self] friendName in
+            guard let self else { return }
+            let pokeMakingFriendCompletedVC = self.factory.makePokeMakingFriendCompleted(friendName: friendName).viewController
+            pokeMakingFriendCompletedVC.modalPresentationStyle = .overFullScreen
+            self.rootController?.present(pokeMakingFriendCompletedVC, animated: false)
+        }
+
+        pokeMain.vm.onAnonymousFriendUpgrade = { [weak self] user in
+            guard let self else { return }
+            let pokeAnonymousFriendUpgradeVC = self.factory.makePokeAnonymousFriendUpgrade(user: user).viewController
+            pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
+            self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
+        }
+
+        pokeMain.vm.switchToOnboarding = { [weak self] in
+            guard let self = self else { return }
+            self.runPokeOnboardingFlow()
+        }
+        
+        let navController = UINavigationController(rootViewController: pokeMain.vc)
+        navController.modalPresentationStyle = .overFullScreen
+        rootController = navController
+        navigationController.present(navController, animated: true)
+    }
+    
+    internal func runPokeOnboardingFlow() {
+        let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
+            navigationController: rootController ?? navigationController,
+            factory: factory
+        )
+        
+        pokeOnboardingCoordinator.finishFlow = { [weak self, weak pokeOnboardingCoordinator] in
+            pokeOnboardingCoordinator?.childCoordinators = []
+            self?.removeDependency(pokeOnboardingCoordinator)
+        }
+        
+        addDependency(pokeOnboardingCoordinator)
+        pokeOnboardingCoordinator.start()
+    }
+    
+    internal func runPokeNotificationListFlow() {
+        let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
+            navigationController: rootController ?? navigationController,
+            factory: factory
+        )
+        
+        pokeNotificationListCoordinator.finishFlow = { [weak self, weak pokeNotificationListCoordinator] in
+            pokeNotificationListCoordinator?.childCoordinators = []
+            self?.removeDependency(pokeNotificationListCoordinator)
+        }
+        
+        addDependency(pokeNotificationListCoordinator)
+        pokeNotificationListCoordinator.start()
+    }
+    
+    private func runPokeMyFriendsFlow() {
+        let pokeMyFriendsCoordinator = PokeMyFriendsCoordinator(
+            navigationController: rootController ?? navigationController,
+            factory: factory
+        )
+        
+        pokeMyFriendsCoordinator.finishFlow = { [weak self, weak pokeMyFriendsCoordinator] in
+            self?.removeDependency(pokeMyFriendsCoordinator)
+        }
+        
+        addDependency(pokeMyFriendsCoordinator)
+        pokeMyFriendsCoordinator.start()
+    }
+    
+    private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
+        let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
+
+        guard let bottomSheet = self.factory
+            .makePokeMessageTemplateBottomSheet(messageType: messageType)
+                .vc
+                .viewController as? PokeMessageTemplateBottomSheet
+        else { return .empty() }
+        
+        let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
+        
+        bottomSheetManager.present(toPresent: bottomSheet, on: view)
+        
+        return bottomSheet
+            .signalForClick()
+            .map { (userModel, $0, $1) }
+            .asDriver()
+    }
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -19,11 +19,11 @@ public
 final class PokeCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
-    private let factory: PokeFeatureBuildable
+    private let factory: LegacyPokeFeatureBuildable
     private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     
-    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: LegacyPokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
@@ -19,11 +19,11 @@ public
 final class PokeMyFriendsCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
-    private let factory: PokeFeatureBuildable
+    private let factory: LegacyPokeFeatureBuildable
     private let router: LegacyRouter
     private weak var rootController: UINavigationController?
     
-    public init(factory: PokeFeatureBuildable, router: LegacyRouter) {
+    public init(factory: LegacyPokeFeatureBuildable, router: LegacyRouter) {
         self.factory = factory
         self.router = router
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
@@ -1,0 +1,122 @@
+//
+//  PokeMyFriendsCoordinator.swift
+//  PokeFeature
+//
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import Domain
+import BaseFeatureDependency
+import PokeFeatureInterface
+import WebFeature
+
+public final class PokeMyFriendsCoordinator: DefaultCoordinator {
+    
+    // MARK: - Properties
+    
+    public var finishFlow: (() -> Void)?
+    
+    private let factory: PokeFeatureBuildable
+    private let navigationController: UINavigationController
+    private weak var rootController: UINavigationController?
+    
+    // MARK: - Init
+    
+    public init(
+        navigationController: UINavigationController,
+        factory: PokeFeatureBuildable
+    ) {
+        self.navigationController = navigationController
+        self.factory = factory
+    }
+    
+    // MARK: - Coordinator Life Cycle
+    
+    public override func start() {
+        showPokeMyFriends()
+    }
+    
+    // MARK: - Navigation
+    
+    private func showPokeMyFriends() {
+        var pokeMyFriends = factory.makePokeMyFriends()
+        
+        pokeMyFriends.vm.showFriendsListButtonTap = { [weak self] relation in
+            self?.showPokeMyFriendsList(with: relation)
+        }
+        
+        pokeMyFriends.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let self else { return .empty() }
+            return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
+        }
+        
+        pokeMyFriends.vm.onProfileImageTapped = { [weak self] playgroundId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.navigationController.pushViewController(webView, animated: true)
+        }
+        
+        pokeMyFriends.vm.onAnonymousFriendUpgrade = { [weak self] user in
+            guard let self else { return }
+            let pokeAnonymousFriendUpgradeVC = self.factory.makePokeAnonymousFriendUpgrade(user: user).viewController
+            pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
+            self.navigationController.present(pokeAnonymousFriendUpgradeVC, animated: false)
+        }
+        
+        navigationController.pushViewController(pokeMyFriends.vc, animated: true)
+    }
+    
+    private func showPokeMyFriendsList(with relation: PokeRelation) {
+        var pokeMyFriendsList = factory.makePokeMyFriendsList(relation: relation)
+        
+        pokeMyFriendsList.vm.onCloseButtonTap = { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        }
+        
+        pokeMyFriendsList.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let self else { return .empty() }
+            return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
+        }
+        
+        pokeMyFriendsList.vm.onProfileImageTapped = { [weak self] playgroundId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.rootController?.pushViewController(webView, animated: true)
+        }
+        
+        pokeMyFriendsList.vm.onAnonymousFriendUpgrade = { [weak self] user in
+            guard let self else { return }
+            let pokeAnonymousFriendUpgradeVC = self.factory.makePokeAnonymousFriendUpgrade(user: user).viewController
+            pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
+            self.navigationController.present(pokeAnonymousFriendUpgradeVC, animated: false)
+        }
+        
+        let navController = UINavigationController(rootViewController: pokeMyFriendsList.vc)
+        rootController = navController
+        navigationController.present(navController, animated: true)
+    }
+    
+    private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
+        guard let bottomSheet = self.factory
+            .makePokeMessageTemplateBottomSheet(messageType: .pokeFriend)
+            .vc
+            .viewController as? PokeMessageTemplateBottomSheet
+        else { return .empty() }
+        
+        let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
+        
+        bottomSheetManager.present(toPresent: bottomSheet, on: view)
+        
+        return bottomSheet
+            .signalForClick()
+            .map { (userModel, $0, $1) }
+            .asDriver()
+    }
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -1,0 +1,97 @@
+//
+//  PokeNotificationListCoordinator.swift
+//  PokeFeature
+//
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import Domain
+import BaseFeatureDependency
+import PokeFeatureInterface
+import WebFeature
+
+public final class PokeNotificationListCoordinator: DefaultCoordinator {
+    
+    // MARK: - Properties
+    
+    public var finishFlow: (() -> Void)?
+    
+    private let factory: PokeFeatureBuildable
+    private let navigationController: UINavigationController
+    private weak var rootController: UINavigationController?
+    
+    // MARK: - Init
+    
+    public init(
+        navigationController: UINavigationController,
+        factory: PokeFeatureBuildable
+    ) {
+        self.navigationController = navigationController
+        self.factory = factory
+    }
+    
+    // MARK: - Coordinator Life Cycle
+    
+    public override func start() {
+        showPokeNotificationListView()
+    }
+    
+    // MARK: - Navigation
+    
+    private func showPokeNotificationListView() {
+        var pokeNotiListVC = factory.makePokeNotificationList()
+        
+        pokeNotiListVC.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let bottomSheet = self?.factory
+                .makePokeMessageTemplateBottomSheet(messageType: userModel.isFirstMeet ? .pokeSomeone : .pokeFriend)
+                    .vc
+                    .viewController as? PokeMessageTemplateBottomSheet
+            else { return .empty() }
+            
+            let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
+            bottomSheetManager.present(toPresent: bottomSheet, on: self?.rootController)
+            
+            return bottomSheet
+                .signalForClick()
+                .map { (userModel, $0, $1) }
+                .asDriver()
+        }
+        
+        pokeNotiListVC.vm.onNewFriendAdded = { [weak self] friendName in
+            guard let self else { return }
+            
+            let pokeMakingFriendCompletedVC = self.factory.makePokeMakingFriendCompleted(friendName: friendName).viewController
+            pokeMakingFriendCompletedVC.modalPresentationStyle = .overFullScreen
+            self.rootController?.present(pokeMakingFriendCompletedVC, animated: false)
+        }
+
+        pokeNotiListVC.vm.onAnonymousFriendUpgrade = { [weak self] user in
+            guard let self else { return }
+            let pokeAnonymousFriendUpgradeVC = self.factory.makePokeAnonymousFriendUpgrade(user: user).viewController
+            pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
+            self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
+        }
+
+        pokeNotiListVC.vm.onProfileImageTapped = { [weak self] playgroundId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.navigationController.pushViewController(webView, animated: true)
+        }
+        
+        let navController = UINavigationController(rootViewController: pokeNotiListVC.vc)
+        rootController = navController
+        
+        var willAnimate = true
+        if let top = navigationController.topViewController, type(of: top) == type(of: pokeNotiListVC.vc) {
+            willAnimate = false
+            navigationController.popViewController(animated: false)
+        }
+        
+        navigationController.pushViewController(pokeNotiListVC.vc, animated: willAnimate)
+    }
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -18,10 +18,10 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let router: LegacyRouter
-    private let factory: PokeFeatureBuildable
+    private let factory: LegacyPokeFeatureBuildable
     private weak var rootController: UINavigationController?
     
-    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: LegacyPokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -18,10 +18,10 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let router: LegacyRouter
-    private let factory: PokeFeatureBuildable
+    private let factory: LegacyPokeFeatureBuildable
     private weak var rootController: UINavigationController?
     
-    public init(router: LegacyRouter, factory: PokeFeatureBuildable) {
+    public init(router: LegacyRouter, factory: LegacyPokeFeatureBuildable) {
         self.router = router
         self.factory = factory
     }
@@ -39,7 +39,7 @@ extension PokeOnboardingCoordinator {
         self.router.present(self.rootController, animated: true, modalPresentationSytle: .overFullScreen)
     }
     
-    func makePokeOnboardingView() -> PokeOnboardingPresentable {
+    func makePokeOnboardingView() -> LegacyPokeOnboardingPresentable {
         var pokeOnboarding = self.factory.makePokeOnboarding()
         
         pokeOnboarding.vm.onNaviBackTapped = { [weak self] in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -1,0 +1,92 @@
+//
+//  PokeOnboardingCoordinator.swift
+//  PokeFeature
+//
+//  Created by Jae Hyun Lee on 6/3/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import Domain
+import BaseFeatureDependency
+import PokeFeatureInterface
+import WebFeature
+
+public final class PokeOnboardingCoordinator: DefaultCoordinator {
+    
+    // MARK: - Properties
+    
+    public var finishFlow: (() -> Void)?
+    
+    private let factory: PokeFeatureBuildable
+    private let navigationController: UINavigationController
+    private weak var rootController: UINavigationController?
+    
+    // MARK: - Init
+    
+    public init(
+        navigationController: UINavigationController,
+        factory: PokeFeatureBuildable
+    ) {
+        self.navigationController = navigationController
+        self.factory = factory
+    }
+    
+    // MARK: - Coordinator Life Cycle
+    
+    public override func start() {
+        showPokeOnboardingView()
+    }
+    
+    // MARK: - Navigation
+    
+    private func showPokeOnboardingView() {
+        let pokeOnboarding = makePokeOnboardingView()
+        
+        let navController = UINavigationController(rootViewController: pokeOnboarding.vc)
+        rootController = navController
+        navigationController.present(navController, animated: true)
+    }
+    
+    private func makePokeOnboardingView() -> PokeOnboardingPresentable {
+        var pokeOnboarding = factory.makePokeOnboarding()
+        
+        pokeOnboarding.vm.onNaviBackTapped = { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+            self?.finishFlow?()
+        }
+        
+        pokeOnboarding.vm.onFirstVisitInOnboarding = { [weak self] in
+            let viewController = PokeOnboardingBottomSheet()
+            let bottomSheetManager = BottomSheetManager(configuration: .onboarding(minHeight: PokeOnboardingBottomSheet.minHeight))
+            bottomSheetManager.present(toPresent: viewController, on: self?.rootController)
+        }
+        
+        pokeOnboarding.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let bottomSheet = self?.factory
+                .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone)
+                    .vc
+                    .viewController as? PokeMessageTemplateBottomSheet
+            else { return .empty() }
+            
+            let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
+            bottomSheetManager.present(toPresent: bottomSheet, on: self?.rootController)
+            
+            return bottomSheet
+                .signalForClick()
+                .map { (userModel, $0, $1) }
+                .asDriver()
+        }
+        
+        pokeOnboarding.vm.onAvartarTapped = { [weak self] memberId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(memberId)") else { return }
+            
+            let webView = SOPTWebView(startWith: url)
+            self?.rootController?.pushViewController(webView, animated: true)
+        }
+        
+        return pokeOnboarding
+    }
+}

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMakingFriendCompletedScene/VC/PokeAnonymousFriendUpgradeVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMakingFriendCompletedScene/VC/PokeAnonymousFriendUpgradeVC.swift
@@ -20,7 +20,7 @@ import Domain
 import PokeFeatureInterface
 import BaseFeatureDependency
 
-public class PokeAnonymousFriendUpgradeVC: UIViewController, PokeAnonymousFriendUpgradePresentable  {
+public class PokeAnonymousFriendUpgradeVC: UIViewController, LegacyPokeAnonymousFriendUpgradePresentable, PokeAnonymousFriendUpgradePresentable  {
 
   // MARK: - Properties
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -14,7 +14,7 @@ import Core
 import DSKit
 import Domain
 
-public final class PokeMessageTemplateBottomSheet: UIViewController, PokeMessageTemplatesViewControllable {
+public final class PokeMessageTemplateBottomSheet: UIViewController, LegacyPokeMessageTemplatesViewControllable, PokeMessageTemplatesViewControllable {
     
   public var minimumContentHeight: CGFloat {
      return PokeMessageTemplateBottomSheet.minimumContentHeight

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -535,12 +535,22 @@ extension ApplicationCoordinator {
     }
     
     @discardableResult
-    internal func makePokeCoordinator() -> LegacyPokeCoordinator {
-        let coordinator = LegacyPokeCoordinator(
-            router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
-            factory: LegacyPokeBuilder()
-        )
+    internal func makePokeCoordinator() -> DefaultPokeCoordinator {
+        var coordinator: DefaultPokeCoordinator
         
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator = LegacyPokeCoordinator(
+                router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
+                factory: LegacyPokeBuilder()
+            )
+        case .new:
+            coordinator = PokeCoordinator(
+                navigationController: UIWindow.getRootNavigationController,
+                factory: PokeBuilder()
+            )
+        }
+
         coordinator.finishFlow = { [weak self, weak coordinator] in
             coordinator?.childCoordinators = []
             self?.removeDependency(coordinator)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -520,7 +520,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runPokeFlow() -> PokeCoordinator {
+    internal func runPokeFlow() -> LegacyPokeCoordinator {
         let coordinator = makePokeCoordinator()
         
         addDependency(coordinator)
@@ -535,8 +535,8 @@ extension ApplicationCoordinator {
     }
     
     @discardableResult
-    internal func makePokeCoordinator() -> PokeCoordinator {
-        let coordinator = PokeCoordinator(
+    internal func makePokeCoordinator() -> LegacyPokeCoordinator {
+        let coordinator = LegacyPokeCoordinator(
             router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
             factory: LegacyPokeBuilder()
         )
@@ -552,8 +552,8 @@ extension ApplicationCoordinator {
     }
     
     @discardableResult
-    internal func runPokeOnboardingFlow() -> PokeOnboardingCoordinator {
-        let coordinator = PokeOnboardingCoordinator(
+    internal func runPokeOnboardingFlow() -> LegacyPokeOnboardingCoordinator {
+        let coordinator = LegacyPokeOnboardingCoordinator(
             router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
@@ -570,8 +570,8 @@ extension ApplicationCoordinator {
         return coordinator
     }
     
-    internal func runPokeNotificationListFlow() -> PokeNotificationListCoordinator {
-        let coordinator = PokeNotificationListCoordinator(
+    internal func runPokeNotificationListFlow() -> LegacyPokeNotificationListCoordinator {
+        let coordinator = LegacyPokeNotificationListCoordinator(
             router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -538,7 +538,7 @@ extension ApplicationCoordinator {
     internal func makePokeCoordinator() -> PokeCoordinator {
         let coordinator = PokeCoordinator(
             router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
-            factory: PokeBuilder()
+            factory: LegacyPokeBuilder()
         )
         
         coordinator.finishFlow = { [weak self, weak coordinator] in
@@ -557,7 +557,7 @@ extension ApplicationCoordinator {
             router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
-            factory: PokeBuilder()
+            factory: LegacyPokeBuilder()
         )
         coordinator.finishFlow = { [weak self, weak coordinator] in
             coordinator?.childCoordinators = []
@@ -575,7 +575,7 @@ extension ApplicationCoordinator {
             router: LegacyRouter(
                 rootController: UIWindow.getRootNavigationController
             ),
-            factory: PokeBuilder()
+            factory: LegacyPokeBuilder()
         )
         
         coordinator.finishFlow = { [weak self, weak coordinator] in
@@ -677,7 +677,7 @@ extension ApplicationCoordinator {
                 rootController: UIWindow.getRootNavigationController
             ),
             factory: DailySoptuneBuilder(),
-            pokeFactory: PokeBuilder()
+            pokeFactory: LegacyPokeBuilder()
         )
         coordinator.finishFlow = { [weak self, weak coordinator] in
             coordinator?.childCoordinators = []

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -520,8 +520,8 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runPokeFlow() -> LegacyPokeCoordinator {
-        let coordinator = makePokeCoordinator()
+    internal func runPokeFlow() -> DefaultCoordinator {
+        var coordinator = makePokeCoordinator()
         
         addDependency(coordinator)
         coordinator.start()
@@ -562,13 +562,24 @@ extension ApplicationCoordinator {
     }
     
     @discardableResult
-    internal func runPokeOnboardingFlow() -> LegacyPokeOnboardingCoordinator {
-        let coordinator = LegacyPokeOnboardingCoordinator(
-            router: LegacyRouter(
-                rootController: UIWindow.getRootNavigationController
-            ),
-            factory: LegacyPokeBuilder()
-        )
+    internal func runPokeOnboardingFlow() -> DefaultCoordinator {
+        var coordinator: DefaultCoordinator
+        
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator = LegacyPokeOnboardingCoordinator(
+                router: LegacyRouter(
+                    rootController: UIWindow.getRootNavigationController
+                ),
+                factory: LegacyPokeBuilder()
+            )
+        case .new:
+            coordinator = PokeOnboardingCoordinator(
+                navigationController: UIWindow.getRootNavigationController,
+                factory: PokeBuilder()
+            )
+        }
+
         coordinator.finishFlow = { [weak self, weak coordinator] in
             coordinator?.childCoordinators = []
             self?.removeDependency(coordinator)
@@ -580,14 +591,24 @@ extension ApplicationCoordinator {
         return coordinator
     }
     
-    internal func runPokeNotificationListFlow() -> LegacyPokeNotificationListCoordinator {
-        let coordinator = LegacyPokeNotificationListCoordinator(
-            router: LegacyRouter(
-                rootController: UIWindow.getRootNavigationController
-            ),
-            factory: LegacyPokeBuilder()
-        )
+    internal func runPokeNotificationListFlow() -> DefaultCoordinator {
+        var coordinator: DefaultCoordinator
         
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator = LegacyPokeNotificationListCoordinator(
+                router: LegacyRouter(
+                    rootController: UIWindow.getRootNavigationController
+                ),
+                factory: LegacyPokeBuilder()
+            )
+        case .new:
+            coordinator = PokeNotificationListCoordinator(
+                navigationController: UIWindow.getRootNavigationController,
+                factory: PokeBuilder()
+            )
+        }
+
         coordinator.finishFlow = { [weak self, weak coordinator] in
             coordinator?.childCoordinators = []
             self?.removeDependency(coordinator)


### PR DESCRIPTION
## 🌴 PR 요약

**PokeFlow에서의 Router 의존성을 제거**했습니다.

🌱 작업한 브랜치
- #567 

## 🌱 PR Point

생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

PokeCoordinator에서 showPokeMain 메서드를 공통 인터페이스로 분리했어요.

```swift
import BaseFeatureDependency

public protocol DefaultPokeCoordinatorOutput {
    func showPokeMain(isRouteFromRoot: Bool)
}

public typealias DefaultPokeCoordinator = DefaultPokeCoordinatorOutput & DefaultCoordinator
```

- `showPokeMain` 함수를 정의한 `DefaultPokeCoordinatorOutput` 프로토콜을 생성하고,
- `DefaultPokeCoordinatorOutput`과 `DefaultCoordinator`를 결합한 `DefaultPokeCoordinator`를 typealias로 정의하여
- `LegacyPokeCoordinator`와 `PokeCoordinator`가 이를 채택하도록 변경했는데요.
![스크린샷 2025-06-05 오후 11 42 56](https://github.com/user-attachments/assets/fa58bc69-bf7c-40bc-bb32-307b40b23f96)
+) 그 이유는 `PokeDeepLink`에서 `showPokeMain`을 사용하고 있기에, 레거시와 리팩 pokeCoordinator에서 해당 함수를 공통 인터페이스로 묶어야 할 필요성이 있기 때문입니닷!


## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #567 
