### PR TITLE
[Fix] #687 - 인증중앙화 QA 반영

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -92,6 +92,7 @@ public struct I18N {
             public static let signUp = "SOPT 회원가입"
             public static let wantToKnowAccount = "로그인한 계정을 알고 싶어요."
             public static let resetSocialAccount = "소셜 계정을 재설정하고 싶어요."
+            public static let inquireToKakaoTalk = "카카오톡 채널에 문의할게요."
             public static let userNotFound = "앗! 회원 정보를 찾을 수 없어요."
             public static let userInfo = "회원 정보"
             public static let signUpFirst = "먼저 회원가입 후, 다시 로그인해주세요."

--- a/SOPT-iOS/Projects/Data/Sources/DI/BaseService+.swift
+++ b/SOPT-iOS/Projects/Data/Sources/DI/BaseService+.swift
@@ -24,7 +24,7 @@ extension BaseService {
                 AccessTokenPlugin(tokenClosure: { _ in 
                     repository.fetch()?.accessToken ?? ""
                 })
-                ,NetworkLoggerPlugin()
+                ,Moya.NetworkLoggerPlugin.verbose
             ],
             interceptor: ReissueInterceptor(
                 refreshClosure: repository.refresh

--- a/SOPT-iOS/Projects/Data/Sources/Transform/CoreSignUpTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/CoreSignUpTransform.swift
@@ -13,7 +13,6 @@ import Domain
 extension SignUpModel {
     func toData() -> CoreSignUpRequestEntity {
         return CoreSignUpRequestEntity(
-            name: name,
             phone: phone,
             token: token,
             authPlatform: provider.toData()

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -32,7 +32,7 @@ extension AppDelegate {
                 interface: AuthTokensRepositoryInterface.self,
                 implement: {
                     let reissueService = DefaultReissueService(
-                        plugins: [ NetworkLoggerPlugin()]
+                        plugins: [ Moya.NetworkLoggerPlugin.verbose]
                     )
                     let repository = AuthTokensRepository(remote: reissueService)
                     return repository
@@ -44,7 +44,7 @@ extension AppDelegate {
                 interface: AuthTokensRepositoryInterface.self,
                 implement: {
                     let reissueService = DefaultLegacyReissueService(
-                        plugins: [ NetworkLoggerPlugin()]
+                        plugins: [ Moya.NetworkLoggerPlugin.verbose]
                     )
                     let repository = LegacyAuthTokensRepository(remote: reissueService)
                     return repository
@@ -66,7 +66,7 @@ extension AppDelegate {
             interface: PhoneVerifyRepositoryInterface.self,
             implement: {
                 PhoneVerifyRepository(
-                    coreAuthService: DefaultCoreAuthService(plugins: [ NetworkLoggerPlugin() ])
+                    coreAuthService: DefaultCoreAuthService(plugins: [ Moya.NetworkLoggerPlugin.verbose ])
                 )
             }
         )
@@ -84,7 +84,7 @@ extension AppDelegate {
             interface: CoreAuthRepositoryInterface.self,
             implement: {
                 CoreAuthRepository(
-                    coreAuthService: DefaultCoreAuthService(plugins: [ NetworkLoggerPlugin() ]),
+                    coreAuthService: DefaultCoreAuthService(plugins: [ Moya.NetworkLoggerPlugin.verbose ]),
                     socialService: DefaultSocialService.standard)
             }
         )

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/Auth/ChangeSocialAccountUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/Auth/ChangeSocialAccountUseCase.swift
@@ -12,7 +12,7 @@ import Core
 
 public protocol ChangeSocialAccountUseCase {
     func resetSocialAccount(with provider: OAuthProvider, name: String?, phone: String) -> AnyPublisher<Void, Never>
-    var sideEffect: PassthroughSubject<Error, Never> { get }
+    var sideEffect: PassthroughSubject<CoreAuthError, Never> { get }
 }
 
 public struct DefaultChangeSocialAccountUseCase: ChangeSocialAccountUseCase {
@@ -23,7 +23,7 @@ public struct DefaultChangeSocialAccountUseCase: ChangeSocialAccountUseCase {
     
     private var cancelBag = CancelBag()
     
-    public let sideEffect = PassthroughSubject<Error, Never>()
+    public let sideEffect = PassthroughSubject<CoreAuthError, Never>()
     
     public init(
         repository: CoreAuthRepositoryInterface,

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/LoginHelpBottomSheetPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/LoginHelpBottomSheetPresentable.swift
@@ -13,6 +13,7 @@ import Domain
 public protocol LoginHelpBottomSheetViewControllable: LegacyViewControllable { 
     var onWantToKnowLoginAccountButtonDidTap: (() -> Void)? { get set }
     var onResetSocialAccountButtonDidTap: (() -> Void)? { get set }
+    var onInquireToKakaoTalkButtonDidTap: (() -> Void)? { get set }
 }
 
 public typealias LoginHelpBottomSheetPresentable = LoginHelpBottomSheetViewControllable

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
@@ -12,7 +12,7 @@ import Core
 
 public protocol SignInViewControllable: LegacyViewControllable { }
 
-public protocol SignInCoordinatable {
+public protocol SignInRoutingTrigger {
     var onLoginHelpButtonTapped: (() -> Void)? { get set }
     var onSocialLoginFail: (() -> Void)? { get set }
     var onSignUpButtonTapped: (() -> Void)? { get set }
@@ -20,6 +20,6 @@ public protocol SignInCoordinatable {
     var onVisitorButtonTapped: (() -> Void)? { get set }
 }
 
-public typealias SignInViewModelType = ViewModelType & SignInCoordinatable
+public typealias SignInViewModelType = ViewModelType & SignInRoutingTrigger
 
 public typealias SignInPresentable = (vc: SignInViewControllable, vm: any SignInViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
@@ -211,6 +211,14 @@ extension ChangeSocialAccountVC {
                 owner.navigationBar.isHidden = step != .phoneVerify
             }
             .store(in: cancelBag)
+        
+        output.errorToastMessage
+            .withUnretained(self)
+            .delay(for: .seconds(1), scheduler: RunLoop.main, options: .none)
+            .sink { owner, message in
+                Toast.showMDSToast(type: .error, text: message)
+            }
+            .store(in: cancelBag)
     }
     
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountViewModel.swift
@@ -32,6 +32,7 @@ public final class ChangeSocialAccountViewModel: ChangeSocialAccountViewModelTyp
     
     public struct Output {
         let currentStep = CurrentValueSubject<Step, Never>(.phoneVerify)
+        let errorToastMessage = PassthroughSubject<String, Never>()
     }
     
     private let useCase: ChangeSocialAccountUseCase
@@ -46,6 +47,13 @@ public final class ChangeSocialAccountViewModel: ChangeSocialAccountViewModelTyp
     
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
+        
+        useCase.sideEffect
+            .map { $0.description }
+            .sink { description in
+                output.errorToastMessage.send(description)
+        }
+        .store(in: cancelBag)
         
         input.verifySuccess
             .sink { _ in

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -157,6 +157,11 @@ extension AuthCoordinator {
             self?.runSearchSocialFlow()
         }
         
+        bottomSheetVC.onInquireToKakaoTalkButtonDidTap = { 
+            bottomSheetVC.dismiss(animated: true)
+            openExternalLink(urlStr: ExternalURL.KakaoTalk.serviceProposal)
+        }
+        
         let bottomSheetManager = BottomSheetManager(
             configuration: .fixed(
                 minHeight: bottomSheetVC.minimumContentHeight,

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyViewModel.swift
@@ -41,7 +41,7 @@ public class PhoneVerifyViewModel: PhoneVerifyViewModelType {
         let timeLeft = CurrentValueSubject<Int, Never>(0)
         let phoneTextFieldText = CurrentValueSubject<String, Never>("")
         let codeTextFieldText = CurrentValueSubject<String, Never>("")
-        let timerIsRunning = PassthroughSubject<Bool, Never>()
+        let timerIsRunning = CurrentValueSubject<Bool, Never>(false)
         let sendButtonIsEnabled = CurrentValueSubject<Bool, Never>(false)
         let doneButtonIsEnabled =  CurrentValueSubject<Bool, Never>(false)
     }
@@ -67,18 +67,18 @@ public class PhoneVerifyViewModel: PhoneVerifyViewModelType {
         useCase.sideEffect
             .sink { err in
                 switch err {
+                case .userNotFound:
+                    output.phoneFailDescription.send("SOPT 활동 시 사용한 전화번호가 아니에요.")
+                case .alreadyExist:
+                    output.phoneFailDescription.send("이미 가입된 전화번호예요.")
                 case .invalidRequest:
-                    output.phoneFailDescription.send("요청 형식이 잘못됐어요.")
+                    output.codeFailDescription.send("존재하지 않는 번호 인증 이력입니다")
                 case .invalidVerifyCode:
                     output.codeFailDescription.send("인증번호가 올바르지 않습니다.")
                     return
                 case .timeout:
                     output.codeFailDescription.send("3분이 초과되었어요. 인증번호를 다시 요청해주세요.")
                     return
-                case .userNotFound:
-                    output.phoneFailDescription.send("SOPT 활동 시 사용한 전화번호가 아니에요.")
-                case .alreadyExist:
-                    output.phoneFailDescription.send("이미 가입된 전화번호예요.")
                 case .unknown(_):
                     output.codeFailDescription.send("알 수 없는 오류예요.")
                 }
@@ -155,10 +155,13 @@ public class PhoneVerifyViewModel: PhoneVerifyViewModelType {
         
         input.codeTextFieldText
             .withUnretained(self)
-            .filter { $1.count >= $0.useCase.policy.codeMaxLength }
-            .map {
-                let newValue = $1.prefix($0.useCase.policy.codeMaxLength)
-                return String(newValue)
+            .map { owner, code in
+                // code 글자수 제한보다 많이 입력할 경우, 무효화한다.
+                if code.count >= owner.useCase.policy.codeMaxLength  {
+                    let newValue = code.prefix(owner.useCase.policy.codeMaxLength)
+                    return String(newValue)
+                }
+                return code
             }
             .sink { output.codeTextFieldText.send($0) }
             .store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
@@ -19,10 +19,11 @@ public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomShee
     private static let i18n = I18N.SignIn.Refactor.self
     public var onWantToKnowLoginAccountButtonDidTap: (() -> Void)?
     public var onResetSocialAccountButtonDidTap: (() -> Void)?
+    public var onInquireToKakaoTalkButtonDidTap: (() -> Void)?
     private let cancelBag = CancelBag()
     
     public var minimumContentHeight: CGFloat {
-        return 158.adjustedH
+        return 202.adjustedH
     }
     
     // MARK: - Views
@@ -61,6 +62,18 @@ public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomShee
         $0.layer.masksToBounds = true
     }
     
+    private let inquireToKakaoTalkButton = UIButton().then {
+        $0.setTitleColor(DSKitAsset.Colors.gray10.color, for: .normal)
+        $0.setTitle(i18n.inquireToKakaoTalk, for: .normal)
+        $0.titleLabel?.font = DSKitFontFamily.Suit.regular.font(size: 16)
+        $0.contentHorizontalAlignment = .leading
+        $0.titleEdgeInsets = .init(top: 0, left: 10, bottom: 0, right: 0)
+        $0.setBackgroundColor(DSKitAsset.Colors.gray700.color, for: .highlighted)
+        $0.setBackgroundColor(DSKitAsset.Colors.gray800.color, for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.layer.masksToBounds = true
+    }
+    
     public init() {
         super.init(nibName: nil, bundle: nil)
         
@@ -83,7 +96,8 @@ extension LoginHelpBottomSheetVC {
             warnImageView,
             titleLabel,
             wantToKnowAccountButton,
-            resetSocialAccountButton
+            resetSocialAccountButton,
+            inquireToKakaoTalkButton
         )
         
         self.warnImageView.snp.makeConstraints {
@@ -108,6 +122,12 @@ extension LoginHelpBottomSheetVC {
             $0.top.equalTo(wantToKnowAccountButton.snp.bottom).offset(4)
             $0.horizontalEdges.equalToSuperview().inset(14)
             $0.height.equalTo(wantToKnowAccountButton.snp.height)
+        }
+        
+        self.inquireToKakaoTalkButton.snp.makeConstraints {
+            $0.top.equalTo(resetSocialAccountButton.snp.bottom).offset(4)
+            $0.horizontalEdges.equalToSuperview().inset(14)
+            $0.height.equalTo(wantToKnowAccountButton.snp.height)
             $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide).inset(8)
         }
     }
@@ -129,6 +149,15 @@ extension LoginHelpBottomSheetVC {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onResetSocialAccountButtonDidTap?()
+            }
+            .store(in: cancelBag)
+        
+        inquireToKakaoTalkButton
+            .publisher(for: .touchUpInside)
+            .asDriver()
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onInquireToKakaoTalkButtonDidTap?()
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreSignUpEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/CoreAuth/CoreSignUpEntity.swift
@@ -9,18 +9,15 @@
 import Foundation
 
 public struct CoreSignUpRequestEntity: Encodable {
-    let name: String?
     let phone: String
     let token: String
     let authPlatform: PlatformType
     
     public init(
-        name: String?,
         phone: String,
         token: String,
         authPlatform: PlatformType
     ) {
-        self.name = name
         self.phone = phone
         self.token = token
         self.authPlatform = authPlatform

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/MainEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/MainEntity.swift
@@ -17,7 +17,8 @@ public struct MainEntity: Codable {
 // MARK: - UserInfo
 
 public struct UserInfo: Codable {
-    public let status, name, profileImage: String
+    public let status, name: String
+    public let profileImage: String?
     public let historyList: [Int]
     
     enum CodingKeys: String, CodingKey {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
@@ -301,7 +301,7 @@ extension BaseService {
                         let body = try decoder.decode(T.self, from: value.data)
                         continuation.resume(returning: body)
                     } catch let error {
-                        continuation.resume(throwing: error)
+                        continuation.resume(throwing: MoyaError.jsonMapping(value))
                     }
                 case .failure(let error):
                     continuation.resume(throwing: error)

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -12,6 +12,8 @@ import Domain
 import Data
 import Networks
 
+import Moya
+
 extension AppDelegate {
     var container: DIContainer {
         DIContainer.shared
@@ -31,7 +33,7 @@ extension AppDelegate {
                 interface: AuthTokensRepositoryInterface.self,
                 implement: {
                     let reissueService = DefaultReissueService(
-                        plugins: [ NetworkLoggerPlugin()]
+                        plugins: [ Moya.NetworkLoggerPlugin.verbose]
                     )
                     let repository = AuthTokensRepository(remote: reissueService)
                     return repository
@@ -43,7 +45,7 @@ extension AppDelegate {
                 interface: AuthTokensRepositoryInterface.self,
                 implement: {
                     let reissueService = DefaultLegacyReissueService(
-                        plugins: [ NetworkLoggerPlugin()]
+                        plugins: [ Moya.NetworkLoggerPlugin.verbose]
                     )
                     let repository = LegacyAuthTokensRepository(remote: reissueService)
                     return repository
@@ -64,7 +66,7 @@ extension AppDelegate {
         container.register(
             interface: PhoneVerifyRepositoryInterface.self,
             implement: {
-                PhoneVerifyRepository(coreAuthService: DefaultCoreAuthService(plugins: [ NetworkLoggerPlugin() ]))
+                PhoneVerifyRepository(coreAuthService: DefaultCoreAuthService(plugins: [ Moya.NetworkLoggerPlugin.verbose ]))
             }
         )
         
@@ -79,7 +81,7 @@ extension AppDelegate {
             interface: CoreAuthRepositoryInterface.self,
             implement: {
                 CoreAuthRepository(
-                    coreAuthService: DefaultCoreAuthService(plugins: [ NetworkLoggerPlugin() ]),
+                    coreAuthService: DefaultCoreAuthService(plugins: [ Moya.NetworkLoggerPlugin.verbose ]),
                     socialService: DefaultSocialService.standard
                 )
             }


### PR DESCRIPTION
## 🌴 PR 요약
인증중앙화 QA 반영합니다

### 🌱 작업한 브랜치
- closed/#687

### 🌱 작업 내용
<img width="254" height="420" alt="스크린샷 2025-08-23 오후 9 33 18" src="https://github.com/user-attachments/assets/84d2078c-04ed-46d5-808b-7b5bc3611262" />

### 전달 사항

4c4a351274f9ac36e35a4861ef2337d11f96811c
- API 관련 오류가 있는데 로그에 requestbody, responsebody가 찍히지 않아서 원인을 파악하기 어렵더라구요. 기존 프로젝트에 존재하던 SOPT.NetworkLoggerPlugin는 사용하지 않고, Moya.NetworkLoggerPlugin로 변경했어요. 

bc91bc283440d70636cff60175a69404a2fa3b77 (cc. @dlwogus0128 )
- `requestObjectAsync` 에서 디코딩 시 문제가 발생하면 MoyaError.jsonMapping error 던지도록 수정했어요. 이유는 외부에서 에러 디버깅할 때 어느 api에서 DTO가 맞지 않았는지 쉽게 파악하기 위함이에요.


+) 현재 메인뷰에서 한 API에서 문제가 발생하더라도 서버 alert이 띄우는 구조라서 api 변경에 민감하게 반응하는 구조에요.
추후에 [HomeVM](https://github.com/sopt-makers/SOPT-iOS/blob/develop/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift#L242)에서 오류를 잡았을 때 placholder 용 PresentationModel로 대체하는 방식이 좋을 것 같아요
