### PR TITLE
[Refactor] #666 - on/off 가능한 신규 인증 유저 플로우 구축

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/DIContainer/Injected.swift
+++ b/SOPT-iOS/Projects/Core/Sources/DIContainer/Injected.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @propertyWrapper
 public class Injected<T> {
-    public let wrappedValue: T
+    public var wrappedValue: T
     
     public init() {
         self.wrappedValue = DIContainer.shared.resolve()

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthCoordinatorInterface.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthCoordinatorInterface.swift
@@ -1,10 +1,11 @@
 //
-//  AuthCoordnatorFinishOutput.swift
+//  AuthCoordinatorInterface.swift
 //  AuthFeatureInterface
 //
 //  Created by 장석우 on 7/12/25.
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
+
 
 import Foundation
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthCoordnatorFinishOutput.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthCoordnatorFinishOutput.swift
@@ -1,0 +1,18 @@
+//
+//  AuthCoordnatorFinishOutput.swift
+//  AuthFeatureInterface
+//
+//  Created by 장석우 on 7/12/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import BaseFeatureDependency
+import Core
+
+public protocol AuthCoordinatorFinishOutput {
+    var finishFlow: ((UserType) -> Void)? { get set }
+}
+
+public typealias DefaultAuthCoordinator = BaseCoordinator & AuthCoordinatorFinishOutput

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -14,12 +14,6 @@ import Core
 import DSKit
 import WebFeature
 
-public protocol AuthCoordinatorFinishOutput {
-    var finishFlow: ((UserType) -> Void)? { get set }
-}
-
-public typealias DefaultAuthCoordinator = BaseCoordinator & AuthCoordinatorFinishOutput
-
 public final class AuthCoordinator: DefaultAuthCoordinator {
 
     public var finishFlow: ((UserType) -> Void)?

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
@@ -11,4 +11,11 @@ import Foundation
 /// Coordinator에서 DeepLinkOption의 종류를 지정하는 enum입니다.
 public enum DeepLinkOption {
     case signInSuccess(url: String)
+    
+    public var url: String {
+        switch self {
+        case .signInSuccess(let url):
+            return url
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Interface/Sources/AuthFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Interface/Sources/AuthFeatureBuildable.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-public protocol AuthFeatureBuildable {
-    func makeSignIn() -> SignInPresentable
+public protocol LegacyAuthFeatureBuildable {
+    func makeSignIn() -> LegacySignInPresentable
 }

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Interface/Sources/SignInPresentable.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Interface/Sources/SignInPresentable.swift
@@ -10,16 +10,16 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol SignInViewControllable: LegacyViewControllable {
+public protocol LegacySignInViewControllable: LegacyViewControllable {
     var skipAnimation: Bool { get set }
     var accessCode: String? { get set }
     var requestState: String? { get set }
 }
 
-public protocol SignInCoordinatable {
+public protocol LegacySignInCoordinatable {
     var onSignInSuccess: ((SiginInHandleableType) -> Void)? { get set }
     var onVisitorButtonTapped: (() -> Void)? { get set }
 }
 
-public typealias SignInViewModelType = ViewModelType & SignInCoordinatable
-public typealias SignInPresentable = (vc: SignInViewControllable, vm: any SignInViewModelType)
+public typealias LegacySignInViewModelType = ViewModelType & LegacySignInCoordinatable
+public typealias LegacySignInPresentable = (vc: LegacySignInViewControllable, vm: any LegacySignInViewModelType)

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Project.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Project.swift
@@ -13,8 +13,9 @@ let project = Project.makeModule(
     name: "LegacyAuthFeature",
     targets: [.unitTest, .staticFramework, .demo, .interface],
     internalDependencies: [
+        .Features.Auth.Interface
     ],
     interfaceDependencies: [
-      .Features.Web.Feature
+        .Features.Web.Feature
     ]
 )

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/Coordinator/AuthBuilder.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/Coordinator/AuthBuilder.swift
@@ -10,7 +10,7 @@ import Core
 import Domain
 import LegacyAuthFeatureInterface
 
-public class AuthBuilder: AuthFeatureBuildable {
+public class LegacyAuthBuilder: LegacyAuthFeatureBuildable {
     @Injected public var repository: SignInRepositoryInterface
     @Injected public var oauthRepository: CoreOAuthRepositoryInterface
     @Injected public var coreRepository: CoreAuthRepositoryInterface
@@ -18,15 +18,15 @@ public class AuthBuilder: AuthFeatureBuildable {
     
     public init() { }
     
-    public func makeSignIn() -> SignInPresentable {
+    public func makeSignIn() -> LegacySignInPresentable {
         let useCase = DefaultSignInUseCase(
             repository: repository,
             oauthRepository: oauthRepository,
             coreRepository: coreRepository,
             tokenRepository: tokenRepository
         )
-        let vm = SignInViewModel(useCase: useCase)
-        let vc = SignInVC()
+        let vm = LegacySignInViewModel(useCase: useCase)
+        let vc = LegacySignInVC()
         vc.viewModel = vm
         return (vc, vm)
     }

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -10,25 +10,21 @@ import Foundation
 
 import BaseFeatureDependency
 import LegacyAuthFeatureInterface
+import AuthFeatureInterface
 import Core
 import DSKit
 
-public protocol AuthCoordinatorFinishOutput {
-    var finishFlow: ((UserType) -> Void)? { get set }
-}
-
-public typealias DefaultAuthCoordinator = BaseCoordinator & AuthCoordinatorFinishOutput
 
 public
-final class AuthCoordinator: DefaultAuthCoordinator {
+final class LegacyAuthCoordinator: DefaultAuthCoordinator {
     
     public var finishFlow: ((UserType) -> Void)?
     
-    private let factory: AuthFeatureBuildable
+    private let factory: LegacyAuthFeatureBuildable
     private let router: LegacyRouter
     private var url: String?
     
-    public init(router: LegacyRouter, factory: AuthFeatureBuildable, url: String? = nil) {
+    public init(router: LegacyRouter, factory: LegacyAuthFeatureBuildable, url: String? = nil) {
         self.factory = factory
         self.router = router
         self.url = url
@@ -83,7 +79,7 @@ final class AuthCoordinator: DefaultAuthCoordinator {
         }
     }
     
-    private func redirectSignIn(module: inout SignInViewControllable, url: String) {
+    private func redirectSignIn(module: inout LegacySignInViewControllable, url: String) {
         module.skipAnimation = true
         for item in parseParameter(url: url) {
             if item.query == "state" {
@@ -99,7 +95,7 @@ final class AuthCoordinator: DefaultAuthCoordinator {
     }
 }
 
-extension AuthCoordinator {
+extension LegacyAuthCoordinator {
     func parseParameter(url: String) -> [(query: String, value: String)] {
         let components = URLComponents(string: url)
         let params = components?.query ?? ""

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/SignInScene/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/SignInScene/SignInVC.swift
@@ -20,11 +20,11 @@ import BaseFeatureDependency
 import SnapKit
 import Then
 
-public class SignInVC: UIViewController, SignInViewControllable {
+public class LegacySignInVC: UIViewController, LegacySignInViewControllable {
 
     // MARK: - Properties
 
-    public var viewModel: SignInViewModel!
+    public var viewModel: LegacySignInViewModel!
     public var skipAnimation: Bool = false
     public var accessCode: String? = nil
     public var requestState: String? = nil
@@ -83,7 +83,7 @@ public class SignInVC: UIViewController, SignInViewControllable {
 
 // MARK: - UI & Layout
 
-extension SignInVC {
+extension LegacySignInVC {
 
     private enum Metric {
         static let topInset = 151.adjustedH + logoMutableY
@@ -154,7 +154,7 @@ extension SignInVC {
 
 // MARK: - Methods
 
-extension SignInVC {
+extension LegacySignInVC {
 
     private func bindViews() {
         signInButton.publisher(for: .touchUpInside)
@@ -179,7 +179,7 @@ extension SignInVC {
             .compactMap { _ in () }
             .asDriver()
 
-        let input = SignInViewModel.Input(
+        let input = LegacySignInViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
             playgroundSignInFinished: signInFinished,
             visitorButtonTapped: visitorButtonTapped

--- a/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/SignInScene/SignInViewModel.swift
+++ b/SOPT-iOS/Projects/Features/LegacyAuthFeature/Sources/SignInScene/SignInViewModel.swift
@@ -13,7 +13,7 @@ import Domain
 
 import LegacyAuthFeatureInterface
 
-public class SignInViewModel: SignInViewModelType {
+public class LegacySignInViewModel: LegacySignInViewModelType {
     
     private let useCase: SignInUseCase
     private var cancelBag = CancelBag()
@@ -43,7 +43,7 @@ public class SignInViewModel: SignInViewModelType {
     }
 }
 
-extension SignInViewModel {
+extension LegacySignInViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -11,6 +11,8 @@ import UIKit
 import Core
 import BaseFeatureDependency
 import SplashFeature
+import AuthFeature
+import LegacyAuthFeature
 import HomeFeature
 import AppMyPageFeature
 import NotificationFeature
@@ -22,14 +24,7 @@ import WebFeature
 import SoptlogFeature
 import TabBarFeature
 
-#if DEV || PROD
-import LegacyAuthFeature
-#else
-import AuthFeature
-#endif
-
-public
-final class ApplicationCoordinator: BaseCoordinator {
+public final class ApplicationCoordinator: BaseCoordinator {
     
     // MARK: - Properties
     
@@ -64,6 +59,20 @@ final class ApplicationCoordinator: BaseCoordinator {
     // MARK: - Coordinator Life Cycle
     
     public override func start(with option: DeepLinkOption?) {
+        
+        DIContainer.shared.register(
+            interface: DefaultAuthCoordinator.self,
+            implement: { [weak self] in
+                guard let self else { return }
+                switch FeatureFlag.auth {
+                case .legacy:
+                    return LegacyAuthCoordinator(router: self.router, factory: LegacyAuthBuilder(), url: option?.url)
+                case .new:
+                    return AuthCoordinator(router: self.router, factory: AuthBuilder(), url: option?.url)
+                }
+            }
+        )
+        
         if let option {
             switch option {
             case .signInSuccess(let url):
@@ -232,7 +241,7 @@ extension ApplicationCoordinator {
         by style: CoordinatorStartingOption,
         with url: String? = nil
     ) {
-        let coordinator = AuthCoordinator(router: router, factory: AuthBuilder(), url: url)
+        @Injected var coordinator: DefaultAuthCoordinator
         
         coordinator.finishFlow = { [weak self, weak coordinator] userType in
             Config.coordinatorFlag == .legacy
@@ -246,7 +255,7 @@ extension ApplicationCoordinator {
     
     private func runSignInSuccessFlow(with url: String) {
         childCoordinators = []
-        let coordinator = AuthCoordinator(router: router, factory: AuthBuilder(), url: url)
+        @Injected var coordinator: DefaultAuthCoordinator
         coordinator.finishFlow = { [weak self, weak coordinator] userType in
             Config.coordinatorFlag == .legacy
             ? self?.runLegacyTabBarFlow(type: userType)


### PR DESCRIPTION
# 요약

신규 인증 로직을 on/off 가능한 구조로 만들기 위해 4단계에 걸쳐 작업을 진행했습니다.

[Phase 1. 토큰 Interceptor 리팩토링](https://github.com/sopt-makers/SOPT-iOS/pull/646)
[Phase 2. 기존 인증 토큰 조회 및 저장 로직 리팩토링](https://github.com/sopt-makers/SOPT-iOS/pull/664)
[Phase 3. on/off 가능한 신규 인증 서버 로직 구축](https://github.com/sopt-makers/SOPT-iOS/pull/667)
**Phase 4. on/off 가능한 신규 인증 유저 플로우 구축**

이번 PR은 네 번째 단계인 **Phase 4. on/off 가능한 신규 인증 유저 플로우 구축**입니다.

# 배경

이전 PR에선 FeatureFlag를 통해 인증 서버 로직을 on/off 가능하게 만들었어요.
신규 인증 로직은 인증 서버 뿐만 아니라 로그인뷰, 회원가입 뷰 등등 뷰까지 변경하게 됩니다.

기존 프로젝트에선 LegacyAuth, Auth 모듈로 분리하였고, ApplicationCoord이 어떤 모듈을 import 하는 지에 따라 로직이 분기처리 되었어요. import은 FeatureFlag로 분기처리할 수 없어, 전처리문으로 분기처리해야한다는 한계점이 존재했어요. 이번 PR에서는 아래와 같이 모든 인증 분기처리를 FeatureFlag로 관리하고자 해요.

**AS-IS**

- 전처리문
    - AuthCoord, LegacyAuthCoord 분기처리
- FeatureFlag
    - 인증 서버 분기처리

**TO-BE**

- FeatureFlag
    - 인증 서버 분기처리
    - AuthCoord, LegacyAuthCoord 분기처리

# 목표

FeatureFlag로 모든 인증 로직이(인증 서버 로직, 신규 회원가입 및 로그인 flow)이 on/ off 되는 구조 만들기

# 설계

이전 PR에서는 변경되는 부분이 저장였기에 TokenRepository를 추상화한 후, 다형성을 통해 문제를 해결했어요.

이번 PR에선 변경되는 부분은 인증 화면의 흐름이 달라집니다. 따라서 AuthCoordinator를 추상화한 후에, 다형성을 통해 문제를 해결하고자 합니다.

첫째로, LegacyAuth와 Auth의 Coordinator가 같은 Interface를 채택하도록 구현했어요.

따라서 아래와 같이 legacyAuth 모듈이 Auth Interface모듈을 의존하도록 했어요.

<img width="765" height="431" alt="스크린샷 2025-07-20 오후 7 10 13" src="https://github.com/user-attachments/assets/aaceef51-2480-4ba5-a4cd-b0b861b082b0" />


그 후, FeatureFlag를 통해 의존성을 등록했어요

### 의존성 등록

```swift
DIContainer.shared.register(
    interface: DefaultAuthCoordinator.self,
    implement: {
        switch FeatureFlag.auth {
        case .new:
            return LegacyAuthCoordinator(...)
        case .legacy:
            return AuthCoordinator(...)
    }
)
```

### Client
그러면 기존 로직에선 분기처리 없이 AuthCoordinator를 resolve하여 사용할 수 있습니다.

```swift
@Injected var coordinator: DefaultAuthCoordinator
coordinator.finsihFlow = { ... }
coordinator.start()
```

# 고려할 점

LegacyAuthCoordinator와 AuthCoordinator는 객체를 생성할 때 router및 url이 필요해요.
이는 applicationCoordinator에서 결정되는 데이터였어요.
따라서 의존성 등록하는 시점을 ApplicationCoord로 선정했습니다.
기존엔 모든 의존성은 AppDelegate에서 등록됐기에 기존 방식과 조금 달라지는 것이 신경쓰이네요.

## 📮 관련 이슈
- closed: #666 