### PR TITLE
[Refactor] #634 - NotificationFlow의 코디네이터 의존성 제거 방식 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -57,10 +57,6 @@ public final class ShowAttendanceViewModel: ShowAttendanceViewModelType {
         self.useCase = useCase
         self.coordinator = coordinator
     }
-    
-    deinit {
-        print("vm deinit")
-    }
 }
 
 extension ShowAttendanceViewModel {

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/LegacyNotificationFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/LegacyNotificationFeatureBuildable.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol LegacyNotificationFeatureBuildable {
-    func makeNotificationList() -> LegacyNotificationListPresentable
+    func makeNotificationList(coordinator: Coordinator) -> LegacyNotificationListPresentable
     func makeNotificationDetailVC(notificationId: String) -> LegacyNotificationDetailPresentable
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationDetailPresentable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationDetailPresentable.swift
@@ -14,13 +14,13 @@ import Domain
 
 public protocol NotificationDetailViewControllable: LegacyViewControllable { }
 
-public protocol NotificationDetailCoordinatable {
+public protocol NotificationDetailRoutingTrigger {
     var onShortCutButtonTap: ((ShortCutLink) -> Void)? { get set }
 }
 
 public typealias ShortCutLink = (url: String, isDeepLink: Bool)
 
-public typealias NotificationDetailViewModelType = ViewModelType & NotificationDetailCoordinatable
+public typealias NotificationDetailViewModelType = ViewModelType & NotificationDetailRoutingTrigger
 public typealias LegacyNotificationDetailPresentable = (vc: NotificationDetailViewControllable, vm: any NotificationDetailViewModelType)
 
 public typealias NotificationDetailPresentable = (vc: UIViewController, vm: any NotificationDetailViewModelType)

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationFeatureBuildable.swift
@@ -9,8 +9,9 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol NotificationFeatureBuildable {
-    func makeNotificationList() -> NotificationListPresentable
+    func makeNotificationList(coordinator: Coordinator) -> NotificationListPresentable
     func makeNotificationDetailVC(notificationId: String) -> NotificationDetailPresentable
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Interface/Sources/NotificationListPresentable.swift
@@ -13,11 +13,11 @@ import Core
 import Domain
 
 public protocol NotificationListViewControllable: LegacyViewControllable { }
-public protocol NotificationListCoordinatable {
+public protocol NotificationListRoutingTrigger {
     var onNaviBackButtonTap: (() -> Void)? { get set }
     var onNotificationTap: ((String) -> Void)? { get set }
 }
-public typealias NotificationListViewModelType = ViewModelType & NotificationListCoordinatable
+public typealias NotificationListViewModelType = ViewModelType & NotificationListRoutingTrigger
 public typealias LegacyNotificationListPresentable = (vc: NotificationListViewControllable, vm: any NotificationListViewModelType)
 
 public typealias NotificationListPresentable = (vc: UIViewController, vm: any NotificationListViewModelType)

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/LegacyNotificationBuilder.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/LegacyNotificationBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import NotificationFeatureInterface
 
 public
@@ -19,9 +20,9 @@ final class LegacyNotificationBuilder {
 }
 
 extension LegacyNotificationBuilder: LegacyNotificationFeatureBuildable {
-    public func makeNotificationList() -> LegacyNotificationListPresentable {
+    public func makeNotificationList(coordinator: Coordinator) -> LegacyNotificationListPresentable {
         let useCase = DefaultNotificationListUseCase(repository: notificationListRepository)
-        let vm = NotificationListViewModel(useCase: useCase)
+        let vm = NotificationListViewModel(useCase: useCase, coordinator: coordinator)
         let vc = NotificationListVC(viewModel: vm)
         return (vc, vm)
     }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/LegacyNotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/LegacyNotificationCoordinator.swift
@@ -31,7 +31,7 @@ final class LegacyNotificationCoordinator: DefaultNotificationCoordinator {
     }
     
     private func showNotifcationList() {
-        var notificiationList = factory.makeNotificationList()
+        var notificiationList = factory.makeNotificationList(coordinator: self)
         notificiationList.vm.onNaviBackButtonTap = { [weak self] in
             self?.router.popModule()
             self?.finishFlow?()

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationBuilder.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import NotificationFeatureInterface
 
 public
@@ -19,9 +20,9 @@ final class NotificationBuilder {
 }
 
 extension NotificationBuilder: NotificationFeatureBuildable {
-    public func makeNotificationList() -> NotificationListPresentable {
+    public func makeNotificationList(coordinator: Coordinator) -> NotificationListPresentable {
         let useCase = DefaultNotificationListUseCase(repository: notificationListRepository)
-        let vm = NotificationListViewModel(useCase: useCase)
+        let vm = NotificationListViewModel(useCase: useCase, coordinator: coordinator)
         let vc = NotificationListVC(viewModel: vm)
         return (vc, vm)
     }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinator.swift
@@ -17,15 +17,13 @@ public protocol NotificationCoordinatorDelegate: AnyObject {
     func notificationCoordinator(_ coordinator: NotificationCoordinator, to destination: NotificationCoordinatorDestination)
 }
 
-public final class NotificationCoordinator: DefaultNotificationCoordinator {
+public final class NotificationCoordinator: BaseCoordinator {
     
     // MARK: - Properties
     
     public weak var delegate: NotificationCoordinatorDelegate?
-    public var requestCoordinating: ((NotificationCoordinatorDestination) -> Void)?
-    public var finishFlow: (() -> Void)?
 
-    private let navigationController: UINavigationController
+    private weak var navigationController: UINavigationController?
     private let factory: NotificationFeatureBuildable
     
     // MARK: - Init
@@ -48,18 +46,17 @@ public final class NotificationCoordinator: DefaultNotificationCoordinator {
     // MARK: - Navigation
     
     private func showNotificationList() {
-        var notificationList = factory.makeNotificationList()
+        var notificationList = factory.makeNotificationList(coordinator: self)
         
         notificationList.vm.onNaviBackButtonTap = { [weak self] in
-            self?.navigationController.popViewController(animated: true)
-            self?.finishFlow?()
+            self?.navigationController?.popViewController(animated: true)
         }
         
         notificationList.vm.onNotificationTap = { [weak self] notificationId in
             self?.showNotificationDetail(notificationId: notificationId)
         }
         
-        navigationController.pushViewController(notificationList.vc, animated: true)
+        navigationController?.pushViewController(notificationList.vc, animated: true)
     }
 
     public func showNotificationDetail(notificationId: String) {
@@ -78,6 +75,6 @@ public final class NotificationCoordinator: DefaultNotificationCoordinator {
             self.delegate?.notificationCoordinator(self, to: destination)
         }
         
-        navigationController.pushViewController(notificationDetail.vc, animated: true)
+        navigationController?.pushViewController(notificationDetail.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinatorOutput.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/Coordinator/NotificationCoordinatorOutput.swift
@@ -8,6 +8,7 @@
 
 import BaseFeatureDependency
 
+// TODO: - Legacy 제거 시 함께 제거
 public protocol NotificationCoordinatorOutput: CoordinatorFinishOutput {
     var requestCoordinating: ((NotificationCoordinatorDestination) -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationDetailScene/ViewModel/NotificationDetailViewModel.swift
@@ -16,9 +16,13 @@ import BaseFeatureDependency
 import NotificationFeatureInterface
 
 public class NotificationDetailViewModel: NotificationDetailViewModelType {
+    
+    // MARK: - Trigger
+    
+    public var onShortCutButtonTap: ((ShortCutLink) -> Void)?
 
     // MARK: - Properties
-    
+
     private let useCase: NotificationDetailUseCase
     private var cancelBag = CancelBag()
     
@@ -37,10 +41,6 @@ public class NotificationDetailViewModel: NotificationDetailViewModelType {
     public struct Output {
         var notification = PassthroughSubject<NotificationDetailModel, Never>()
     }
-    
-    // MARK: - NotificationCoordinatable
-    
-    public var onShortCutButtonTap: ((ShortCutLink) -> Void)?
     
     // MARK: - init
   

--- a/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/NotificationFeature/Sources/NotificationListScene/ViewModel/NotificationListViewModel.swift
@@ -11,13 +11,18 @@ import Combine
 
 import Core
 import Domain
-
-import NotificationFeatureInterface
+import BaseFeatureDependency
 
 public class NotificationListViewModel: NotificationListViewModelType {
     
+    // MARK: - Trigger
+    
+    public var onNaviBackButtonTap: (() -> Void)?
+    public var onNotificationTap: ((String) -> Void)?
+    
     // MARK: - Properties
     
+    private let coordinator: AnyCoordinatorObject
     private let useCase: NotificationListUseCase
     private var cancelBag = CancelBag()
     
@@ -48,15 +53,11 @@ public class NotificationListViewModel: NotificationListViewModelType {
         var refreshLoading = PassthroughSubject<Bool, Never>()
     }
     
-    // MARK: - NotificationCoordinatable
-    
-    public var onNaviBackButtonTap: (() -> Void)?
-    public var onNotificationTap: ((String) -> Void)?
-    
     // MARK: - init
     
-    public init(useCase: NotificationListUseCase) {
+    public init(useCase: NotificationListUseCase, coordinator: Coordinator) {
         self.useCase = useCase
+        self.coordinator = coordinator
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -188,6 +188,7 @@ extension ApplicationCoordinator {
                 self?.removeDependency(legacyCoordinator
                 )
             }
+            addDependency(legacyCoordinator)
             coordinator = legacyCoordinator
         case .new:
             let newCoordinator = SplashCoordinator(
@@ -202,7 +203,6 @@ extension ApplicationCoordinator {
             coordinator = newCoordinator
         }
         
-        addDependency(coordinator)
         coordinator.start()
     }
     
@@ -677,8 +677,8 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runNotificationFlow() -> DefaultNotificationCoordinator {
-        var coordinator: DefaultNotificationCoordinator
+    internal func runNotificationFlow() -> BaseCoordinator {
+        var coordinator: BaseCoordinator
         
         switch Config.coordinatorFlag {
         case .legacy:
@@ -698,6 +698,11 @@ extension ApplicationCoordinator {
                 }
             }
             
+            addDependency(legacyCoordinator)
+            legacyCoordinator.finishFlow = { [weak self, weak legacyCoordinator] in
+                legacyCoordinator?.childCoordinators = []
+                self?.removeDependency(legacyCoordinator)
+            }
             coordinator = legacyCoordinator
         case .new:
             let newCoordinator = NotificationCoordinator(
@@ -708,12 +713,6 @@ extension ApplicationCoordinator {
             coordinator = newCoordinator
         }
         
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
-        }
-        
-        addDependency(coordinator)
         coordinator.start()
         
         return coordinator


### PR DESCRIPTION
## 🌴 PR 요약
- NotificationFlow의 코디네이터 의존성 제거 방식을 변경했습니다.

🌱 작업한 브랜치
- feature/#634

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
https://github.com/user-attachments/assets/c551935f-028e-4a8f-ab93-c1eedb00b6ae



## 📮 관련 이슈
- Resolved: #634
