### PR TITLE
[Fix] #680 - 인증중앙화 오류 해결

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
@@ -48,14 +48,17 @@ extension UserDefaultKeyList {
         clearSoptampUserData()
     }
     
+    
     public static func clearUserData() {
+        // 편의상 legacy, new 분기처리 하지 않고 한번에 삭제한다.
+        
+        // legacy
         UserDefaultKeyList.Auth.appAccessToken = nil
         UserDefaultKeyList.Auth.appRefreshToken = nil
         UserDefaultKeyList.Auth.playgroundToken = nil
         UserDefaultKeyList.Auth.isActiveUser = nil
-    }
-    
-    public static func clearCoreUserData() {
+        
+        // new
         UserDefaultKeyList.CoreAuth.accessToken = nil
         UserDefaultKeyList.CoreAuth.refreshToken = nil
     }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
@@ -42,9 +42,15 @@ extension CoreAuthRepository: CoreAuthRepositoryInterface {
     ) -> AnyPublisher<AuthTokens, CoreAuthError> {
         coreAuthService
             .login(.init(token: identityToken, authPlatform: provider.toData()))
-            .compactMap { $0.data.toDomain() }
-            .mapError { _ in
-                return CoreAuthError.loginFail
+            .compactMap { $0.toDomain() }
+            .mapError { error in
+                if case let .statusCode(response) = error {
+                    let response = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+                    let message = response?["message"] as? String
+                    return CoreAuthError.loginFail(message)
+                } else {
+                    return CoreAuthError.loginFail(nil)
+                }
             }
             .eraseToAnyPublisher()
     }
@@ -52,8 +58,15 @@ extension CoreAuthRepository: CoreAuthRepositoryInterface {
     public func signUp(_ model: Domain.SignUpModel) -> AnyPublisher<Void, CoreAuthError> {
         coreAuthService
             .signUp(model.toData())
-            .mapVoid()
-            .mapError { _ in CoreAuthError.signUpFail }
+            .mapError { error in
+                if case let .statusCode(response) = error {
+                    let response = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+                    let message = response?["message"] as? String
+                    return CoreAuthError.signUpFail(message)
+                } else {
+                    return CoreAuthError.signUpFail(nil)
+                }
+            }
             .eraseToAnyPublisher()
     }
     

--- a/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/CoreAuthRepository.swift
@@ -74,15 +74,31 @@ extension CoreAuthRepository: CoreAuthRepositoryInterface {
         socialService
             .changeSocialAccount(model.toData())
             .mapVoid()
-            .mapError { _ in CoreAuthError.changeSocialAccountFail }
+            .mapError { error in
+                if case let .statusCode(response) = error {
+                    let response = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+                    let message = response?["message"] as? String
+                    return CoreAuthError.changeSocialAccountFail(message)
+                } else {
+                    return CoreAuthError.changeSocialAccountFail(nil)
+                }
+            }
             .eraseToAnyPublisher()
     }
     
     public func searchSocialAccount(_ phone: String) -> AnyPublisher<OAuthProvider, CoreAuthError> {
         socialService
             .getSocialAccount(for: phone)
-            .compactMap { $0.data.toDomain() }
-            .mapError { _ in CoreAuthError.changeSocialAccountFail }
+            .compactMap { $0.toDomain() }
+            .mapError { error in
+                if case let .statusCode(response) = error {
+                    let response = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any]
+                    let message = response?["message"] as? String
+                    return CoreAuthError.searchSocialAccountFail(message)
+                } else {
+                    return CoreAuthError.searchSocialAccountFail(nil)
+                }
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/CoreOAuthRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/CoreOAuthRepository.swift
@@ -28,6 +28,8 @@ public class CoreOAuthRepository {
     
     private let oAuthServiceFactory: OAuthServiceFactory
     
+    private var service: OAuthService?
+    
     public init(oAuthServiceFactory: OAuthServiceFactory) {
         self.oAuthServiceFactory = oAuthServiceFactory
     }
@@ -37,10 +39,11 @@ extension CoreOAuthRepository: CoreOAuthRepositoryInterface {
     
     public func getIdentityToken(from provider: OAuthProvider) -> AnyPublisher<String, Domain.CoreAuthError> {
         let oAuthService = oAuthServiceFactory.create(provider)
+        self.service = oAuthService
         return oAuthService.getIdentityToken()
             .mapError { _ in
                 CoreAuthError.oAuthFail(provider)
-            } // oauth error의 구체화 필요시 여기서 구현
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/CoreLoginTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/CoreLoginTransform.swift
@@ -11,7 +11,7 @@ import Foundation
 import Domain
 import Networks
 
-extension CoreLoginEntity {
+extension AuthTokensEntity {
     public func toDomain() -> AuthTokensModel {
         .init(accessToken: accessToken, refreshToken: refreshToken)
     }

--- a/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
@@ -12,7 +12,8 @@ public enum CoreAuthError: Error {
     case oAuthFail(OAuthProvider)
     case loginFail(String?)
     case signUpFail(String?)
-    case changeSocialAccountFail
+    case changeSocialAccountFail(String?)
+    case searchSocialAccountFail(String?)
     case unknown(Error)
 }
 
@@ -25,8 +26,10 @@ extension CoreAuthError {
             message ?? "로그인에 문제가 발생했습니다."
         case .signUpFail(let message):
             message ?? "회원가입에 문제가 발생했습니다."
-        case .changeSocialAccountFail:
-            "소셜 계정 변경에 문제가 발생했습니다."
+        case .changeSocialAccountFail(let message):
+            message ?? "소셜 계정 변경에 문제가 발생했습니다."
+        case .searchSocialAccountFail(let message):
+            message ?? "소셜 계정 조회에 문제가 발생했습니다."
         case .unknown(_):
             "알 수 없는 문제가 발생했습니다."
         }

--- a/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/CoreAuthError.swift
@@ -10,8 +10,25 @@ import Foundation
 
 public enum CoreAuthError: Error {
     case oAuthFail(OAuthProvider)
-    case loginFail
-    case signUpFail
+    case loginFail(String?)
+    case signUpFail(String?)
     case changeSocialAccountFail
     case unknown(Error)
+}
+
+extension CoreAuthError {
+    public var description: String {
+        switch self {
+        case .oAuthFail(let provider):
+            "\(provider.title) 인증 시 문제가 발생했습니다."
+        case .loginFail(let message):
+            message ?? "로그인에 문제가 발생했습니다."
+        case .signUpFail(let message):
+            message ?? "회원가입에 문제가 발생했습니다."
+        case .changeSocialAccountFail:
+            "소셜 계정 변경에 문제가 발생했습니다."
+        case .unknown(_):
+            "알 수 없는 문제가 발생했습니다."
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/Auth/SignInUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/Auth/SignInUseCase.swift
@@ -59,7 +59,10 @@ extension DefaultSignInUseCase: SignInUseCase {
         oauthRepository.getIdentityToken(from: provider)
             .map { (provider, $0) }
             .flatMap(coreRepository.login)
-            .handleEvents(receiveOutput: tokenRepository.save)
+            .handleEvents(receiveOutput: { [weak self] token in
+                self?.tokenRepository.save(token)
+                self?.coreRepository.saveRecentLogin(provider)
+            })
             .mapVoid()
             .catch { [weak self] in
                 self?.sideEffect.send($0)

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -125,13 +125,12 @@ extension AppMyPageViewModel {
         }
     }
 }
-
+import WebKit
 extension AppMyPageViewModel {
     private func logout() {
-        UserDefaultKeyList.Auth.appAccessToken = nil
-        UserDefaultKeyList.Auth.appRefreshToken = nil
-        UserDefaultKeyList.Auth.playgroundToken = nil
+        UserDefaultKeyList.clearUserData()
         SFSafariViewController.DataStore.default.clearWebsiteData()
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies({_ in  })
     }
     
     private func showResetSoptampAlert() {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
@@ -311,5 +311,12 @@ extension SignInVC {
                 }
             }
             .store(in: cancelBag)
+        
+        output.loginFailToastMessage
+            .withUnretained(self)
+            .sink { owner, message in
+                Toast.showMDSToast(type: .error, text: message)
+            }
+            .store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
@@ -100,32 +100,13 @@ extension SignInViewModel {
             }.store(in: self.cancelBag)
         
         useCase.sideEffect
-            .map({ $0.toastMessage})
-            .sink { toastMessage in
-                output.loginFailToastMessage.send(toastMessage)
+            .map { $0.description }
+            .sink { description in
+                output.loginFailToastMessage.send(description)
         }
         .store(in: cancelBag)
         
         
         return output
-    }
-}
-
-
-extension CoreAuthError {
-    var toastMessage: String {
-        switch self {
-            
-        case .oAuthFail(let provider):
-            "\(provider.title) 인증 시 문제가 발생했습니다."
-        case .loginFail:
-            "로그인에 문제가 발생했습니다."
-        case .signUpFail:
-            "회원가입에 문제가 발생했습니다."
-        case .changeSocialAccountFail:
-            "소셜 계정 변경에 문제가 발생했습니다."
-        case .unknown(_):
-            "알 수 없는 문제가 발생했습니다."
-        }
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
@@ -34,6 +34,7 @@ public class SignInViewModel: SignInViewModelType {
     
     public struct Output {
         let recentLogin = PassthroughSubject<OAuthProvider?, Never>()
+        let loginFailToastMessage = PassthroughSubject<String, Never>()
     }
     
     // MARK: - SignInCoordinating
@@ -98,6 +99,33 @@ extension SignInViewModel {
                 owner.onSignUpButtonTapped?()
             }.store(in: self.cancelBag)
         
+        useCase.sideEffect
+            .map({ $0.toastMessage})
+            .sink { toastMessage in
+                output.loginFailToastMessage.send(toastMessage)
+        }
+        .store(in: cancelBag)
+        
+        
         return output
+    }
+}
+
+
+extension CoreAuthError {
+    var toastMessage: String {
+        switch self {
+            
+        case .oAuthFail(let provider):
+            "\(provider.title) 인증 시 문제가 발생했습니다."
+        case .loginFail:
+            "로그인에 문제가 발생했습니다."
+        case .signUpFail:
+            "회원가입에 문제가 발생했습니다."
+        case .changeSocialAccountFail:
+            "소셜 계정 변경에 문제가 발생했습니다."
+        case .unknown(_):
+            "알 수 없는 문제가 발생했습니다."
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -224,7 +224,7 @@ extension ApplicationCoordinator {
     }
     
     private func checkDidSignIn() {
-        if UserDefaultKeyList.Auth.appAccessToken == nil {
+        if UserDefaultKeyList.Auth.hasAccessToken() {
             runSignInFlow(by: .root)
         } else {
             Config.coordinatorFlag == .legacy

--- a/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
@@ -43,6 +43,22 @@ public final class SOPTWebView: UIViewController, SOPTWebViewControllable {
             $0.mediaTypesRequiringUserActionForPlayback = config.mediaTypesRequiringUserActionForPlayback
         }
         
+        if FeatureFlag.auth == .new {
+            // refreshToken
+            if !self.barrier,
+               let refreshToken = UserDefaultKeyList.CoreAuth.refreshToken,
+               let cookie = HTTPCookie(properties: [
+                HTTPCookiePropertyKey.domain: url.host() ?? "",
+                HTTPCookiePropertyKey.name: "refresh-token",
+                HTTPCookiePropertyKey.path: "/",
+                HTTPCookiePropertyKey.value: refreshToken,
+                HTTPCookiePropertyKey.secure: "TRUE",
+                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24 * 14)
+               ]) {
+                configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
+            }
+        }
+        
         self.webView = WKWebView(frame: .zero, configuration: configuration).then {
             $0.allowsBackForwardNavigationGestures = config.allowsBackForwardNavigationGestures
         }
@@ -141,24 +157,9 @@ extension SOPTWebView: WKNavigationDelegate {
             if !self.barrier,
                   let accessToken = UserDefaultKeyList.CoreAuth.accessToken
             {
-                
                 self.webView.evaluateJavaScript(
                     "localStorage.setItem(\"serviceAccessToken\", \"\(accessToken)\")"
                 )
-            }
-                
-            // refreshToken
-            if !self.barrier,
-               let refreshToken = UserDefaultKeyList.CoreAuth.refreshToken,
-               let cookie = HTTPCookie(properties: [
-                HTTPCookiePropertyKey.domain: webView.url?.host() ?? "",
-                HTTPCookiePropertyKey.name: "refresh-token",
-                HTTPCookiePropertyKey.path: "/",
-                HTTPCookiePropertyKey.value: refreshToken,
-                HTTPCookiePropertyKey.secure: "TRUE",
-                HTTPCookiePropertyKey.expires: Date().addingTimeInterval(60 * 60 * 24 * 14)
-            ]) {
-                self.webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
             }
         }
        

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreSignInEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreSignInEntity.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import Core
 
-public struct CoreLoginEntity: Decodable {
+public struct AuthTokensEntity: Decodable {
     public let accessToken: String
     public let refreshToken: String
     
@@ -20,4 +20,4 @@ public struct CoreLoginEntity: Decodable {
     }
 }
 
-extension CoreLoginEntity: AuthTokens { }
+extension AuthTokensEntity: AuthTokens { }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/ASAuthorizationControllerProxy.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/ASAuthorizationControllerProxy.swift
@@ -13,6 +13,7 @@ import Foundation
 final class ASAuthorizationControllerProxy: NSObject {
     
     private let presentationWindow: UIWindow = UIWindow()
+    
     public let didComplete = PassthroughSubject<ASAuthorization, OAuthError>()
     
     private override init() {}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CoreAuthService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/CoreAuthService.swift
@@ -19,8 +19,8 @@ public typealias DefaultCoreAuthService = BaseService<CoreAuthAPI>
 public protocol CoreAuthService {
     func sendVerifyCode(_ dto: SendVerificationCodeRequestEntity) -> AnyPublisher<Void, MoyaError>
     func verifyCode(_ dto: VerifyCodeRequestEntity) -> AnyPublisher<VerifyResultEntity, MoyaError>
-    func login(_ dto: CoreLoginRequestEntity) -> AnyPublisher<BaseEntity<CoreLoginEntity>, Error>
-    func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error>
+    func login(_ dto: CoreLoginRequestEntity) -> AnyPublisher<AuthTokensEntity, MoyaError>
+    func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Void, MoyaError>
 }
 
 extension DefaultCoreAuthService: CoreAuthService {
@@ -39,12 +39,19 @@ extension DefaultCoreAuthService: CoreAuthService {
             .eraseToAnyPublisher()
     }
     
-    public func login(_ dto: CoreLoginRequestEntity) -> AnyPublisher<BaseEntity<CoreLoginEntity>, Error> {
-        requestObjectInCombine(.login(dto: dto))
+    public func login(_ dto: CoreLoginRequestEntity) -> AnyPublisher<AuthTokensEntity, MoyaError> {
+        provider.requestPublisher(.login(dto: dto))
+            .filterSuccessfulStatusCodes()
+            .map(BaseEntity<AuthTokensEntity>.self)
+            .map { $0.data }
+            .eraseToAnyPublisher()
     }
     
-    public func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error> {
-        requestObjectInCombineNoResult(.signUp(dto: dto))
+    public func signUp(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Void, MoyaError> {
+        provider.requestPublisher(.signUp(dto: dto))
+            .filterSuccessfulStatusCodes()
+            .mapVoid()
+            .eraseToAnyPublisher()
     }
     
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/ReissueService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/ReissueService.swift
@@ -50,7 +50,7 @@ extension DefaultReissueService: ReissueService {
             case .success(let value):
                 do {
                     let decoder = JSONDecoder()
-                    let body = try decoder.decode(BaseEntity<CoreLoginEntity>.self, from: value.data)
+                    let body = try decoder.decode(BaseEntity<AuthTokensEntity>.self, from: value.data)
                     completion(body.data)
                 } catch {
                     completion(nil)

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SocialService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SocialService.swift
@@ -16,16 +16,23 @@ import Moya
 public typealias DefaultSocialService = BaseService<SocialAPI>
 
 public protocol SocialService {
-    func getSocialAccount(for phoneNumber: String) -> AnyPublisher<BaseEntity<SocialAccountResultEntity>, Error>
-    func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error>
+    func getSocialAccount(for phoneNumber: String) -> AnyPublisher<SocialAccountResultEntity, MoyaError>
+    func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Void, MoyaError>
 }
 
 extension DefaultSocialService: SocialService {
-    public func getSocialAccount(for phoneNumber: String) -> AnyPublisher<BaseEntity<SocialAccountResultEntity>, Error> {
-        requestObjectInCombine(.getSocialAccount(phone: phoneNumber))
+    public func getSocialAccount(for phoneNumber: String) -> AnyPublisher<SocialAccountResultEntity, MoyaError> {
+        provider.requestPublisher(.getSocialAccount(phone: phoneNumber))
+            .filterSuccessfulStatusCodes()
+            .map(BaseEntity<SocialAccountResultEntity>.self)
+            .map { $0.data }
+            .eraseToAnyPublisher()
     }
     
-    public func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Int, Error> {
-        return requestObjectInCombineNoResult(.changeSocialAccount(dto: dto))
+    public func changeSocialAccount(_ dto: CoreSignUpRequestEntity) -> AnyPublisher<Void, MoyaError> {
+        provider.requestPublisher(.changeSocialAccount(dto: dto))
+            .filterSuccessfulStatusCodes()
+            .mapVoid()
+            .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
인증중앙화에서 문제가 발생하는 부분을 해결합니다.

🌱 작업한 브랜치
- closed/#680

## 🌱 PR Point
- AppleService 메모리 해제되는 문제 해결
- new 인증 로직시 문제가 발생했을 때 서버에서 전달하는 메시지를 토스트로 띄우도록 변경
- WebView Cookie 미전달 문제 해결
- legacy accessToken 기반으로 동작하는 부분 수정