### PR TITLE
[Refactor] #609 - 솝탬프의 파트별 랭킹/개인 랭킹 뷰 메모리 누수 방지

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -109,6 +109,7 @@ public struct I18N {
     
     public struct RankingList {
         public static let noSentenceText = "설정된 한 마디가 없습니다."
+        public static let rankingForPartTitle = "파트별 랭킹"
     }
     
     public struct ListDetail {

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -110,6 +110,7 @@ public struct I18N {
     public struct RankingList {
         public static let noSentenceText = "설정된 한 마디가 없습니다."
         public static let rankingForPartTitle = "파트별 랭킹"
+        public static let myRanking = "내 랭킹 보기"
     }
     
     public struct ListDetail {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -135,7 +135,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable {
         bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .highlighted)
         bt.tintColor = .white
         bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: "파트별 랭킹")
+        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.rankingForPartTitle)
         let style = NSMutableParagraphStyle()
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/RankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/RankingChartCVC.swift
@@ -148,10 +148,11 @@ extension RankingChartCVC {
           
           chartRectangle
             .signalForClickUserName()
-            .sink(receiveValue: {
-              self.usernameTapped?(chartRectangleModel[index])
+            .withUnretained(self)
+            .sink(receiveValue: { owner, _ in
+                owner.usernameTapped?(chartRectangleModel[index])
             }).store(in: self.cancelBag)
-          
+            
             chartRectangle.setData(score: chartRectangleModel[index].score,
                                    username: chartRectangleModel[index].username)
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/RankingListCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/RankingListCVC.swift
@@ -145,7 +145,7 @@ extension RankingListCVC {
 
 extension RankingListCVC: RankingListTappable {
     func getModelItem() -> RankingListTapItem? {
-        guard let model = model else { return nil }
+        guard let model else { return nil }
         return RankingListTapItem.init(username: model.username,
                                        sentence: model.sentence)
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/PartRankingCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/PartRankingCompositionalLayout.swift
@@ -13,9 +13,10 @@ extension PartRankingVC {
 
     func createLayout() -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            guard let self else { return nil }
             switch RankingSection.type(sectionIndex) {
-            case .chart: return self?.createChartSection()
-            case .list: return self?.createListSection()
+            case .chart: return self.createChartSection()
+            case .list: return self.createListSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/PartRankingCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/PartRankingCompositionalLayout.swift
@@ -12,10 +12,10 @@ extension PartRankingVC {
     static let standardWidth = UIScreen.main.bounds.width - 40.adjusted
 
     func createLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
             switch RankingSection.type(sectionIndex) {
-            case .chart: return self.createChartSection()
-            case .list: return self.createListSection()
+            case .chart: return self?.createChartSection()
+            case .list: return self?.createListSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/RankingCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/RankingCompositionalLayout.swift
@@ -12,7 +12,8 @@ extension RankingVC {
     static let standardWidth = UIScreen.main.bounds.width - 40.adjusted
     
     func createLayout() -> UICollectionViewLayout {
-        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            guard let self else { return nil }
             switch RankingSection.type(sectionIndex) {
             case .chart: return self.createChartSection()
             case .list: return self.createListSection()

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
@@ -37,7 +37,7 @@ public class PartRankingVC: UIViewController, PartRankingViewControllable {
     
     lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
         .setTitleTypoStyle(.SoptampFont.h2)
-        .setTitle("파트별 랭킹")
+        .setTitle(I18N.RankingList.rankingForPartTitle)
         .setRightButton(.none)
     
     private lazy var rankingCollectionView: UICollectionView = {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
@@ -134,9 +134,10 @@ extension PartRankingVC {
         
         output.partRanking
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] partRankingModels in
-                self?.applySnapshot(model: partRankingModels)
-            }.store(in: cancelBag)
+            .withUnretained(self)
+            .sink(receiveValue: { owner, partRankingModels in
+                owner.applySnapshot(model: partRankingModels)
+            }).store(in: cancelBag)
     }
     
     private func setDelegate() {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -58,7 +58,7 @@ public class RankingVC: UIViewController, RankingViewControllable {
         bt.layer.cornerRadius = 27.adjustedH
         bt.backgroundColor = DSKitAsset.Colors.white.color
         bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: "내 랭킹 보기")
+        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.myRanking)
         let style = NSMutableParagraphStyle()
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitAsset.Colors.black.color, range: NSMakeRange(0, attributedStr.length))

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -204,7 +204,7 @@ extension RankingVC {
     private func setDataSource() {
         dataSource = UICollectionViewDiffableDataSource(
             collectionView: rankingCollectionView,
-            cellProvider: { collectionView, indexPath, itemIdentifier in
+            cellProvider: { [weak self] collectionView, indexPath, itemIdentifier in
                 switch RankingSection.type(indexPath.section) {
                 case .chart:
                     guard 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -152,7 +152,8 @@ extension RankingVC {
         
         let showRankingButtonTapped = self.showMyRankingFloatingButton
             .publisher(for: .touchUpInside)
-            .filter { _ in self.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
+            .withUnretained(self)
+            .filter { owner, _ in owner.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
             .mapVoid()
             .asDriver()
         
@@ -165,14 +166,13 @@ extension RankingVC {
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
         output.$rankingListModel
-            .sink { [weak self] model in
-                guard
-                    let self,
-                    let name = UserDefaultKeyList.User.soptampName,
+            .withUnretained(self)
+            .sink { owner, model in
+                guard let name = UserDefaultKeyList.User.soptampName,
                     model.contains(where: { $0.username == name })
                 else { return }
                 
-                self.showMyRankingFloatingButton.isHidden = false
+                owner.showMyRankingFloatingButton.isHidden = false
             }.store(in: self.cancelBag)
         
         output.$rankingListModel
@@ -217,7 +217,7 @@ extension RankingVC {
                     
                     chartCell.setData(model: chartCellModel)
                     chartCell.usernameTapped = { [weak self] balloonModel in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         
                         let item = balloonModel.toRankingListTapItem()
                         self.onCellTap?(item.username, item.sentence)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/RankingViewModel.swift
@@ -54,7 +54,7 @@ extension RankingViewModel {
         input.viewDidLoad.merge(with: input.refreshStarted)
             .withUnretained(self)
             .sink { owner, _ in
-                switch self.rankingViewType {
+                switch owner.rankingViewType {
                 case .all:
                     owner.useCase.fetchRankingList(isCurrentGeneration: false)
                 case .currentGeneration:


### PR DESCRIPTION
## 🌴 PR 요약
- 솝탬프 랭킹과 파트별 랭킹 플로우에서 발생하는 메모리 누수를 방지했습니다.

🌱 작업한 브랜치
- feature/#609

## 🌱 PR Point
마이페이지 딥링크 테스트 중 솝탬프 플로우의 메모리 누수를 발견했습니다.

|메모리에 남아있는 객체|메모리 그래프|
|:----:|:---:|
|PartRankingVC|![image](https://github.com/user-attachments/assets/e0d6cf49-b0e6-43c3-8547-b0e65faf0a3b)|
|RankingVC|![image](https://github.com/user-attachments/assets/e45fd7e0-0ecd-4f05-aa18-167489f77594)|
|RankingChartCVC|![image](https://github.com/user-attachments/assets/68c5c0d8-8d46-458d-9d17-7f569631d19e)|

각 객체 별 누수 원인이 되는 부분은 다음과 같습니다.
#### PartRankingVC
- `UICollectionViewCompositionalLayout`의 클로저에서 `self`를 강하게 캡처하여 순환 참조 발생

#### RankingVC
- `UICollectionViewCompositionalLayout`의 클로저에서 `self`를 강하게 캡처하여 순환 참조 발생
- 버튼 이벤트 스트림 구성 시 클로저 내에서 `self`를 강하게 캡처
- `rankingListModel`의 `sink` 구독 클로저에서 `self`를 강하게 캡처
- ViewModel 내부에서 `self`를 강하게 캡처
- `UICollectionViewDiffableDataSource`의 `cellProvider` 클로저에서 `self`를 직접 참조

#### RankingChartCVC
- 이벤트 구독 클로저에서 `self`를 강하게 캡처

누수의 원인이 되는 코드에서 `[weak self]`를 사용하거나 `withUnretained(self)`를 활용해 문제를 해결했습니다.



### 💡 cellProvider 클로저 내 self 캡처
```swift
dataSource = UICollectionViewDiffableDataSource(
    collectionView: rankingCollectionView,
    cellProvider: { [weak self] collectionView, indexPath, itemIdentifier in
        switch RankingSection.type(indexPath.section) {
        case .chart:
        // cell 인스턴스 생성
        cell.usernameTapped = { [weak self]
           self.onCellTap?(item.username, item.sentence)
        ... 
        }
       // 중략
    }
}
```
usernameTapped 클로저 내부에서 `weak self`를 사용하기 때문에 누수가 없다고 생각했지만, 메모리 그래프 상에서는 cellProvider에서 누수가 발생하고 있었습니다.

<img width="303" alt="image" src="https://github.com/user-attachments/assets/be20442d-ab92-4856-9031-c7566a60d9df" />

이러한 현상의 원인은 중첩 클로저 구조에 있었습니다.
**내부 클로저에서 self를 참조하면, 이를 감싸고 있는 상위 클로저 또한 self를 암묵적으로 캡처**하게 됩니다.
이로 인해 cellProvider 클로저 역시 self를 강하게 참조하게 되었고, 결과적으로 VC가 해제되지 않는 문제가 발생했습니다.
또한 셀은 재사용 큐에 계속 보관되기 때문에, 재사용될 때마다 해당 클로저가 계속 유지되며 메모리 누수의 규모도 점차 커지고 있었습니다.

원인 파악 후, weak self를 사용하여 누수를 방지했습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #609
