### PR TITLE
[feat] #526 - change social 구현

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
@@ -42,8 +42,12 @@ extension CoreAuthRepository: CoreAuthRepositoryInterface {
         UserDefaultKeyList.CoreAuth.refreshToken = tokens.refreshToken
     }
     
-    public func changeSocialAccount() -> AnyPublisher<Void, CoreAuthError> {
-        fatalError()
+    public func changeSocialAccount(_ model: Domain.SignUpModel) -> AnyPublisher<Void, Domain.CoreAuthError> {
+        coreAuthService
+            .changeSocialAccount(model.toData())
+            .mapVoid()
+            .mapError { _ in CoreAuthError.changeSocialAccountFail }
+            .eraseToAnyPublisher()
     }
     
     public func searchSocialAccount() -> AnyPublisher<Void, CoreAuthError> {

--- a/SOPT-iOS/Projects/Data/Sources/Transform/PhoneVerifyTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PhoneVerifyTransform.swift
@@ -14,9 +14,10 @@ import Networks
 extension PhoneVerifyType {
     func toData() -> VerifyEntityType {
         switch self {
-        case .change: return .change
+        case .changePhoneNumber: return .changePhoneNumber
+        case .changeSocialAccount: return .changeSocialAccount
         case .register: return .register
-        case .search: return .search
+        case .searchSocialAccount: return .searchSocialAccount
         }
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
@@ -12,5 +12,6 @@ public enum CoreAuthError: Error {
     case oAuthFail(OAuthProvider)
     case loginFail
     case signUpFail
+    case changeSocialAccountFail
     case unknown(Error)
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/PhoneVerifyModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/PhoneVerifyModel.swift
@@ -10,8 +10,9 @@ import Foundation
 
 public enum PhoneVerifyType {
     case register  // 회원가입
-    case change    // 소설계정재설정
-    case search    // 계정 찾기
+    case changeSocialAccount    // 소설계정재설정
+    case changePhoneNumber
+    case searchSocialAccount    // 계정 찾기
 }
 
 public struct PhoneSendModel {

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/CoreAuthRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/CoreAuthRepositoryInterface.swift
@@ -10,7 +10,7 @@ import Combine
 
 public protocol CoreAuthRepositoryInterface {
     func login(for provider: OAuthProvider, with identityToken: String) -> AnyPublisher<CoreAuthTokens, CoreAuthError>
-    func changeSocialAccount() -> AnyPublisher<Void, CoreAuthError>
+    func changeSocialAccount(_ model: SignUpModel) -> AnyPublisher<Void, CoreAuthError>
     func searchSocialAccount() -> AnyPublisher<Void, CoreAuthError>
     func signUp(_ model: SignUpModel) -> AnyPublisher<Void, CoreAuthError>
     func saveTokens(_ tokens: CoreAuthTokens) -> Void

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ChangeSocialAccountUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ChangeSocialAccountUseCase.swift
@@ -1,0 +1,56 @@
+//
+//  ResetSocialUseCase.swift
+//  Domain
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Core
+
+public protocol ChangeSocialAccountUseCase {
+    func resetSocialAccount(with provider: OAuthProvider, name: String?, phone: String) -> AnyPublisher<Void, Never>
+    var sideEffect: PassthroughSubject<Error, Never> { get }
+}
+
+public struct DefaultChangeSocialAccountUseCase: ChangeSocialAccountUseCase {
+    
+    private let oAuthRepository: CoreOAuthRepositoryInterface
+    private let repository: CoreAuthRepositoryInterface
+    
+    private var cancelBag = CancelBag()
+    
+    public let sideEffect = PassthroughSubject<Error, Never>()
+    
+    public init(
+        repository: CoreAuthRepositoryInterface,
+        oAuthRepository: CoreOAuthRepositoryInterface
+    ) {
+        self.repository = repository
+        self.oAuthRepository = oAuthRepository
+    }
+        
+    public func resetSocialAccount(
+        with provider: OAuthProvider,
+        name: String?,
+        phone: String
+    ) -> AnyPublisher<Void, Never> {
+        oAuthRepository.getIdentityToken(from: provider)
+            .map { SignUpModel(name: name, phone: phone, token: $0, provider: provider)}
+            .flatMap { model in
+                self.repository.changeSocialAccount(model)
+                    .flatMap {
+                        self.repository.login(for: provider, with: model.token)
+                    }
+            }
+            .handleEvents(receiveOutput: self.repository.saveTokens)
+            .mapVoid()
+            .catch { error in
+                self.sideEffect.send(error)
+                return Empty<Void, Never>()
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/AuthFeatureBuildable_Refactor.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/AuthFeatureBuildable_Refactor.swift
@@ -13,4 +13,5 @@ public protocol AuthFeatureViewBuildable_Refactor {
     func makeLoginHelpBottomSheet() -> LoginHelpBottomSheetPresentable
     func makeUserNotFound() -> UserNotFoundPresentable
     func makeSignUp() -> SignUpPresentable
+    func makeChangeSocialAccount() -> ChangeSocialAccountPresentable
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/ChangeSocialAccountPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/Refactor/ChangeSocialAccountPresentable.swift
@@ -1,0 +1,21 @@
+//
+//  ChangeSocialAccountPresentable.swift
+//  AuthFeature
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import BaseFeatureDependency
+import Core
+import Domain
+
+public protocol ChangeSocialAccountViewControllable: LegacyViewControllable { }
+
+public protocol ChangeSocialAccountCoordinatable {
+    var changeSocialAccountSucceed: (() -> Void)? { get set }
+}
+
+public typealias ChangeSocialAccountViewModelType = ViewModelType & ChangeSocialAccountCoordinatable
+
+public typealias ChangeSocialAccountPresentable = (vc: ChangeSocialAccountViewControllable, vm: any ChangeSocialAccountViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
@@ -8,7 +8,7 @@
 
 import Core
 import Domain
-@_exported import AuthFeatureInterface
+import AuthFeatureInterface
 
 public class AuthBuilder: AuthFeatureViewBuildable {
     @Injected public var repository: SignInRepositoryInterface

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
@@ -1,0 +1,217 @@
+//
+//  ChangeSocialAccountVC.swift
+//  AuthFeature
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import DSKit
+import Core
+
+import AuthFeatureInterface
+import BaseFeatureDependency
+
+import SnapKit
+import Then
+
+
+public class ChangeSocialAccountVC: UIViewController, ChangeSocialAccountViewControllable {
+    
+    //MARK: - Properties
+    
+    private let phoneVerifyView = PhoneVerifyView()
+    private let oAuthView = ChangeSocialOAuthView()
+    
+    private let viewModel: ChangeSocialAccountViewModel
+    private let phoneVerifyViewModel: PhoneVerifyViewModel
+    
+    private let cancelBag = CancelBag()
+    
+    // MARK: - Initialization
+    
+    public init(
+        viewModel: ChangeSocialAccountViewModel,
+        phoneVerifyViewModel: PhoneVerifyViewModel
+    ) {
+        self.viewModel = viewModel
+        self.phoneVerifyViewModel = phoneVerifyViewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - UI Components
+    
+    private lazy var navigationBar = OPNavigationBar(
+        self,
+        type: .oneLeftButton,
+        backgroundColor: DSKitAsset.Colors.black100.color,
+        ignoreLeftButtonAction: false
+    )
+    
+    private let lineView = UIView().then {
+        $0.backgroundColor = DSKitAsset.Colors.black40.color
+    }
+    
+    private let firstCircle = UILabel().then {
+        $0.text = "1"
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
+        $0.backgroundColor = DSKitAsset.Colors.blue400.color
+        $0.layer.cornerRadius = 11
+        $0.layer.masksToBounds = true
+        $0.textAlignment = .center
+    }
+    
+    private let checkImageView = UIImageView().then {
+        $0.image = DSKitAsset.Assets.check.image.withAlignmentRectInsets(.init(top: -4, left: -4, bottom: -4, right: -4))
+        $0.contentMode = .scaleAspectFit
+        $0.backgroundColor = DSKitAsset.Colors.blue400.color
+        $0.layer.cornerRadius = 11
+        $0.layer.masksToBounds = true
+        $0.isHidden = true
+    }
+    
+    private let secondCircle = UILabel().then {
+        $0.text = "2"
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
+        $0.backgroundColor = DSKitAsset.Colors.black40.color
+        $0.layer.cornerRadius = 11
+        $0.layer.masksToBounds = true
+        $0.textAlignment = .center
+    }
+    
+    private let firstLabel = UILabel().then {
+        $0.text = "SOPT 회원인증"
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
+        $0.textColor = DSKitAsset.Colors.white.color
+        $0.textAlignment = .center
+    }
+    
+    private let secondLabel = UILabel().then {
+        $0.text = "소셜 계정 재설정"
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
+        $0.textColor = DSKitAsset.Colors.white.color
+        $0.textAlignment = .center
+    }
+   
+    
+    // MARK: - View Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setLayout()
+        bind()
+    }
+    
+}
+
+// MARK: - UI & Layout
+
+extension ChangeSocialAccountVC {
+    
+    private func setUI() {
+        self.view.backgroundColor = DSKitAsset.Colors.black100.color
+        
+        self.view.addSubviews(
+            navigationBar,
+            lineView,
+            firstCircle,
+            checkImageView,
+            secondCircle,
+            firstLabel,
+            secondLabel,
+            phoneVerifyView,
+            oAuthView
+        )
+    }
+    
+    private func setLayout() {
+        navigationBar.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(123)
+            $0.height.equalTo(1)
+        }
+        
+        firstCircle.snp.makeConstraints {
+            $0.centerX.equalTo(lineView.snp.leading)
+            $0.centerY.equalTo(lineView)
+            $0.size.equalTo(22)
+        }
+        
+        checkImageView.snp.makeConstraints {
+            $0.edges.equalTo(firstCircle)
+        }
+        
+        secondCircle.snp.makeConstraints {
+            $0.centerX.equalTo(lineView.snp.trailing)
+            $0.centerY.equalTo(lineView)
+            $0.size.equalTo(22)
+        }
+        
+        firstLabel.snp.makeConstraints {
+            $0.top.equalTo(firstCircle.snp.bottom).offset(12)
+            $0.centerX.equalTo(firstCircle)
+        }
+        
+        secondLabel.snp.makeConstraints {
+            $0.top.equalTo(secondCircle.snp.bottom).offset(12)
+            $0.centerX.equalTo(secondCircle)
+        }
+        
+        phoneVerifyView.snp.makeConstraints {
+            $0.top.equalTo(firstLabel.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+        }
+        
+        oAuthView.snp.makeConstraints {
+            $0.edges.equalTo(phoneVerifyView)
+        }
+        
+    }
+    
+    private func bind() {
+
+        let pvInput = phoneVerifyView.viewModelInput
+        let pvOutput = phoneVerifyViewModel.transform(from: pvInput, cancelBag: cancelBag)
+        phoneVerifyView.bindOutput(pvOutput, cancelBag: cancelBag)
+            
+        let input = type(of: viewModel).Input.init(
+            phone: pvOutput.phoneTextFieldText.asDriver(),
+            verifySuccess: pvOutput.verifySuccess.asDriver(),
+            oAuth: oAuthView.viewModelInput
+        )
+        
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+        
+        output.currentStep
+            .withUnretained(self)
+            .sink { owner, step in
+                let bg = step == .phoneVerify ? DSKitAsset.Colors.black40.color : DSKitAsset.Colors.blue400.color
+                owner.phoneVerifyView.isHidden = step != .phoneVerify
+                owner.oAuthView.isHidden = step != .oAuth
+                owner.checkImageView.isHidden = step == .phoneVerify
+                owner.lineView.backgroundColor = bg
+                owner.secondCircle.backgroundColor = bg
+                owner.navigationBar.isHidden = step != .phoneVerify
+            }
+            .store(in: cancelBag)
+    }
+    
+}
+

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialAccountViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialAccountViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  ChangeSocialAccountViewModel.swift
+//  AuthFeature
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+import Core
+import Domain
+
+public final class ChangeSocialAccountViewModel: ChangeSocialAccountViewModelType {
+    
+    enum Step: Int {
+        case phoneVerify
+        case oAuth
+    }
+    
+    public struct Input {
+        let phone: Driver<String>
+        let verifySuccess: Driver<Void>
+        var oAuth: OAuth
+        
+        public struct OAuth {
+            let googleLoginTapped: Driver<Void>
+            let appleLoginTapped: Driver<Void>
+        }
+    }
+    
+    public struct Output {
+        let currentStep = CurrentValueSubject<Step, Never>(.phoneVerify)
+    }
+    
+    private let useCase: ChangeSocialAccountUseCase
+    
+    public var changeSocialAccountSucceed: (() -> Void)?
+    
+    public init(
+        useCase: ChangeSocialAccountUseCase
+    ) {
+        self.useCase = useCase
+    }
+    
+    public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+        
+        input.verifySuccess
+            .sink { _ in
+                output.currentStep.send(.oAuth)
+            }
+            .store(in: cancelBag)
+
+        
+        Publishers.Merge(
+            input.oAuth.googleLoginTapped.map { OAuthProvider.google },
+            input.oAuth.appleLoginTapped.map { OAuthProvider.apple }
+        )
+        .withLatestFrom(input.phone)
+        .withUnretained(self)
+        .flatMap { owner, output in
+            owner.useCase.resetSocialAccount(with: output.0, name: nil, phone: output.1)
+        }
+        .withUnretained(self)
+        .sink { owner, _ in
+            owner.changeSocialAccountSucceed?()
+        }
+        .store(in: cancelBag)
+        
+        return output
+    }
+}

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
@@ -1,0 +1,101 @@
+//
+//  ChangeSocialOAuthView.swift
+//  AuthFeature
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import DSKit
+
+public final class ChangeSocialOAuthView: UIView {
+    
+    private static let i18n = I18N.SignIn.Refactor.self
+    
+    public var viewModelInput: ChangeSocialAccountViewModel.Input.OAuth {
+        .init(
+            googleLoginTapped: googleLoginButton.publisher(for: .touchUpInside).mapVoid().asDriver(),
+            appleLoginTapped: appleLoginButton.publisher(for: .touchUpInside).mapVoid().asDriver()
+        )
+    }
+    
+    //MARK: - Properties
+
+    private let titleLabel = UILabel().then {
+        $0.text = "소셜 계정 재설정"
+        $0.font = DSKitFontFamily.Suit.bold.font(size: 24)
+        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.textAlignment = .center
+    }
+    
+    private let descriptionLabel = UILabel().then {
+        $0.text = "반갑습니다 회원님\n재설정할 소셜 계정을 선택해주세요"
+        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
+        $0.textColor = DSKitAsset.Colors.gray60.color
+        $0.textAlignment = .center
+        $0.numberOfLines = 2
+    }
+    
+    private let googleLoginButton = AppImageTextButton(
+        title: i18n.googleLogin,
+        image: DSKitAsset.Assets.logoGoogle.image.withRenderingMode(.automatic)
+    )
+    
+    private let appleLoginButton = AppImageTextButton(
+        title: i18n.googleLogin,
+        image: DSKitAsset.Assets.logoApple.image
+    )
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    private func setUI() {
+        self.backgroundColor = DSKitAsset.Colors.black100.color
+    }
+    
+    private func setLayout() {
+        self.addSubviews(
+            titleLabel,
+            descriptionLabel,
+            googleLoginButton,
+            appleLoginButton
+        )
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(54)
+            $0.centerX.equalToSuperview()
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(14)
+            $0.centerX.equalToSuperview()
+        }
+        
+        googleLoginButton.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(66)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+            
+        }
+        
+        appleLoginButton.snp.makeConstraints {
+            $0.top.equalTo(googleLoginButton.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+            $0.bottom.lessThanOrEqualToSuperview()
+        }
+       
+    }
+}

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/Coordinator/AuthBuilder_Refactor.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/Coordinator/AuthBuilder_Refactor.swift
@@ -8,7 +8,9 @@
 
 import Core
 import Domain
+
 @_exported import AuthFeatureInterface
+import BaseFeatureDependency
 
 public final class AuthBuilder_Refactor: AuthFeatureViewBuildable_Refactor {
     
@@ -28,13 +30,13 @@ public final class AuthBuilder_Refactor: AuthFeatureViewBuildable_Refactor {
         vc.viewModel = vm
         return (vc, vm)
     }
-
+    
     public func makeLoginHelpBottomSheet() -> LoginHelpBottomSheetPresentable {
         return LoginHelpBottomSheetVC()
     }
     
     public func makeUserNotFound() -> UserNotFoundPresentable {
-         return UserNotFoundVC()
+        return UserNotFoundVC()
     }
     
     public func makeSignUp() -> SignUpPresentable {
@@ -42,10 +44,24 @@ public final class AuthBuilder_Refactor: AuthFeatureViewBuildable_Refactor {
         let phoneUseCase = DefaultPhoneVerifyUseCase(repository: phoneRepository)
         
         let vm = SignUpViewModel(useCase: useCase)
-        let phoneVM = PhoneVerifyViewModel(useCase: phoneUseCase)
+        let phoneVM = PhoneVerifyViewModel(useCase: phoneUseCase, phoneVerifyType: .register)
         let vc = SignUpVC(viewModel: vm, phoneVerifyViewModel: phoneVM)
         
         return (vc, vm)
     }
     
+    public func makeChangeSocialAccount() -> ChangeSocialAccountPresentable {
+        let useCase = DefaultChangeSocialAccountUseCase(
+            repository: coreRepository,
+            oAuthRepository: oauthRepository
+        )
+        
+        let phoneUseCase = DefaultPhoneVerifyUseCase(repository: phoneRepository)
+        
+        let vm = ChangeSocialAccountViewModel(useCase: useCase)
+        let phoneVM = PhoneVerifyViewModel(useCase: phoneUseCase, phoneVerifyType: .changeSocialAccount)
+        let vc = ChangeSocialAccountVC(viewModel: vm, phoneVerifyViewModel: phoneVM)
+        return (vc, vm)
+    }
+
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/Coordinator/AuthCoordinator_Refactor.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/Coordinator/AuthCoordinator_Refactor.swift
@@ -15,7 +15,6 @@ import DSKit
 
 public final class AuthCoordinator_Refactor: DefaultAuthCoordinator {
 
-
     public var finishFlow: ((UserType) -> Void)?
 
     private let factory: AuthFeatureViewBuildable_Refactor
@@ -129,13 +128,25 @@ extension AuthCoordinator_Refactor {
         
         self.router.push(signUpVC.vc)
     }
-
+    
+    private func runChangeSocialFlow() {
+        var changeSocialAccount = self.factory.makeChangeSocialAccount()
+        
+        changeSocialAccount.vm.changeSocialAccountSucceed = { [weak self] in
+            let userType = UserDefaultKeyList.Auth.getUserType() //TODO: 인증중앙화 후 로직으로 수정
+            self?.finishFlow?(userType)
+        }
+        
+        self.router.push(changeSocialAccount.vc)
+    }
+    
     private func showLoginHelpBottomSheet(on vc: LegacyViewControllable) {
         guard let bottomSheetVC = self.factory.makeLoginHelpBottomSheet().viewController as? LoginHelpBottomSheetVC
         else { return Void() }
         
         bottomSheetVC.onResetSocialAccountButtonDidTap = {
-            print("resetSocialAccountButtonDidTap") //TODO: asdf
+            bottomSheetVC.dismiss(animated: true)
+            self.runChangeSocialFlow()
         }
         
         bottomSheetVC.onWantToKnowLoginAccountButtonDidTap = {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/PhoneVerifyScene/PhoneVerifyViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/PhoneVerifyScene/PhoneVerifyViewModel.swift
@@ -97,11 +97,13 @@ extension PhoneVerifyViewModel {
                 output.codeFailDescription.send(nil)
             }
             )
-            .map { PhoneSendModel(
-                name: nil,
-                phone: output.phoneTextFieldText.value,
-                type: self.phoneVerifyType
-            ) }
+            .withUnretained(self)
+            .map { owner, _ in 
+                PhoneSendModel(
+                    name: nil,
+                    phone: output.phoneTextFieldText.value,
+                    type: owner.phoneVerifyType
+            )}
             .flatMap(useCase.send)
             .withUnretained(self)
             .sink { owner , _ in

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/PhoneVerifyScene/PhoneVerifyViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Refactor/PhoneVerifyScene/PhoneVerifyViewModel.swift
@@ -17,6 +17,8 @@ public class PhoneVerifyViewModel: PhoneVerifyViewModelType {
 
     private let useCase: PhoneVerifyUseCase
     
+    private let phoneVerifyType: PhoneVerifyType
+    
     private let timerPublisher: Timer.TimerPublisher
     @Published private var timerCancellable: AnyCancellable?
     
@@ -48,9 +50,11 @@ public class PhoneVerifyViewModel: PhoneVerifyViewModelType {
     
     init(
         useCase: PhoneVerifyUseCase,
+        phoneVerifyType: PhoneVerifyType,
         timerPublisher: Timer.TimerPublisher = Timer.publish(every: 1, on: .main, in: .default)
     ) {
         self.useCase = useCase
+        self.phoneVerifyType = phoneVerifyType
         self.timerPublisher = timerPublisher
     }
 }
@@ -93,7 +97,11 @@ extension PhoneVerifyViewModel {
                 output.codeFailDescription.send(nil)
             }
             )
-            .map { PhoneSendModel(name: nil, phone: output.phoneTextFieldText.value, type: .register) }
+            .map { PhoneSendModel(
+                name: nil,
+                phone: output.phoneTextFieldText.value,
+                type: self.phoneVerifyType
+            ) }
             .flatMap(useCase.send)
             .withUnretained(self)
             .sink { owner , _ in
@@ -158,7 +166,7 @@ extension PhoneVerifyViewModel {
                 name: nil,
                 phone: output.phoneTextFieldText.value,
                 code: output.codeTextFieldText.value,
-                type: .register)
+                type: self.phoneVerifyType)
             }
             .flatMap(useCase.verify)
             .withUnretained(self)

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/CoreAuthAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/CoreAuthAPI.swift
@@ -13,6 +13,7 @@ public enum CoreAuthAPI {
     case verfiyCode(dto: VerifyCodeRequestEntity)
     case signUp(dto: CoreSignUpRequestEntity)
     case login(dto: CoreLoginRequestEntity)
+    case changeSocialAccount(dto: CoreSignUpRequestEntity)
 }
 
 extension CoreAuthAPI: BaseAPI {
@@ -38,6 +39,8 @@ extension CoreAuthAPI: BaseAPI {
             return "/signup"
         case .login:
             return "/login/app"
+        case .changeSocialAccount:
+            return "/accounts"
         }
     }
     
@@ -52,19 +55,23 @@ extension CoreAuthAPI: BaseAPI {
             return .post
         case .login:
             return .post
+        case .changeSocialAccount:
+            return .patch
         }
     }
     
     
     public var task: Task {
         switch self {
-        case let .sendVerifyCode(dto):
+        case .sendVerifyCode(let dto):
             return .requestJSONEncodable(dto)
-        case let .verfiyCode(dto):
+        case .verfiyCode(let dto):
             return .requestJSONEncodable(dto)
-        case let .signUp(dto):
+        case .signUp(let dto):
             return .requestJSONEncodable(dto)
-        case let .login(dto):
+        case .login(let dto):
+            return .requestJSONEncodable(dto)
+        case .changeSocialAccount(dto: let dto):
             return .requestJSONEncodable(dto)
         }
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreChangeSocialAccountRequestEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreChangeSocialAccountRequestEntity.swift
@@ -1,0 +1,9 @@
+//
+//  CoreChangeSocialAccountRequestEntity.swift
+//  Networks
+//
+//  Created by 장석우 on 5/24/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/SendVerificationCodeRequestEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/SendVerificationCodeRequestEntity.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct SendVerificationCodeRequestEntity: Encodable {
     let name: String?
+    let id: String? = nil
     let phone: String
     let type: VerifyEntityType
     

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/VerifyEntityType.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/VerifyEntityType.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public enum VerifyEntityType: String, Encodable {
     case register = "REGISTER"
-    case change = "CHANGE"
-    case search = "SEARCH"
+    case searchSocialAccount = "SEARCH_SOCIAL_PLATFORM"
+    case changeSocialAccount = "CHANGE_SOCIAL_PLATFORM"
+    case changePhoneNumber = "CHANGE_PHONE_NUMBER"
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CoreAuthService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CoreAuthService.swift
@@ -20,9 +20,11 @@ public protocol CoreAuthService {
     func verifyCode(_ dto: VerifyCodeRequestEntity) -> AnyPublisher<BaseEntity<VerifyResultEntity>, Error>
     func login(_ dto: CoreLoginRequestEntity) -> AnyPublisher<BaseEntity<CoreLoginEntity>, Error>
     func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error>
+    func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error>
 }
 
 extension DefaultCoreAuthService: CoreAuthService {
+    
     public func sendVerifyCode(_ dto: SendVerificationCodeRequestEntity) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.sendVerifyCode(dto: dto))
     }
@@ -38,5 +40,10 @@ extension DefaultCoreAuthService: CoreAuthService {
     public func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error> {
         requestObjectInCombineNoResult(.signUp(dto: dto))
     }
+    
+    public func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, any Error> {
+        requestObjectInCombineNoResult(.changeSocialAccount(dto: dto))
+    }
+    
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#526

## 🌱 PR Point
- 소셜재설정 ui 및 api 연동했습니다.

## 📌 참고 사항
네이밍 및 컨벤션이 다소 미흡한 점 양해부탁드립니다..!
develop 머지 전에 한번에 싹 정리하겠습니다 🥲

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|로그인 화면|<img src = "https://github.com/user-attachments/assets/48f2cc0a-872e-49ab-875f-f3e45835fd45" width = "300">|
|회원 인증|<img src = "https://github.com/user-attachments/assets/512fbf1d-48af-4c03-95fb-17736719fb77" width = "300">|
|소셜계정 재설정|<img src = "https://github.com/user-attachments/assets/c2302110-cbab-45b3-ad49-d96cbcac1d07" width = "300">|


## 📮 관련 이슈
- Resolved: #526
