### PR TITLE
[Hotfix] #611 - 홈화면 버그 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -123,11 +123,18 @@ extension HomeCalendarDetailVC {
             make.height.equalTo(209.adjustedH)
         }
         
+        setAttendanceButtonVisibility()
+        
         attendanceButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(34)
             make.height.equalTo(56)
         }
+    }
+    
+    private func setAttendanceButtonVisibility() {
+        let userType = UserDefaultKeyList.Auth.getUserType()
+        self.attendanceButton.isHidden = (userType == .inactive)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -142,6 +142,6 @@ extension CalendarCardCVC {
                                                  titleColor: tagType.textColor,
                                                  backgroundColor: tagType.backgroundColor)
         }
-        self.attendanceButton.isHidden = userType == .visitor
+        self.attendanceButton.isHidden = (userType == .visitor || userType == .inactive)
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
@@ -32,6 +32,7 @@ final class SurveyCVC: UICollectionViewCell {
         $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
         $0.textColor = DSKitAsset.Colors.white.color
         $0.numberOfLines = 2
+        $0.lineBreakMode = .byWordWrapping
     }
     
     private lazy var surveyButton = AppCustomButton()

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
@@ -31,6 +31,7 @@ final class SurveyCVC: UICollectionViewCell {
     private let subTitleLabel = UILabel().then {
         $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
         $0.textColor = DSKitAsset.Colors.white.color
+        $0.numberOfLines = 2
     }
     
     private lazy var surveyButton = AppCustomButton()
@@ -71,6 +72,7 @@ extension SurveyCVC {
         
         subTitleLabel.snp.makeConstraints { make in
             make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview()
             make.centerX.equalToSuperview()
         }
         


### PR DESCRIPTION
## 🌴 PR 요약

홈화면의 사소한 버그들을 수정했어요.

🌱 작업한 브랜치
- #611 

## 🌱 PR Point

- 비활동기수일 경우, 출석 버튼이 노출되고 있다는 cs가 들어와 수정했어요.
- 설문 섹션에서 subTitle의 leading, trailing이 지정되어 있지 않아 설정했어요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
우선 머지해서 심사 올릴게요! 

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #611 
