### PR TITLE
[Refactor] #631 - AttendanceFlow의 코디네이터 의존성 제거 방식 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/AttendanceFeatureBuildable.swift
@@ -11,7 +11,7 @@ import BaseFeatureDependency
 import Domain
 
 public protocol AttendanceFeatureBuildable {
-    func makeShowAttendanceVC() -> ShowAttendancePresentable
+    func makeShowAttendanceVC(coordinator: Coordinator) -> ShowAttendancePresentable
     func makeAttendanceVC(
         lectureRound: AttendanceRoundModel,
         dismissCompletion: (() -> Void)?

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/LegacyAttendanceFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Interface/Sources/LegacyAttendanceFeatureBuildable.swift
@@ -11,7 +11,7 @@ import BaseFeatureDependency
 import Domain
 
 public protocol LegacyAttendanceFeatureBuildable {
-    func makeShowAttendanceVC() -> LegacyShowAttendanceViewControllable
+    func makeShowAttendanceVC(coordinator: Coordinator) -> LegacyShowAttendanceViewControllable
     func makeAttendanceVC(
         lectureRound: AttendanceRoundModel,
         dismissCompletion: (() -> Void)?

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import AttendanceFeatureInterface
 
 public
@@ -19,9 +20,9 @@ final class AttendanceBuilder {
 }
 
 extension AttendanceBuilder: AttendanceFeatureBuildable {
-    public func makeShowAttendanceVC() -> ShowAttendancePresentable {
+    public func makeShowAttendanceVC(coordinator: Coordinator) -> ShowAttendancePresentable {
         let useCase = DefaultShowAttendanceUseCase(repository: showAttendanceRepository)
-        let viewModel = ShowAttendanceViewModel(useCase: useCase)
+        let viewModel = ShowAttendanceViewModel(useCase: useCase, coordinator: coordinator)
         let showAttendanceVC = ShowAttendanceVC(viewModel: viewModel)
         return (showAttendanceVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
@@ -20,7 +20,7 @@ public final class AttendanceCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: AttendanceFeatureBuildable
-    private let navigationController: UINavigationController
+    private weak var navigationController: UINavigationController?
     
     // MARK: - Init
     
@@ -41,18 +41,17 @@ public final class AttendanceCoordinator: DefaultCoordinator {
     // MARK: - Navigation
     
     private func showShowAttendance() {
-        var showAttendance = factory.makeShowAttendanceVC()
+        var showAttendance = factory.makeShowAttendanceVC(coordinator: self)
         
         showAttendance.vc.onNaviBackTap = { [weak self] in
-            self?.navigationController.popViewController(animated: true)
-            self?.finishFlow?()
+            self?.navigationController?.popViewController(animated: true)
         }
         
         showAttendance.vc.onAttendanceButtonTap = { [weak self] lectureRound, completion in
             self?.showAttendance(lectureRound, completion)
         }
         
-        navigationController.pushViewController(showAttendance.vc, animated: true)
+        navigationController?.pushViewController(showAttendance.vc, animated: true)
     }
     
     internal func showAttendance(_ lectureRound: AttendanceRoundModel, _ dismissCompletion: (() -> Void)?) {
@@ -63,6 +62,6 @@ public final class AttendanceCoordinator: DefaultCoordinator {
         
         attendance.vc.modalPresentationStyle = .overFullScreen
         attendance.vc.modalTransitionStyle = .crossDissolve
-        navigationController.present(attendance.vc, animated: true)
+        navigationController?.present(attendance.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/LegacyAttendanceBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/LegacyAttendanceBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import AttendanceFeatureInterface
 
 public
@@ -19,9 +20,9 @@ final class LegacyAttendanceBuilder {
 }
 
 extension LegacyAttendanceBuilder: LegacyAttendanceFeatureBuildable {
-    public func makeShowAttendanceVC() -> LegacyShowAttendanceViewControllable {
+    public func makeShowAttendanceVC(coordinator: Coordinator) -> LegacyShowAttendanceViewControllable {
         let useCase = DefaultShowAttendanceUseCase(repository: showAttendanceRepository)
-        let viewModel = ShowAttendanceViewModel(useCase: useCase)
+        let viewModel = ShowAttendanceViewModel(useCase: useCase, coordinator: coordinator)
         let showAttendanceVC = ShowAttendanceVC(viewModel: viewModel)
         return showAttendanceVC
     }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/LegacyAttendanceCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/LegacyAttendanceCoordinator.swift
@@ -29,7 +29,7 @@ final class LegacyAttendanceCoordinator: DefaultCoordinator {
     }
     
     private func showShowAttendance() {
-        var showAttendance = factory.makeShowAttendanceVC()
+        var showAttendance = factory.makeShowAttendanceVC(coordinator: self)
         showAttendance.onNaviBackTap = { [weak self] in
             self?.router.popModule()
             self?.finishFlow?()

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 
 import Core
 import Domain
-
+import BaseFeatureDependency
 import AttendanceFeatureInterface
 
 struct AttendanceButtonInfo {
@@ -31,6 +31,7 @@ public final class ShowAttendanceViewModel: ShowAttendanceViewModelType {
     private var cancelBag = CancelBag()
     public var sceneType: AttendanceScheduleType?
     public var lectureRound: AttendanceRoundModel = .EMPTY
+    private let coordinator: AnyCoordinatorObject
     
     // MARK: - Inputs
     
@@ -52,8 +53,13 @@ public final class ShowAttendanceViewModel: ShowAttendanceViewModelType {
     
     // MARK: - init
   
-    public init(useCase: ShowAttendanceUseCase) {
+    public init(useCase: ShowAttendanceUseCase, coordinator: Coordinator) {
         self.useCase = useCase
+        self.coordinator = coordinator
+    }
+    
+    deinit {
+        print("vm deinit")
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -469,6 +469,11 @@ extension ApplicationCoordinator {
                 ),
                 factory: LegacyAttendanceBuilder()
             )
+            coordinator.finishFlow = { [weak self, weak coordinator] in
+                coordinator?.childCoordinators = []
+                self?.removeDependency(coordinator)
+            }
+            addDependency(coordinator)
         case .new:
             coordinator = AttendanceCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
@@ -476,11 +481,6 @@ extension ApplicationCoordinator {
             )
         }
         
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
-        }
-        addDependency(coordinator)
         coordinator.start()
         
         return coordinator


### PR DESCRIPTION
## 🌴 PR 요약
- AttendanceFlow의 코디네이터 의존성 제거 방식을 변경했습니다.

🌱 작업한 브랜치
- feature/#631

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 제 dev환경에서는 모달 화면전환이 확인이 안되는데, `showAttendanceVC`가 코디네이터의 루트 VC라 showAttendanceVC만 확인해도 문제되지 않을 듯 하여 PR 올립니다 ! ! 
- TODO로 적혀있는 VC -> VM 책임 변경은 리팩토링하지 않았습니다.

## 📸 스크린샷
<img width="762" alt="image" src="https://github.com/user-attachments/assets/cb9b1f93-75cb-4832-8071-f8bebe74c107" />


## 📮 관련 이슈
- Resolved: #631
