### PR TITLE
[Fix] #676 - Sprint3 QA 반영

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -15,12 +15,22 @@ public extension UIImageView {
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) 
         else {
             print("URL 인코딩 실패")
+            self.image = placeholder
+            completion?(nil)
             return
         }
-
-        let cache = ImageCache.default
-        if urlString == "" {
+        
+        // SVG 이미지일 경우 검사
+        if urlString.lowercased().hasSuffix(".svg") {
             self.image = placeholder
+            completion?(nil)
+            return
+        }
+        
+        let cache = ImageCache.default
+        if urlString.isEmpty {
+            self.image = placeholder
+            completion?(nil)
         } else {
             cache.retrieveImage(forKey: urlString) { result in
                 result.success { imageCache in

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setImage.swift
@@ -51,8 +51,12 @@ public extension UIImageView {
                 .cacheMemoryOnly
             ],
             completionHandler: { result in
-                result.success { imageResult in
+                switch result {
+                case .success(let imageResult):
                     completion?(imageResult.image)
+                case .failure:
+                    self.image = placeholder
+                    completion?(nil)
                 }
             }
         )

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeLatestPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeLatestPostsModel.swift
@@ -10,24 +10,24 @@ import Foundation
 
 public struct HomeLatestPostModel {
     public let profileImage: String?
-    public let name: String
+    public let name: String?
     public let generationAndPart: String?
     public let category: String
     public let title: String
     public let content: String
     public let webLink: String
-    public let id: Int
+    public let id: Int?
     public let isOutdated: Bool
 
     public init(
         profileImage: String?,
-        name: String,
+        name: String?,
         generationAndPart: String?,
         category: String,
         title: String,
         content: String,
         webLink: String,
-        id: Int,
+        id: Int?,
         isOutdated: Bool
     ) {
         self.profileImage = profileImage

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomePopularPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomePopularPostsModel.swift
@@ -10,25 +10,25 @@ import Foundation
 
 public struct HomePopularPostModel {
     public let profileImage: String?
-    public let name: String
+    public let name: String?
     public let generationAndPart: String?
     public let rank: Int
     public let category: String
     public let title: String
     public let content: String
     public let webLink: String
-    public let id: Int
+    public let id: Int?
 
     public init(
         profileImage: String?,
-        name: String,
+        name: String?,
         generationAndPart: String?,
         rank: Int,
         category: String,
         title: String,
         content: String,
         webLink: String,
-        id: Int
+        id: Int?
     ) {
         self.profileImage = profileImage
         self.name = name

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -17,6 +17,17 @@ enum PopularPostsCVCStatus {
     case unfocusing
 }
 
+enum PopularPostCategory: String, CaseIterable {
+    case first = "실시간 인기 1위"
+    case second = "실시간 인기 2위"
+    case third = "실시간 인기 3위"
+}
+
+enum PostCellType {
+    case popular
+    case latest
+}
+
 final class DefaultPostCVC: UICollectionViewCell {
     
     // MARK: - Properties
@@ -203,8 +214,7 @@ extension DefaultPostCVC {
 // MARK: - Methods
 
 extension DefaultPostCVC {
-    func configureCell(model: some PostDisplayable) {
-        self.categorySubPhraseView.setData(with: model.title)
+    func configureCell(model: some PostDisplayable, index: IndexPath, cellType: PostCellType) {
         self.categoryTagView.setData(with: model.category)
         self.userNameLabel.text = model.name
             
@@ -222,15 +232,22 @@ extension DefaultPostCVC {
                 self.userNameLabel.lineBreakMode = .byTruncatingTail
             }
         }
-
+    
+        switch cellType {
+        case .latest:
+            self.categorySubPhraseView.setData(with: "NEW")
+        case .popular:
+            if let category = PopularPostCategory.allCases[safe: index.row] {
+                self.categorySubPhraseView.setData(with: category.rawValue)
+            }
+        }
+        
         if let profileImage = model.profileImage {
             self.profileImageView.setImage(with: profileImage, placeholder: DSKitAsset.Assets.iconDefaultProfile.image)
         }
         self.postTitleLabel.text = model.title
         self.postContentLabel.text = model.content
         self.postContentLabel.setLineSpacing(lineSpacing: 1)
-        
-//        setNeedsLayout()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -42,6 +42,7 @@ final class DefaultPostCVC: UICollectionViewCell {
     private let userNameLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.gray30.color
         $0.font = DSKitFontFamily.Suit.regular.font(size: 10)
+        $0.textAlignment = .center
     }
     
     private let userPartLabel = UILabel().then {
@@ -95,6 +96,16 @@ final class DefaultPostCVC: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        userNameLabel.numberOfLines = 1
+        userNameLabel.lineBreakMode = .byTruncatingTail
+        userNameLabel.text = nil
+        userPartLabel.isHidden = false
+        userPartLabel.text = nil
+        profileImageView.setPlaceholder()
     }
 }
 
@@ -196,13 +207,30 @@ extension DefaultPostCVC {
         self.categorySubPhraseView.setData(with: model.title)
         self.categoryTagView.setData(with: model.category)
         self.userNameLabel.text = model.name
-        self.userPartLabel.text = model.generationAndPart
+            
+        if let part = model.generationAndPart {
+            if part.isEmpty {
+                // 익명일 경우
+                self.userPartLabel.isHidden = true
+                self.userNameLabel.numberOfLines = 2
+                self.userNameLabel.lineBreakMode = .byWordWrapping
+            } else {
+                // 익명이 아닐 경우
+                self.userPartLabel.isHidden = false
+                self.userPartLabel.text = part
+                self.userNameLabel.numberOfLines = 1
+                self.userNameLabel.lineBreakMode = .byTruncatingTail
+            }
+        }
+
         if let profileImage = model.profileImage {
             self.profileImageView.setImage(with: profileImage, placeholder: DSKitAsset.Assets.iconDefaultProfile.image)
         }
         self.postTitleLabel.text = model.title
         self.postContentLabel.text = model.content
         self.postContentLabel.setLineSpacing(lineSpacing: 1)
+        
+//        setNeedsLayout()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -190,7 +190,7 @@ extension DefaultPostCVC {
         self.userNameLabel.text = model.name
         self.userPartLabel.text = model.generationAndPart
         if let profileImage = model.profileImage {
-            self.profileImageView.setImage(with: profileImage)
+            self.profileImageView.setImage(with: profileImage, placeholder: DSKitAsset.Assets.iconDefaultProfile.image)
         }
         self.postTitleLabel.text = model.title
         self.postContentLabel.text = model.content

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -284,20 +284,22 @@ extension DefaultPostCVC {
 extension DefaultPostCVC {
     func configureCell(model: some PostDisplayable, index: IndexPath, cellType: PostCellType) {
         // NOTE: 사용자의 이름 값이 존재하지 않을 경우, 엠티뷰 레이아웃이 그려집니다.
-        if let name = model.name {
+        if let name = model.name, !name.isEmpty {
             self.userNameLabel.text = name
             updateVisibility(for: cellType)
         } else {
             self.emptySubLabel.text = model.title
             self.emptyTitleLabel.text = "[\(model.category)]\(model.content)"
             changeTitleLabelColor(for: model.category)
-            self.emptyImageView.setImage(with: model.profileImage ?? "")
+            self.emptyImageView.setImage(
+                with: model.profileImage ?? "",
+                placeholder: DSKitAsset.Assets.iconDefaultProfile.image
+            )
             updateVisibility(for: .empty)
             return
         }
         
         self.categoryTagView.setData(with: model.category)
-        self.userNameLabel.text = model.name ?? ""
             
         let part = model.generationAndPart
         if let part, !part.isEmpty {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -52,6 +52,7 @@ final class DefaultPostCVC: UICollectionViewCell {
     private let categoryStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.spacing = 6
+        $0.alignment = .center
     }
     
     private let userStackView = UIStackView().then {
@@ -131,6 +132,13 @@ extension DefaultPostCVC {
             verticalDividerView,
             categoryTagView
         )
+        
+        verticalDividerView.snp.makeConstraints { make in
+            make.height.equalTo(7)
+        }
+        
+        verticalDividerView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        verticalDividerView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         
         userStackView.addArrangedSubviews(
             profileImageView,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -138,6 +138,7 @@ final class DefaultPostCVC: UICollectionViewCell {
         emptyTitleLabel.text = nil
         emptyImageView.image = nil
         profileImageView.setPlaceholder()
+        updateVisibility(for: .latest) // visible 상태는 기본적으로 latest와 같음
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -52,13 +52,13 @@ final class DefaultPostCVC: UICollectionViewCell {
     
     private let userNameLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.gray30.color
-        $0.font = DSKitFontFamily.Suit.regular.font(size: 10)
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 10)
         $0.textAlignment = .center
     }
     
     private let userPartLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.gray400.color
-        $0.font = DSKitFontFamily.Suit.regular.font(size: 10)
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 10)
     }
     
     private let categoryStackView = UIStackView().then {
@@ -74,7 +74,7 @@ final class DefaultPostCVC: UICollectionViewCell {
     
     private let postTitleLabel = UILabel().then {
         $0.textColor = DSKitAsset.Colors.white.color
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 16)
+        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 16)
         $0.lineBreakMode = .byTruncatingTail
         $0.numberOfLines = 1
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -216,7 +216,7 @@ extension DefaultPostCVC {
 extension DefaultPostCVC {
     func configureCell(model: some PostDisplayable, index: IndexPath, cellType: PostCellType) {
         self.categoryTagView.setData(with: model.category)
-        self.userNameLabel.text = model.name
+        self.userNameLabel.text = model.name ?? ""
             
         if let part = model.generationAndPart {
             if part.isEmpty {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -299,21 +299,20 @@ extension DefaultPostCVC {
         self.categoryTagView.setData(with: model.category)
         self.userNameLabel.text = model.name ?? ""
             
-        if let part = model.generationAndPart {
-            if part.isEmpty {
-                // 익명일 경우
-                self.userPartLabel.isHidden = true
-                self.userNameLabel.numberOfLines = 2
-                self.userNameLabel.lineBreakMode = .byWordWrapping
-            } else {
-                // 익명이 아닐 경우
-                self.userPartLabel.isHidden = false
-                self.userPartLabel.text = part
-                self.userNameLabel.numberOfLines = 1
-                self.userNameLabel.lineBreakMode = .byTruncatingTail
-            }
+        let part = model.generationAndPart
+        if let part, !part.isEmpty {
+            // 익명이 아닐 경우
+            self.userPartLabel.isHidden = false
+            self.userPartLabel.text = part
+            self.userNameLabel.numberOfLines = 1
+            self.userNameLabel.lineBreakMode = .byTruncatingTail
+        } else {
+            // 익명일 경우
+            self.userPartLabel.isHidden = true
+            self.userNameLabel.numberOfLines = 2
+            self.userNameLabel.lineBreakMode = .byWordWrapping
         }
-    
+        
         switch cellType {
         case .latest:
             self.categorySubPhraseView.setData(with: "NEW")

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -26,6 +26,7 @@ enum PopularPostCategory: String, CaseIterable {
 enum PostCellType {
     case popular
     case latest
+    case empty
 }
 
 final class DefaultPostCVC: UICollectionViewCell {
@@ -90,6 +91,21 @@ final class DefaultPostCVC: UICollectionViewCell {
         $0.alignment = .leading
         $0.spacing = 6
     }
+    
+    // 엠티 뷰일 경우
+    private let emptyTitleLabel = UILabel().then {
+        $0.textColor = DSKitAsset.Colors.white.color
+        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 16)
+        $0.lineBreakMode = .byTruncatingTail
+        $0.numberOfLines = 1
+    }
+    
+    private let emptySubLabel = UILabel().then {
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 13)
+        $0.textColor = DSKitAsset.Colors.gray300.color
+    }
+    
+    private let emptyImageView = CustomProfileImageView().hideBorder()
 
     // MARK: - Initialization
     
@@ -98,6 +114,7 @@ final class DefaultPostCVC: UICollectionViewCell {
         setUI()
         setStackView()
         setLayout()
+        setEmptyViewLayout()
     }
     
     override func layoutSubviews() {
@@ -114,8 +131,12 @@ final class DefaultPostCVC: UICollectionViewCell {
         userNameLabel.numberOfLines = 1
         userNameLabel.lineBreakMode = .byTruncatingTail
         userNameLabel.text = nil
-        userPartLabel.isHidden = false
         userPartLabel.text = nil
+        postTitleLabel.text = nil
+        postContentLabel.text = nil
+        emptySubLabel.text = nil
+        emptyTitleLabel.text = nil
+        emptyImageView.image = nil
         profileImageView.setPlaceholder()
     }
 }
@@ -209,12 +230,72 @@ extension DefaultPostCVC {
             layer.addSublayer(gradientLayer)
         }
     }
+    
+    // 최신글이 없을 경우 띄워지는 엠티뷰입니다.
+    private func setEmptyViewLayout() {
+        self.addSubviews(emptySubLabel, emptyTitleLabel, emptyImageView)
+        
+        emptySubLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(38)
+            make.leading.equalToSuperview().inset(28)
+        }
+        
+        emptyTitleLabel.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(38)
+            make.leading.equalTo(emptySubLabel.snp.leading)
+        }
+        
+        emptyImageView.snp.remakeConstraints { make in
+            make.size.equalTo(64)
+            make.trailing.equalToSuperview().inset(24)
+            make.centerY.equalToSuperview()
+        }
+    }
+    
+    private func changeTitleLabelColor(for target: String) {
+        self.emptyTitleLabel.partColorChange(
+            targetString: "[\(target)]",
+            textColor: DSKitAsset.Colors.orange300.color
+        )
+    }
+    
+    private func updateVisibility(for cellType: PostCellType) {
+        switch cellType {
+        case .popular, .latest:
+            self.userStackView.isHidden = false
+            self.contentStackView.isHidden = false
+
+            self.emptyTitleLabel.isHidden = true
+            self.emptySubLabel.isHidden = true
+            self.emptyImageView.isHidden = true
+        case .empty:
+            self.emptyTitleLabel.isHidden = false
+            self.emptySubLabel.isHidden = false
+            self.emptyImageView.isHidden = false
+            
+            self.userStackView.isHidden = true
+            self.contentStackView.isHidden = true
+        }
+    }
 }
 
 // MARK: - Methods
 
 extension DefaultPostCVC {
     func configureCell(model: some PostDisplayable, index: IndexPath, cellType: PostCellType) {
+        // NOTE: 사용자의 이름 값이 존재하지 않을 경우, 엠티뷰 레이아웃이 그려집니다.
+        if let name = model.name {
+            self.userNameLabel.text = name
+            updateVisibility(for: cellType)
+        } else {
+            self.emptySubLabel.text = model.title
+            self.emptyTitleLabel.text = "[\(model.category)]\(model.content)"
+            changeTitleLabelColor(for: model.category)
+            self.emptyImageView.setImage(with: model.profileImage ?? "")
+            updateVisibility(for: .empty)
+            return
+        }
+        
         self.categoryTagView.setData(with: model.category)
         self.userNameLabel.text = model.name ?? ""
             
@@ -240,6 +321,7 @@ extension DefaultPostCVC {
             if let category = PopularPostCategory.allCases[safe: index.row] {
                 self.categorySubPhraseView.setData(with: category.rawValue)
             }
+        default: return
         }
         
         if let profileImage = model.profileImage {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -48,14 +48,14 @@ extension HomeForMemberVC {
     }
     
     func createPopularPostCellRegistration() -> PopularPostCellRegistration {
-        collectionView.createCellRegistration { cell, _, item in
-            cell.configureCell(model: item)
+        collectionView.createCellRegistration { cell, index, item in
+            cell.configureCell(model: item, index: index, cellType: .popular)
         }
     }
     
     func createLatestPostCellRegistration() -> LatestPostCellRegistration {
-        collectionView.createCellRegistration { cell, _, item in
-            cell.configureCell(model: item)
+        collectionView.createCellRegistration { cell, index, item in
+            cell.configureCell(model: item, index: index, cellType: .latest)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/HomeCategoryTagLabel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Components/HomeCategoryTagLabel.swift
@@ -29,8 +29,8 @@ final class HomeCategoryTagLabel: UILabel {
 
 extension HomeCategoryTagLabel {
     func setUI() {
-        self.font = DSKitFontFamily.SuitV1.extraBold.font(size: 12)
-        self.textColor = DSKitAsset.Colors.secondary.color
+        self.font = DSKitFontFamily.Suit.semiBold.font(size: 11)
+        self.textColor = DSKitAsset.Colors.orange300.color
         self.textAlignment = .center
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
@@ -110,6 +110,10 @@ public final class LegacyHomeCoordinator: DefaultHomeCoordinator {
             self?.requestCoordinating?(.webLink(url: url))
         }
         
+        homeForMember.vm.onViewAllContentButtonTapped = { [weak self] url in
+            self?.requestCoordinating?(.webLink(url: url))
+        }
+        
         rootViewController = homeForMember.vc.viewController
         
         router.push(homeForMember.vc)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -64,70 +64,26 @@ struct HomePresentationModel {
     
     struct PopularPost: Identifiable, Hashable {
         let profileImage: String?
-        let name: String
+        let name: String?
         let generationAndPart: String?
         let rank: Int
         let category: String
         let title: String
         let content: String
         let webLink: String
-        let id: Int
-
-        init(
-            profileImage: String?,
-            name: String,
-            generationAndPart: String?,
-            rank: Int,
-            category: String,
-            title: String,
-            content: String,
-            webLink: String,
-            id: Int
-        ) {
-            self.profileImage = profileImage
-            self.name = name
-            self.generationAndPart = generationAndPart
-            self.rank = rank
-            self.category = category
-            self.title = title
-            self.content = content
-            self.webLink = webLink
-            self.id = id
-        }
+        let id: String
     }
 
     struct LatestPost: Identifiable, Hashable {
+        let id: String
         let profileImage: String?
-        let name: String
+        let name: String?
         let generationAndPart: String?
         let category: String
         let title: String
         let content: String
         let webLink: String
-        let id: Int
         let isOutdated: Bool
-
-        init(
-            profileImage: String?,
-            name: String,
-            generationAndPart: String?,
-            category: String,
-            title: String,
-            content: String,
-            webLink: String,
-            id: Int,
-            isOutdated: Bool
-        ) {
-            self.profileImage = profileImage
-            self.name = name
-            self.generationAndPart = generationAndPart
-            self.category = category
-            self.title = title
-            self.content = content
-            self.webLink = webLink
-            self.id = id
-            self.isOutdated = isOutdated
-        }
     }
     
     struct Survey: Identifiable, Hashable {
@@ -190,13 +146,20 @@ extension HomeAppServicesModel {
             serviceName: self.serviceName,
             displayAlarmBadge: self.displayAlarmBadge,
             alarmBadge: self.alarmBadge,
-            iconURL: self.iconURL ?? "",                // TODO: - 엠티 이미지 요청 or 후기 폼 API 분리 요청하기
+            iconURL: self.iconURL ?? "",
             deepLink: self.deepLink
         )
     }
 }
 
 extension HomePopularPostModel {
+    // NOTE: 서버에서 post의 id값이 옵셔널로 내려오는 경우가 있어, 필드값을 조합해 ID로 반환합니다.
+    var stableID: String {
+        if let id = self.id { return "latest:id:\(id)" } // id값이 있다면, 그대로 사용
+        // 없다면, 카테고리와 타이틀 값을 조합해서 활용합니다.
+        return "popular:category:\(self.category)title:\(self.title)"
+    }
+    
     func toPresentation() -> HomePresentationModel.PopularPost {
         return HomePresentationModel.PopularPost(
             profileImage: self.profileImage,
@@ -207,14 +170,22 @@ extension HomePopularPostModel {
             title: self.title,
             content: self.content,
             webLink: self.webLink,
-            id: self.id
+            id: self.stableID
         )
     }
 }
 
 extension HomeLatestPostModel {
+    // NOTE: 서버에서 post의 id값이 옵셔널로 내려오는 경우가 있어, 필드값을 조합해 ID로 반환합니다.
+    var stableID: String {
+        if let id = self.id { return "latest:id:\(id)" } // id값이 있다면, 그대로 사용
+        // 없다면, 카테고리와 타이틀 값을 조합해서 활용합니다.
+        return "latest:category:\(self.category)title:\(self.title)"
+    }
+    
     func toPresentation() -> HomePresentationModel.LatestPost {
         return HomePresentationModel.LatestPost(
+            id: self.stableID,
             profileImage: self.profileImage,
             name: self.name,
             generationAndPart: self.generationAndPart,
@@ -222,7 +193,6 @@ extension HomeLatestPostModel {
             title: self.title,
             content: self.content,
             webLink: self.webLink,
-            id: self.id,
             isOutdated: self.isOutdated
         )
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -155,7 +155,7 @@ extension HomeAppServicesModel {
 extension HomePopularPostModel {
     // NOTE: 서버에서 post의 id값이 옵셔널로 내려오는 경우가 있어, 필드값을 조합해 ID로 반환합니다.
     var stableID: String {
-        if let id = self.id { return "latest:id:\(id)" } // id값이 있다면, 그대로 사용
+        if let id = self.id { return "popular:id:\(id)" } // id값이 있다면, 그대로 사용
         // 없다면, 카테고리와 타이틀 값을 조합해서 활용합니다.
         return "popular:category:\(self.category)title:\(self.title)"
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
@@ -11,11 +11,11 @@ import Foundation
 /// Post cell 관련 모델에서 쓰이는 공통 프로토콜입니다.
 protocol PostDisplayable {
     var profileImage: String? { get }
-    var name: String { get }
+    var name: String? { get }
     var generationAndPart: String? { get }
     var category: String { get }
     var title: String { get }
     var content: String { get }
     var webLink: String { get }
-    var id: Int { get }
+    var id: String { get }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
@@ -17,5 +17,5 @@ protocol PostDisplayable {
     var title: String { get }
     var content: String { get }
     var webLink: String { get }
-    var id: String { get }
+    var id: String { get } // 서버에서 내려오는 값은 Int?
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
@@ -39,6 +39,7 @@ final class HomeDefaultHeaderView: UICollectionReusableView {
         attributedTitle.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
         config.attributedTitle = attributedTitle
         let chervonRightImage = DSKitAsset.Assets.iconChevronRight.image.withTintColor(DSKitAsset.Colors.gray300.color)
+            .preparingThumbnail(of: .init(width: 16, height: 16))
         config.image = chervonRightImage
         config.imagePlacement = .trailing
         $0.configuration = config

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
@@ -42,6 +42,10 @@ public final class CustomProfileImageView: UIImageView {
         self.layer.cornerRadius = self.frame.width / 2
     }
     
+    public func setPlaceholder() {
+        self.image = DSKitAsset.Assets.iconDefaultProfile.image
+    }
+    
     @discardableResult
     public func hideBorder() -> Self {
         self.layer.borderWidth = 0

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeLatestPostsResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeLatestPostsResponseEntity.swift
@@ -14,12 +14,12 @@ public struct HomeLatestPostsResponseEntityWrapper: Decodable {
 
 public struct HomeLatestPostsResponseEntity: Decodable {
     public let profileImage: String?
-    public let name: String
+    public let name: String?
     public let generationAndPart: String
     public let category: String
     public let title: String
     public let content: String
     public let webLink: String
-    public let id: Int
+    public let id: Int?
     public let isOutdated: Bool
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomePopularPostsResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomePopularPostsResponseEntity.swift
@@ -14,12 +14,12 @@ public struct HomePopularPostsResponseEntityWrapper: Decodable {
 
 public struct HomePopularPostsResponseEntity: Decodable {
     public let profileImage: String?
-    public let name: String
-    public let generationAndPart: String
+    public let name: String?
+    public let generationAndPart: String?
     public let rank: Int
     public let category: String
     public let title: String
     public let content: String
     public let webLink: String
-    public let id: Int
+    public let id: Int?
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/GoogleAuthenticationService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/GoogleAuthenticationService.swift
@@ -17,8 +17,8 @@ public final class GoogleOAuthService: OAuthService {
     
     public func getIdentityToken() -> AnyPublisher<String, OAuthError> {
         Future<String, OAuthError> { promise in
-            Task {
-                guard let topVC = await UIApplication.getMostTopViewController() else {
+            Task { @MainActor in
+                guard let topVC = UIApplication.getMostTopViewController() else {
                     promise(.failure(OAuthError.unknown(NSError())))
                     return
                 }


### PR DESCRIPTION
## 🌴 PR 요약

- Sprint3의 QA를 반영했습니다.

🌱 작업한 브랜치
- #676 

## 🌱 PR Point

1. 서버에서 이미지가 svg로 내려오는 경우가 있어서, **디코딩되지 않는 이미지 포맷일 경우 placeholder**를 보여줄 수 있도록 수정했어요.
2. post cell에 맵핑되는 데이터들 중 **옵셔널로 내려오는 경우**가 있어서, 해당 부분들도 수정했어요.
2.1. 최신 글의 경우, **name 필드가 nil일 경우 empty view**를 보여줘야 해서, 해당 부분에 대한 분기 처리를 구현했어요.
3. **인증 관련 서비스 코드 쪽에 View 로직**이 있는데, 해당 부분을 MainActor로 격리시켜서 우선 해결해뒀어용.
4. 그 밖에 디자인 QA 잡힌 것들 수정했어요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
없어용

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|최신 post 엠티뷰 분기 처리|<video src = "https://github.com/user-attachments/assets/e5747398-e565-4296-a63a-329ff72a11a5" width = 300>|

## 📮 관련 이슈
- Resolved: #676 
