### PR TITLE
[Fix] #636 - Splash가 deinit되지 않는 문제 해결

### DIFF
--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -355,8 +355,7 @@ extension ApplicationCoordinator {
         )
         
         coordinator.delegate = self
-        self.tabBarController = tabBarFactory.vc
-        self.tabBarController?.selectedIndex = initSelectedTabType.rawValue
+        self.rootNavigationController.setViewControllers([tabBarFactory.vc], animated: false)
         
         addDependency(coordinator)
         coordinator.start()

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -35,7 +35,8 @@ final class ApplicationCoordinator: BaseCoordinator {
     internal let rootNavigationController: UINavigationController
     
     private weak var legacyRootController: UINavigationController?
-    private var navigationControllerByTab: [TabBarItemType: UINavigationController] = [:]
+    private let homeNavigationController = UINavigationController()
+    private let soptlogNavigationController = UINavigationController()
     weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: DefaultHomeCoordinator?
@@ -53,7 +54,6 @@ final class ApplicationCoordinator: BaseCoordinator {
         self.notificationHandler = notificationHandler
         
         super.init()
-        self.makeNavigationController()
     }
     
     // MARK: - Coordinator Life Cycle
@@ -66,12 +66,6 @@ final class ApplicationCoordinator: BaseCoordinator {
             }
         } else {
             runSplashFlow()
-        }
-    }
-    
-    private func makeNavigationController() {
-        TabBarItemType.allCases.forEach {
-            self.navigationControllerByTab[$0] = UINavigationController()
         }
     }
     
@@ -345,12 +339,9 @@ extension ApplicationCoordinator {
 
         runHomeFlow(type: userType)
         runSoptlogFlow(type: userType)
-
-        guard let homeNavigation = self.navigationControllerByTab[.home],
-              let soptlogNavigation = self.navigationControllerByTab[.soptlog] else { return }
         
         let tabBarFactory = tabBarBuilder.makeTabBar(
-            with: [homeNavigation, soptlogNavigation],
+            with: [homeNavigationController, soptlogNavigationController],
             userType: userType
         )
         
@@ -409,7 +400,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = HomeCoordinator(
-                navigationController: self.navigationControllerByTab[.home] ?? UINavigationController(),
+                navigationController: homeNavigationController,
                 factory: HomeBuilder(),
                 userType: type
             )
@@ -801,7 +792,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = SoptlogCoordinator(
-                navigationController: self.navigationControllerByTab[.soptlog] ?? UINavigationController(),
+                navigationController: soptlogNavigationController,
                 factory: SoptlogBuilder(),
                 userType: type
             )

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -150,8 +150,6 @@ extension ApplicationCoordinator {
     }
     
     private func handleNewWebLink(webLink: String) {
-        print("ApplicationCoordinator의 rootNavigationController: \(rootNavigationController)",
-              "UIWindow의 최상위 navigationController: \(UIWindow.getRootNavigationController)")
         self.rootNavigationController.dismiss(animated: true)
         guard let url = URL(string: webLink) else { return }
         let webView = SOPTWebView(startWith: url)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -68,11 +68,6 @@ final class ApplicationCoordinator: BaseCoordinator {
             runSplashFlow()
         }
     }
-}
-
-// MARK: - Push Notification Binding
-
-extension ApplicationCoordinator {
     
     private func makeNavigationController() {
         TabBarItemType.allCases.forEach {

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -35,7 +35,9 @@ final class ApplicationCoordinator: BaseCoordinator {
     internal let rootNavigationController: UINavigationController
     
     private weak var legacyRootController: UINavigationController?
-    weak var tabBarController: UITabBarController?
+    private let homeNavigationController = UINavigationController()
+    private let soptlogNavigationController = UINavigationController()
+    fileprivate weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: DefaultHomeCoordinator?
     private weak var soptlogCoordinator: DefaultSoptlogCoordinator?
@@ -346,7 +348,7 @@ extension ApplicationCoordinator {
               let soptlogVC = soptlogCoordinator.rootViewController else { return }
 
         let tabBarFactory = tabBarBuilder.makeTabBar(
-            with: [homeVC, soptlogVC],
+            with: [homeNavigationController, soptlogNavigationController],
             userType: userType
         )
         
@@ -410,7 +412,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = HomeCoordinator(
-                navigationController: rootNavigationController,
+                navigationController: homeNavigationController,
                 factory: HomeBuilder(),
                 userType: type
             )
@@ -802,7 +804,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = SoptlogCoordinator(
-                navigationController: rootNavigationController,
+                navigationController: soptlogNavigationController,
                 factory: SoptlogBuilder(),
                 userType: type
             )

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -37,7 +37,7 @@ final class ApplicationCoordinator: BaseCoordinator {
     private weak var legacyRootController: UINavigationController?
     private let homeNavigationController = UINavigationController()
     private let soptlogNavigationController = UINavigationController()
-    fileprivate weak var tabBarController: UITabBarController?
+    weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: DefaultHomeCoordinator?
     private weak var soptlogCoordinator: DefaultSoptlogCoordinator?
@@ -127,7 +127,7 @@ extension ApplicationCoordinator {
     }
     
     private func handleNewDeepLink(deepLink: DeepLinkComponentsExecutable) {
-        self.rootNavigationController.dismiss(animated: false)
+        self.rootNavigationController.popToRootViewController(animated: false)
         deepLink.execute(coordinator: self)
     }
     
@@ -150,7 +150,9 @@ extension ApplicationCoordinator {
     }
     
     private func handleNewWebLink(webLink: String) {
-        UIWindow.getRootNavigationController.dismiss(animated: false)
+        print("ApplicationCoordinator의 rootNavigationController: \(rootNavigationController)",
+              "UIWindow의 최상위 navigationController: \(UIWindow.getRootNavigationController)")
+        self.rootNavigationController.dismiss(animated: true)
         guard let url = URL(string: webLink) else { return }
         let webView = SOPTWebView(startWith: url)
         CoordinatorUtils.pushOnRootNavigation(webView)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -341,11 +341,8 @@ extension ApplicationCoordinator {
         let tabBarBuilder = TabBarBuilder()
         let userType = type ?? UserDefaultKeyList.Auth.getUserType()
 
-        let homeCoordinator = runHomeFlow(type: userType)
-        let soptlogCoordinator = runSoptlogFlow(type: userType)
-
-        guard let homeVC = homeCoordinator.rootViewController,
-              let soptlogVC = soptlogCoordinator.rootViewController else { return }
+        runHomeFlow(type: userType)
+        runSoptlogFlow(type: userType)
 
         let tabBarFactory = tabBarBuilder.makeTabBar(
             with: [homeNavigationController, soptlogNavigationController],
@@ -354,11 +351,7 @@ extension ApplicationCoordinator {
         
         let coordinator = TabBarCoordinator(
             navigationController: rootNavigationController,
-            factory: tabBarFactory,
-            items: [
-                homeVC,
-                soptlogVC
-            ]
+            factory: tabBarFactory
         )
         
         coordinator.delegate = self

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -35,8 +35,7 @@ final class ApplicationCoordinator: BaseCoordinator {
     internal let rootNavigationController: UINavigationController
     
     private weak var legacyRootController: UINavigationController?
-    private let homeNavigationController = UINavigationController()
-    private let soptlogNavigationController = UINavigationController()
+    private var navigationControllerByTab: [TabBarItemType: UINavigationController] = [:]
     weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: DefaultHomeCoordinator?
@@ -52,7 +51,9 @@ final class ApplicationCoordinator: BaseCoordinator {
         self.rootNavigationController = rootNavigationController
         self.router = router
         self.notificationHandler = notificationHandler
+        
         super.init()
+        self.makeNavigationController()
     }
     
     // MARK: - Coordinator Life Cycle
@@ -72,6 +73,12 @@ final class ApplicationCoordinator: BaseCoordinator {
 // MARK: - Push Notification Binding
 
 extension ApplicationCoordinator {
+    
+    private func makeNavigationController() {
+        TabBarItemType.allCases.forEach {
+            self.navigationControllerByTab[$0] = UINavigationController()
+        }
+    }
     
     // MARK: - bindNotification
     
@@ -344,8 +351,11 @@ extension ApplicationCoordinator {
         runHomeFlow(type: userType)
         runSoptlogFlow(type: userType)
 
+        guard let homeNavigation = self.navigationControllerByTab[.home],
+              let soptlogNavigation = self.navigationControllerByTab[.soptlog] else { return }
+        
         let tabBarFactory = tabBarBuilder.makeTabBar(
-            with: [homeNavigationController, soptlogNavigationController],
+            with: [homeNavigation, soptlogNavigation],
             userType: userType
         )
         
@@ -404,7 +414,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = HomeCoordinator(
-                navigationController: homeNavigationController,
+                navigationController: self.navigationControllerByTab[.home] ?? UINavigationController(),
                 factory: HomeBuilder(),
                 userType: type
             )
@@ -796,7 +806,7 @@ extension ApplicationCoordinator {
             }
         case .new:
             let newCoordinator = SoptlogCoordinator(
-                navigationController: soptlogNavigationController,
+                navigationController: self.navigationControllerByTab[.soptlog] ?? UINavigationController(),
                 factory: SoptlogBuilder(),
                 userType: type
             )

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
@@ -57,7 +57,6 @@ public final class SplashCoordinator: DefaultCoordinator & SplashCoordinatable {
         }
         
         onNoticeSkipped = { [weak self] in
-            UIWindow.getRootNavigationController.viewControllers.removeAll()
             self?.finished?()
         }
         

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -30,18 +30,15 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
         
     private let factory: TabBarPresentable
     private var navigationController: UINavigationController
-    private let items: [UIViewController]
     
     // MARK: - Init
     
     public init(
         navigationController: UINavigationController,
-        factory: TabBarPresentable,
-        items: [UIViewController]
+        factory: TabBarPresentable
     ) {
         self.navigationController = navigationController
         self.factory = factory
-        self.items = items
     }
     
     // MARK: - Coordinator Life Cycle
@@ -84,8 +81,9 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
             self?.navigationController.pushViewController(webView, animated: true)
         }
         
-        let navigation = UINavigationController(rootViewController: tabBar.vc)
-        CoordinatorUtils.replaceRootWindowWithAnimate(root: navigation, hideBar: true)
-        self.navigationController = navigation
+//        let navigation = UINavigationController(rootViewController: tabBar.vc)
+//        navigationController.pushViewController(tabBar.vc, animated: true)
+//        CoordinatorUtils.replaceRootWindowWithAnimate(root: tabBar.vc, hideBar: true)
+//        self.navigationController = tabBar.vc
     }
 }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -80,10 +80,5 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
             let webView = SOPTWebView(startWith: url)
             self?.navigationController.pushViewController(webView, animated: true)
         }
-        
-//        let navigation = UINavigationController(rootViewController: tabBar.vc)
-//        navigationController.pushViewController(tabBar.vc, animated: true)
-//        CoordinatorUtils.replaceRootWindowWithAnimate(root: tabBar.vc, hideBar: true)
-//        self.navigationController = tabBar.vc
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- Splash가 deinit되지 않는 문제와 탭 바가 화면전환이 되지 않는 문제를 해결했습니다.
- 해결과정에서 탭 바의 구성 방식을 변경하였습니다.

🌱 작업한 브랜치
- feature/#636

## 🌱 PR Point
## ✅ 문제 상황
#626 에서 Splash가 종료되었음에도 SplashVC가 deinit되지 않는 현상이 있었습니다.
```swift
UIWindow.getRootNavigationController.viewControllers.removeAll()
```
해당 코드를 활용해 **최상위 navigation의 모든 뷰컨트롤러를 제거하는 방식**으로 문제를 해결하고자 했으나, 
**탭 바간의 화면전환이 되지 않는 또 다른 문제가 발생**했습니다.

## ✅ 문제 원인
앱 코디네이터에서 **탭 바를 구성하는 로직이 원인**이었습니다.

### 🌿 앱 코디네이터의 tabBarFlow 실행 과정

1. runHomeFlow실행 → rootNavigationController에 HomeVC push
2. soptlogFlow 실행 → rootNavigationController에 SoptlogVC push
3. TabBarCooridnator 실행 → 새로운 NavigationController로 감싸 window.rootController로 설정
4. 하지만 TabBarVC가 가지고 있는 뷰컨은 runHomeFlow와 soptlogFlow로부터 생성된 VC임
5. 따라서 **runHomeFlow와 soptlogFlow의 코디네이터에서 rootNavigationController에 push가 잘 되어야** 탭 바 아이템과 정확히 매치됨.

디버그용 print문을 찍어보니 `viewControllers.removeAll()`로 **SplashVC를 제거한 경우, runHomeFlow와 runSoptlogFlow에서 push가 제대로 일어나지 않고** 있었습니다.

### 🌿그치만 홈 뷰는 잘 보이는데?
탭 바 구성이 제대로 되지 않았음에도 육안상 문제가 없던 이유는 **TabBarController에 뷰컨트롤러를 주입해주었기 때문**입니다.
**탭 바에 주입된 뷰컨트롤러는 `HomeCoordinator`와 `SoptlogCoordinator`에서 생성된 것**이고, **이것이 navigationStack에 존재하지 않아** 탭 바 아이템 구성이 되지 않았다는 오류가 발생하게 됩니다.
```
Thread 1: "Inconsistency in UITabBar items and view controllers detected. No view controller matches the UITabBarItem '<UITabBarItem: 0x101d38db0> title='솝트로그' image=<UIImage:0x600003003b10 anonymous {25, 24} renderingMode=alwaysTemplate> selected'."
```

### 🌿왜 push가 되지 않을까?
`UINavigationStack`은 최소 하나의 뷰컨트롤러를 가지고 있어야 정상적으로 push/pop을 수행할 수 있습니다. 
그런데 `viewControllers.removeAll()`로 **스택을 모두 비웠기 때문에 홈과 솝트로그가 push 되지 않았던 것**입니다. (pop splashVC가 되지 않았던 이유도 동일함)


## ✅ 해결 과정
navigationStack이 비어있다면 `setviewcontrollers` 또는 ` window.rootViewcontroller`로 루트컨트롤러를 교체해주어야합니다. 

### 🌿 탭 바 그렇게 바꿨는데?
유틸함수인 `replaceRootWindowWithAnimate`로 **윈도우의 루트컨트롤러를 교체했기 때문에 정상적으로 스택에 적재된 것**입니다.

단, SplashVC를 띄워주는 네비게이션 컨트롤러와 탭바를 띄워주는 네비게이션 컨트롤러가 달라 SplashVC는 그대로 스택에 남아있게 됩니다.
- SplashVC를 띄우는 navigation: 앱 코디네이터의 rootNavigationContrller
- TabBar를 띄우는 navigation: 탭 바 코디네이터에서 새로 생성한 네비게이션 컨트롤러

따라서 탭바를 띄울 때 새로운 네비게이션 컨트롤러를 생성하지 않고, SplashVC를 띄우는 앱 코디네이터의 navigationController.setViewController를 사용하여 SplashVC가 deinit되고 탭바가 루트컨트롤러가 되도록 수정했습니다.

## ✅ 파생 효과
### 🌿 rootNavigatoinController의 통일
기존에는 웹 링크가 정상 동작하지 않아 `keyWindow`의 `navigationController`를 dismiss하는 방식으로 대응했으나(#621),
이제 **앱 코디네이터의 rootNavigationController와 탭바의 NavigationController가 동일하기 때문에 `UIWindow.getRootNavigationController`와 구분이 필요하지 않습니다.**

### 🌿 딥링크 로직 변경
기존에는 딥링크 로직 실행 전, 앱 코디네이터의 rootNavigationController를 먼저 dismiss한 뒤 딥링크를 파싱하여 화면을 쌓는 방식으로 동작했습니다.
이때 rootNavigationController는 Home, Soptlog, TabBar를 포함하고 있고, 나머지 플로우는 탭바를 띄우는 컨트롤러 위에 쌓이는 구조였습니다.
따라서 **딥링크를 띄우기 전 dismiss하는 네비게이션과 실제 딥링크를 띄우는 네비게이션이 서로 달라 화면 전환에 문제가 없었습니다.**
<img width="635" alt="image" src="https://github.com/user-attachments/assets/3b44281f-4efa-4027-8d04-e4fd054263ba" />

하지만 네비게이션이 하나로 통합되며, **딥링크 처리 중 dismiss가 발생하면 동일한 네비게이션 컨트롤러에서 dismiss와 push가 충돌는 문제**가 생겼습니다.
이는 **dismiss가 순차 실행을 보장하지 않기 때문**으로, dismiss 대신 **pop을 사용해 실행 중인 플로우가 제거된 후 딥링크 로직을 수행**하도록 했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 🌿 탭 바의 각 VC를 감싸는 navigation 추가
HomeVC와 SoptlogVC를 감싸는 NavigationController를 추가했습니다.
기존 구조는 `UINavigationController` → `TabBarController` → `HomeVC / SoptlogVC` 형태로, 홈과 솝트로그 탭이 하나의 네비게이션 스택에서 관리되고 있었습니다.
현재 앱 구조에서는 모든 서비스가 탭 바를 덮기 때문에, 홈 탭에서 화면을 여러 개 push한 뒤 솝트로그 탭으로 이동하는 일이 발생하지 않습니다.
하지만 **홈 탭에서 여러 화면을 push한 뒤 솝트로그 탭으로 이동하면 이전에 쌓아둔 홈 탭의 스택이 그대로 남아있어 문제가 발생**할 가능성이 있습니다.
이를 방지하기 위해 **각 탭의 VC를 별도의 UINavigationController로 감싸 스택을 독립적으로 관리하도록 구조를 변경**하였습니다.

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #636
