### PR TITLE
[Fix] #678 - ResponseDTO 옵셔널 처리 반영

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeAppServicesModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeAppServicesModel.swift
@@ -11,9 +11,10 @@ import Foundation
 public struct HomeAppServicesModel: Codable {
     public var serviceName: String
     public var displayAlarmBadge: Bool
-    public var alarmBadge, iconURL, deepLink: String
+    public var alarmBadge, deepLink: String
+    public var iconURL: String?
     
-    public init(serviceName: String, displayAlarmBadge: Bool, alarmBadge: String, iconURL: String, deepLink: String) {
+    public init(serviceName: String, displayAlarmBadge: Bool, alarmBadge: String, iconURL: String?, deepLink: String) {
         self.serviceName = serviceName
         self.displayAlarmBadge = displayAlarmBadge
         self.alarmBadge = alarmBadge

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -190,7 +190,7 @@ extension HomeAppServicesModel {
             serviceName: self.serviceName,
             displayAlarmBadge: self.displayAlarmBadge,
             alarmBadge: self.alarmBadge,
-            iconURL: self.iconURL,
+            iconURL: self.iconURL ?? "",                // TODO: - 엠티 이미지 요청 or 후기 폼 API 분리 요청하기
             deepLink: self.deepLink
         )
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeAppServiceAccessStatusEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/HomeAppServiceAccessStatusEntity.swift
@@ -13,7 +13,8 @@ import Foundation
 public struct HomeAppServiceAccessStatusEntity: Codable {
     public let serviceName: String
     public let displayAlarmBadge: Bool
-    public let alarmBadge, iconURL, deepLink: String
+    public let alarmBadge, deepLink: String
+    public let iconURL: String?
 
     enum CodingKeys: String, CodingKey {
         case serviceName, displayAlarmBadge, alarmBadge


### PR DESCRIPTION
## 🌴 PR 요약
- app-service API의 DTO 변경사항을 반영했습니다.

🌱 작업한 브랜치
- feature/#678

## 🌱 PR Point
<img width="959" height="287" alt="image" src="https://github.com/user-attachments/assets/bacf865e-aceb-45ed-8027-861da2d26c20" />

iconUrl이 옵셔널로 변경되어 홈뷰가 보이지 않아 DTO 프로퍼티 옵셔널 처리했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
<img width="375" height="2532" alt="image" src="https://github.com/user-attachments/assets/a8df3d74-cdec-4d00-9125-0535b5fa0c6d" />

비회원 홈 뷰에서 후기 폼이 이렇게 노출되고 있는데, 저희가 분기처리 하거나 서버에게 API 분리를 요청해야할 것 같아요.

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #678
