### PR TITLE
[Refactor] #626 - SplashFlow의 코디네이터 의존성 제거 방식 변경(25.06.19 논의 반영)

### DIFF
--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -174,7 +174,7 @@ final class ApplicationCoordinator: BaseCoordinator {
 
 extension ApplicationCoordinator {
     private func runSplashFlow() {
-        var coordinator: DefaultCoordinator
+        var coordinator: BaseCoordinator
         
         switch Config.coordinatorFlag {
         case .legacy:

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacySplashFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/LegacySplashFeatureBuildable.swift
@@ -7,8 +7,9 @@
 //
 
 import Core
+import BaseFeatureDependency
 
 public protocol LegacySplashFeatureViewBuildable {
-    func makeSplash(_ coordinator: SplashCoordinatable) -> LegacySplashPresentable
+    func makeSplash(_ coordinator: Coordinator) -> LegacySplashPresentable
     func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> LegacyNoticePopUpViewControllable
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashFeatureBuildable.swift
@@ -9,8 +9,9 @@
 import UIKit
 
 import Core
+import BaseFeatureDependency
 
 public protocol SplashFeatureBuildable {
-    func makeSplash(_ coordinator: SplashCoordinatable) -> SplashPresentable
+    func makeSplash(_ coordinator: Coordinator) -> SplashPresentable
     func makeNoticePopUpVC(noticeType: NoticePopUpType, content: String) -> NoticePopUpPresentable
 }

--- a/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Interface/Sources/SplashPresentable.swift
@@ -13,12 +13,12 @@ import Domain
 import BaseFeatureDependency
 
 public protocol SplashViewControllable: LegacyViewControllable { }
-public protocol SplashCoordinatable {
+public protocol SplashRoutingTrigger {
     var onNoticeSkipped: (() -> Void)? { get set }
     var onNoticeExist: ((AppNoticeModel) -> Void)? { get set }
     var finished: (() -> Void)? { get set }
 }
 
-public typealias LegacySplashPresentable = (vc: SplashViewControllable, vm: any ViewModelType)
-
-public typealias SplashPresentable = (vc: UIViewController, vm: any ViewModelType)
+public typealias SplashViewModelType = SplashRoutingTrigger & ViewModelType
+public typealias LegacySplashPresentable = (vc: SplashViewControllable, vm: any SplashViewModelType)
+public typealias SplashPresentable = (vc: UIViewController, vm: any SplashViewModelType)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import SplashFeatureInterface
 
 public
@@ -18,7 +19,7 @@ final class LegacySplashBuilder {
 }
 
 extension LegacySplashBuilder: LegacySplashFeatureViewBuildable {
-    public func makeSplash(_ coordinator: SplashCoordinatable) -> LegacySplashPresentable {
+    public func makeSplash(_ coordinator: Coordinator) -> LegacySplashPresentable {
         let useCase = DefaultSplashUseCase(repository: repository)
         let vm = SplashViewModel(useCase: useCase, coordinator: coordinator)
         let vc = SplashVC(viewModel: vm)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/LegacySplashCoordinator.swift
@@ -12,7 +12,7 @@ import Core
 import Domain
 
 public
-final class LegacySplashCoordinator: DefaultCoordinator & SplashCoordinatable {
+final class LegacySplashCoordinator: BaseCoordinator {
     public var finished: (() -> Void)?
     public var onNoticeSkipped: (() -> Void)?
     public var onNoticeExist: ((Domain.AppNoticeModel) -> Void)?
@@ -34,11 +34,12 @@ final class LegacySplashCoordinator: DefaultCoordinator & SplashCoordinatable {
     }
     
     private func showSplash() {
-        let splash = factory.makeSplash(self)
-        onNoticeExist = { [weak self] appNoticeModel in
+        var splash = factory.makeSplash(self)
+        
+        splash.vm.onNoticeExist = { [weak self] appNoticeModel in
             self?.presentNoticePopUp(model: appNoticeModel)
         }
-        onNoticeSkipped = { [weak self] in
+        splash.vm.onNoticeSkipped = { [weak self] in
             self?.finishFlow?()
         }
         router.setRootModule(splash.vc, animated: true)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import SplashFeatureInterface
 
 public final class SplashBuilder {
@@ -17,7 +18,7 @@ public final class SplashBuilder {
 }
 
 extension SplashBuilder: SplashFeatureBuildable {
-    public func makeSplash(_ coordinator: SplashCoordinatable) -> SplashPresentable {
+    public func makeSplash(_ coordinator: Coordinator) -> SplashPresentable {
         let useCase = DefaultSplashUseCase(repository: repository)
         let vm = SplashViewModel(useCase: useCase, coordinator: coordinator)
         let vc = SplashVC(viewModel: vm)

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/Coordinator/SplashCoordinator.swift
@@ -13,22 +13,15 @@ import SplashFeatureInterface
 import Core
 import Domain
 
-public final class SplashCoordinator: DefaultCoordinator & SplashCoordinatable {
-    
-    // MARK: - SplashCoordinatable
-    
-    public var onNoticeSkipped: (() -> Void)?
-    public var onNoticeExist: ((Domain.AppNoticeModel) -> Void)?
-    public var finished: (() -> Void)?
-    
+public final class SplashCoordinator: BaseCoordinator {
     
     // MARK: - Properties
-    
-    public var finishFlow: (() -> Void)?
     
     private weak var navigationController: UINavigationController?
     private let factory: SplashFeatureBuildable
     private let cancelBag = CancelBag()
+    
+    public var finished: (() -> Void)?
     
     // MARK: - Init
     
@@ -50,13 +43,13 @@ public final class SplashCoordinator: DefaultCoordinator & SplashCoordinatable {
     // MARK: - Navigation
     
     private func showSplash() {
-        let splash = factory.makeSplash(self)
+        var splash = factory.makeSplash(self)
         
-        onNoticeExist = { [weak self] appNoticeModel in
+        splash.vm.onNoticeExist = { [weak self] appNoticeModel in
             self?.presentNoticePopUp(model: appNoticeModel)
         }
         
-        onNoticeSkipped = { [weak self] in
+        splash.vm.onNoticeSkipped = { [weak self] in
             self?.finished?()
         }
         

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/ViewModel/SplashViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/ViewModel/SplashViewModel.swift
@@ -14,9 +14,17 @@ import Domain
 import BaseFeatureDependency
 import SplashFeatureInterface
 
-public class SplashViewModel: ViewModelType {
+public class SplashViewModel: SplashViewModelType {
     
-    private let coordinator: SplashCoordinatable
+    // MARK: - Trigger
+    
+    public var onNoticeSkipped: (() -> Void)?
+    public var onNoticeExist: ((Domain.AppNoticeModel) -> Void)?
+    public var finished: (() -> Void)?
+    
+    // MARK: - Properties
+    
+    private let coordinator: AnyCoordinatorObject
     private let useCase: SplashUseCase
     private var cancelBag = CancelBag()
     
@@ -33,7 +41,7 @@ public class SplashViewModel: ViewModelType {
     
     // MARK: - init
     
-    public init(useCase: SplashUseCase, coordinator: SplashCoordinatable) {
+    public init(useCase: SplashUseCase, coordinator: Coordinator) {
         self.useCase = useCase
         self.coordinator = coordinator
     }
@@ -54,7 +62,7 @@ extension SplashViewModel {
                 print("SplashViewModel - completion: \(event)")
             } receiveValue: { owner, appNoticeModel in
                 guard let appNoticeModel = appNoticeModel else {
-                    owner.coordinator.onNoticeSkipped?()
+                    owner.onNoticeSkipped?()
                     return
                 }
                 
@@ -63,7 +71,7 @@ extension SplashViewModel {
                     return
                 }
                 
-                owner.coordinator.onNoticeExist?(appNoticeModel)
+                owner.onNoticeExist?(appNoticeModel)
             }.store(in: cancelBag)
     }
 


### PR DESCRIPTION
## 🌴 PR 요약
- https://github.com/sopt-makers/SOPT-iOS/pull/640 의 논의와 코드리뷰를 바탕으로 재리팩토링 했습니다!

🌱 작업한 브랜치
- feature/#626

## 🌱 PR Point
**SplashFinishOutput 프로토콜 생성**
SplashCoordinator 종료 시 다음 플로우(Auth 또는 TabBar)로 전환하는 클로저를 `SplashFinishOutput` 프로토콜로 분리하여,
화면 분기 책임을 뷰모델이 아닌 코디네이터에서 갖도록 구조를 변경했습니다.(네이밍은 Legacy 코드를 참고했습니다.)

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #626
