### PR TITLE
[Refactor] #620 - 신규 Coordinator에서 사용되는 클로저를 delegate 패턴으로 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -98,7 +98,8 @@ public final class MyPageCoordinator: DefaultMyPageCoordinator {
     private func showWithdrawal(userType: UserType) {
         var withdrawal = factory.makeWithdrawalVC(userType: userType)
         withdrawal.vm.onWithdrawal = { [weak self] in
-            self?.requestCoordinating?(.signInWithToast)
+            guard let self else { return }
+            self.delegate?.myPageCoordinator(self, to: .signInWithToast)
         }
         
         self.navigationController.pushViewController(withdrawal.vc, animated: true)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -141,7 +141,8 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
                 description: I18N.Home.PopUp.needToLoginDetail,
                 customButtonTitle: I18N.Home.PopUp.login,
                 customAction: { [weak self] in
-                    self?.requestCoordinating?(.signIn)
+                    guard let self else { return }
+                    self.delegate?.homeCoordinator(self, to: .signIn)
                 }
             )
         }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
@@ -13,10 +13,15 @@ import NotificationFeatureInterface
 import Domain
 import Core
 
+public protocol NotificationCoordinatorDelegate: AnyObject {
+    func notificationCoordinator(_ coordinator: NotificationCoordinator, to destination: NotificationCoordinatorDestination)
+}
+
 public final class NotificationCoordinator: DefaultNotificationCoordinator {
     
     // MARK: - Properties
     
+    public weak var delegate: NotificationCoordinatorDelegate?
     public var requestCoordinating: ((NotificationCoordinatorDestination) -> Void)?
     public var finishFlow: (() -> Void)?
 
@@ -61,6 +66,7 @@ public final class NotificationCoordinator: DefaultNotificationCoordinator {
         var notificationDetail = factory.makeNotificationDetailVC(notificationId: notificationId)
         
         notificationDetail.vm.onShortCutButtonTap = { [weak self] link in
+            guard let self else { return }
             let url = link.url
             let destination: NotificationCoordinatorDestination = link.isDeepLink ? .deepLink(url: url) : .webLink(url: url)
             AmplitudeInstance.shared.track(eventType: .viewNotificationDetail, eventProperties: [
@@ -68,7 +74,8 @@ public final class NotificationCoordinator: DefaultNotificationCoordinator {
                 "open_method": link.isDeepLink ? "푸시알림" : "알림센터",
                 "contain_deeplink": link.isDeepLink
             ])
-            self?.requestCoordinating?(destination)
+            
+            self.delegate?.notificationCoordinator(self, to: destination)
         }
         
         navigationController.pushViewController(notificationDetail.vc, animated: true)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -14,6 +14,7 @@ import HomeFeature
 import SoptlogFeature
 import TabBarFeature
 import AppMyPageFeature
+import NotificationFeature
 
 // MARK: - TabBarCoordinatorDelegate
 
@@ -79,6 +80,19 @@ extension ApplicationCoordinator: SoptlogCoordinatorDelegate {
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
         case .webLink(let url):
             self.handleWebLink(webLink: url)
+        }
+    }
+}
+
+// MARK: - NotificationCoordinatorDelegate
+
+extension ApplicationCoordinator: NotificationCoordinatorDelegate {
+    public func notificationCoordinator(_ coordinator: NotificationCoordinator, to destination: NotificationCoordinatorDestination) {
+        switch destination {
+        case .deepLink(let url):
+            self.notificationHandler.receive(deepLink: url)
+        case .webLink(let url):
+            self.notificationHandler.receive(webLink: url)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -15,6 +15,29 @@ import SoptlogFeature
 import TabBarFeature
 import AppMyPageFeature
 
+// MARK: - TabBarCoordinatorDelegate
+
+extension ApplicationCoordinator: TabBarCoordinatorDelegate {
+    public func tabBarCoordinator(_ coordinator: TabBarCoordinator, didRequest destination: TabBarCoordinatorDestination) {
+        switch destination {
+        case .home:
+            print("홈클릭")
+            self.selectedTab(.home)
+        case .soptlog:
+            print("솝트로그클릭")
+            self.selectedTab(.soptlog)
+        case .signIn:
+            print("회원가입클릭")
+            self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
+            self.removeDependency(coordinator)
+        }
+    }
+
+    private func selectedTab(_ tab: TabType) {
+        self.tabBarController?.selectedIndex = tab.rawValue
+    }
+}
+
 // MARK: - HomeCoordinatorDelegate
 
 extension ApplicationCoordinator: HomeCoordinatorDelegate {

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -40,7 +40,7 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
         case .calendar:
             showHomeCalendarDetail()
         case .poke(let isNewUser):
-            isNewUser ? runPokeOnboardingFlow() : runPokeFlow()
+            _ = isNewUser ? runPokeOnboardingFlow() : runPokeFlow()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -19,16 +19,13 @@ import NotificationFeature
 // MARK: - TabBarCoordinatorDelegate
 
 extension ApplicationCoordinator: TabBarCoordinatorDelegate {
-    public func tabBarCoordinator(_ coordinator: TabBarCoordinator, didRequest destination: TabBarCoordinatorDestination) {
+    public func tabBarCoordinator(_ coordinator: TabBarCoordinator, to destination: TabBarCoordinatorDestination) {
         switch destination {
         case .home:
-            print("홈클릭")
             self.selectedTab(.home)
         case .soptlog:
-            print("솝트로그클릭")
             self.selectedTab(.soptlog)
         case .signIn:
-            print("회원가입클릭")
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
             self.removeDependency(coordinator)
         }
@@ -72,7 +69,7 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
 // MARK: - SoptlogCoordinatorDelegate
 
 extension ApplicationCoordinator: SoptlogCoordinatorDelegate {
-    public func soptlogCoordinator(_ coordinator: SoptlogCoordinator, didRequest destination: SoptlogCoordinatorDestination) {
+    public func soptlogCoordinator(_ coordinator: SoptlogCoordinator, to destination: SoptlogCoordinatorDestination) {
         switch destination {
         case .dailySoptune:
             self.runDailySoptuneFlow()

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -684,26 +684,30 @@ extension ApplicationCoordinator {
         
         switch Config.coordinatorFlag {
         case .legacy:
-            coordinator = LegacyNotificationCoordinator(
+            let legacyCoordinator = LegacyNotificationCoordinator(
                 router: LegacyRouter(
                     rootController: UIWindow.getRootNavigationController
                 ),
                 factory: LegacyNotificationBuilder()
             )
+            
+            legacyCoordinator.requestCoordinating = { [weak self] destination in
+                switch destination {
+                case .deepLink(let url):
+                    self?.notificationHandler.receive(deepLink: url)
+                case .webLink(let url):
+                    self?.notificationHandler.receive(webLink: url)
+                }
+            }
+            
+            coordinator = legacyCoordinator
         case .new:
-            coordinator = NotificationCoordinator(
+            let newCoordinator = NotificationCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: NotificationBuilder()
             )
-        }
-        
-        coordinator.requestCoordinating = { [weak self] destination in
-            switch destination {
-            case .deepLink(let url):
-                self?.notificationHandler.receive(deepLink: url)
-            case .webLink(let url):
-                self?.notificationHandler.receive(webLink: url)
-            }
+            newCoordinator.delegate = self
+            coordinator = newCoordinator
         }
         
         coordinator.finishFlow = { [weak self, weak coordinator] in

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -413,7 +413,7 @@ extension ApplicationCoordinator {
                 case .calendar:
                     self?.showHomeCalendarDetail()
                 case .poke(let isNewUser):
-                    isNewUser ? self?.runPokeOnboardingFlow() : self?.runPokeFlow()
+                    _ = isNewUser ? self?.runPokeOnboardingFlow() : self?.runPokeFlow()
                 }
             }
         case .new:

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -351,28 +351,12 @@ extension ApplicationCoordinator {
             ]
         )
         
+        coordinator.delegate = self
         self.tabBarController = tabBarFactory.vc
-        self.selectedTab(initSelectedTabType)
-        
-        // 각 코디네이터 실행
-        coordinator.requestCoordinating = { [weak self, weak coordinator] destination in
-            switch destination {
-            case .home:
-                self?.selectedTab(.home)
-            case .soptlog:
-                self?.selectedTab(.soptlog)
-            case .signIn:
-                self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
-                self?.removeDependency(coordinator)
-            }
-        }
+        self.tabBarController?.selectedIndex = initSelectedTabType.rawValue
         
         addDependency(coordinator)
         coordinator.start()
-    }
-    
-    private func selectedTab(_ tab: TabType) {
-        self.tabBarController?.selectedIndex = tab.rawValue
     }
 }
 

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -17,7 +17,7 @@ import SoptlogFeatureInterface
 import WebFeature
 
 public protocol SoptlogCoordinatorDelegate: AnyObject {
-    func soptlogCoordinator(_ coordinator: SoptlogCoordinator, didRequest destination: SoptlogCoordinatorDestination)
+    func soptlogCoordinator(_ coordinator: SoptlogCoordinator, to destination: SoptlogCoordinatorDestination)
 }
 
 public final class SoptlogCoordinator: DefaultSoptlogCoordinator {

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -16,12 +16,17 @@ import BaseFeatureDependency
 import TabBarFeatureInterface
 import WebFeature
 
+public protocol TabBarCoordinatorDelegate: AnyObject {
+    func tabBarCoordinator(_ coordinator: TabBarCoordinator, didRequest destination: TabBarCoordinatorDestination)
+}
+
 public final class TabBarCoordinator: DefaultTabBarCoordinator {
     
     // MARK: - Properties
     
     public var finishFlow: (() -> Void)?
     public var requestCoordinating: ((TabBarCoordinatorDestination) -> Void)?
+    public weak var delegate: TabBarCoordinatorDelegate?
         
     private let factory: TabBarPresentable
     private var navigationController: UINavigationController
@@ -52,10 +57,11 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
     
         tabBar.vm.onTabBarItemTapped = { [weak self] index in
             // 각 탭의 코디네이터 실행
-            guard let tabType = TabType(rawValue: index) else { return }
+            guard let self = self,
+                let tabType = TabType(rawValue: index) else { return }
             switch tabType {
-            case .home: self?.requestCoordinating?(.home)
-            case .soptlog: self?.requestCoordinating?(.soptlog)
+            case .home: self.delegate?.tabBarCoordinator(self, didRequest: .home)
+            case .soptlog: self.delegate?.tabBarCoordinator(self, didRequest: .soptlog)
             }
         }
         
@@ -66,7 +72,8 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
                 description: I18N.Home.PopUp.needToLoginDetail,
                 customButtonTitle: I18N.Home.PopUp.login,
                 customAction: { [weak self] in
-                    self?.requestCoordinating?(.signIn)
+                    guard let self else { return }
+                    self.delegate?.tabBarCoordinator(self, didRequest: .signIn)
                 }
             )
         }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -17,7 +17,7 @@ import TabBarFeatureInterface
 import WebFeature
 
 public protocol TabBarCoordinatorDelegate: AnyObject {
-    func tabBarCoordinator(_ coordinator: TabBarCoordinator, didRequest destination: TabBarCoordinatorDestination)
+    func tabBarCoordinator(_ coordinator: TabBarCoordinator, to destination: TabBarCoordinatorDestination)
 }
 
 public final class TabBarCoordinator: DefaultTabBarCoordinator {


### PR DESCRIPTION
## 🌴 PR 요약
- reqeustCoordinating 클로저를 delegate 패턴으로 변경했습니다.

🌱 작업한 브랜치
- feature/#620

## 🌱 PR Point

아래와 같은 이유로 delegate 패턴을 사용하였습니다.

### ✅ 메모리 누수 가능성 감소
- 클로저는 힙에 저장되며, 순환 참조를 방지하기 위해 `[weak self]`와 같이 캡처 리스트를 활용해야합니다.
- `delegate` 패턴 역시 `weak` 참조를 사용해야 하지만, **`AnyObject` 제약으로 클래스에서만 프로토콜을 채택하도록 강제**할 수 있습니다.
- 이를 활용해 **`delegate`를 `weak` 변수로 선언하면 보다 안정적인 메모리 관리가 가능**합니다.

### ✅ 코드 가독성과 구조적 통일성 향상
- 클로저 구현부 코드가 `ApplicationCoordinator+Delegate`로 분리되어 코드 가독성이 향상됩니다.
- 다수의 신규 코디네이터에서 `delegate` 방식을 사용하므로 **통일성 측면에서도 `delegate` 도입이 적합**하다고 판단했습니다.

### ✅ 타입 구조 단순화
- 기존에는 `requestCoordinating`을 포함한 `FinishOutput` 프로토콜을 채택하고, 이를 `BaseCoordinator`와 묶어 `DefaultCoordinator` 타입으로 사용하고 있었습니다.
- delegate 패턴 도입으로 `requestCoordinating` 및 `FinishOutput` 를 제거함으로써, **`Coordinator`가 채택해야 하는 프로토콜의 수를 줄여 타입 관계가 간결**해집니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- ~DailySoptuneFlow는 #621 머지 후 작업하겠습니다 ~ !~
- DailySoptune의 requestCoordinating에서는 상위 코디네이터에서 finishFlow를 호출하는 역할 뿐이라, delegate 패턴을 사용하는 것이 불필요한 추상화를 한다고 느껴지네요!! finishFlow를 제거하는 방향으로 리팩토링 해보기로 했으니 우선 그대로 두겠습니다 !! 

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #620
