### PR TITLE
[Fix] #692 - playgroundid 제거 및 userId로 대체

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Transform/PokeUserTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PokeUserTransform.swift
@@ -15,7 +15,6 @@ extension PokeUserEntity {
   public func toDomain() -> PokeUserModel {
     return PokeUserModel(
       userId: userId,
-      playgroundId: playgroundId,
       profileImage: profileImage,
       name: name,
       generation: generation,

--- a/SOPT-iOS/Projects/Domain/Sources/Model/PokeUserModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/PokeUserModel.swift
@@ -11,7 +11,6 @@ import Foundation
 // MARK: - Empty
 public struct PokeUserModel: Codable {
   public let userId: Int
-  public let playgroundId: Int
   public let profileImage, name: String
   public let generation: Int
   public let part: String
@@ -26,7 +25,6 @@ public struct PokeUserModel: Codable {
 
   public init(
     userId: Int,
-    playgroundId: Int,
     profileImage: String,
     name: String,
     generation: Int,
@@ -42,7 +40,6 @@ public struct PokeUserModel: Codable {
     anonymousImage: String
   ) {
     self.userId = userId
-    self.playgroundId = playgroundId
     self.profileImage = profileImage
     self.name = name
     self.generation = generation

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -64,8 +64,8 @@ public final class DailySoptuneResultCoordinator: BaseCoordinator {
             self.showDailySoptuneCard(cardModel)
         }
         
-        dailySoptuneResult.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        dailySoptuneResult.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/LegacyDailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/LegacyDailySoptuneResultCoordinator.swift
@@ -57,8 +57,8 @@ public final class LegacyDailySoptuneResultCoordinator: BaseCoordinator {
             self.runDailySoptuneCardFlow(cardModel: cardModel)
         }
         
-        dailySoptuneResult.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        dailySoptuneResult.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/ViewModel/DailySoptuneResultViewModel.swift
@@ -98,7 +98,7 @@ extension DailySoptuneResultViewModel {
             .compactMap { $0 }
             .withUnretained(self)
             .sink { owner, user in
-                owner.onProfileImageTapped?(user.playgroundId)
+                owner.onProfileImageTapped?(user.userId)
             }.store(in: cancelBag)
         
         return output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
@@ -17,7 +17,7 @@ public protocol PokeOnboardingViewControllable: LegacyViewControllable { }
 public protocol PokeOnboardingCoordinatable {
     var onNaviBackTapped: (() -> Void)? { get set }
     var onFirstVisitInOnboarding: (() -> Void)? { get set }
-    var onAvartarTapped: ((_ playgroundId: String) -> Void)? { get set }
+    var onAvartarTapped: ((_ userId: String) -> Void)? { get set }
     var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onMyFriendsTapped: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Amplitude/PokeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Amplitude/PokeEventTracker.swift
@@ -24,22 +24,22 @@ struct PokeEventTracker {
         AmplitudeInstance.shared.track(eventType: .viewPokeFriendDetail, eventProperties: properties)
     }
         
-    func trackClickPokeEvent(clickView: PokeAmplitudeEventPropertyValue, playgroundId: Int? = nil) {
+    func trackClickPokeEvent(clickView: PokeAmplitudeEventPropertyValue, userId: Int? = nil) {
         let properties = AmplitudeEventPropertyBuilder<PokeAmplitudeEventPropertyValue>()
             .addViewType()
             .add(key: .clickViewType, value: clickView)
-            .add(key: .viewProfile, value: playgroundId)
+            .add(key: .viewProfile, value: userId)
             .removeOptional()
             .build()
         
         AmplitudeInstance.shared.track(eventType: .clickPokeIcon, eventProperties: properties)
     }
 
-    func trackClickMemberProfileEvent(clickView: PokeAmplitudeEventPropertyValue, playgroundId: Int? = nil) {
+    func trackClickMemberProfileEvent(clickView: PokeAmplitudeEventPropertyValue, userId: Int? = nil) {
         let properties = AmplitudeEventPropertyBuilder<PokeAmplitudeEventPropertyValue>()
             .addViewType()
             .add(key: .clickViewType, value: clickView)
-            .add(key: .viewProfile, value: playgroundId)
+            .add(key: .viewProfile, value: userId)
             .removeOptional()
             .build()
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
@@ -48,8 +48,8 @@ final class LegacyPokeCoordinator: DefaultPokeCoordinator {
             self?.runPokeMyFriendsFlow()
         }
         
-        pokeMain.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMain.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeMyFriendsCoordinator.swift
@@ -44,8 +44,8 @@ final class LegacyPokeMyFriendsCoordinator: DefaultCoordinator {
             return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
         }
         
-        pokeMyFriends.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMyFriends.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.router.push(webView)
@@ -73,8 +73,8 @@ final class LegacyPokeMyFriendsCoordinator: DefaultCoordinator {
             return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
         }
         
-        pokeMyFriendsList.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMyFriendsList.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
@@ -66,8 +66,8 @@ extension LegacyPokeNotificationListCoordinator {
             self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
         }
 
-        pokeNotiListVC.vm.onProfileImageTapped = { [weak self] playgroundId in
-          guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeNotiListVC.vm.onProfileImageTapped = { [weak self] userId in
+          guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
 
           let webView = SOPTWebView(startWith: url)
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -59,8 +59,8 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
             self?.runPokeMyFriendsFlow()
         }
         
-        pokeMain.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMain.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
@@ -55,8 +55,8 @@ public final class PokeMyFriendsCoordinator: DefaultCoordinator {
             return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
         }
         
-        pokeMyFriends.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMyFriends.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.navigationController.pushViewController(webView, animated: true)
@@ -84,8 +84,8 @@ public final class PokeMyFriendsCoordinator: DefaultCoordinator {
             return self.showMessageBottomSheet(userModel: userModel, on: self.rootController)
         }
         
-        pokeMyFriendsList.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeMyFriendsList.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.rootController?.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -76,8 +76,8 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
             self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
         }
 
-        pokeNotiListVC.vm.onProfileImageTapped = { [weak self] playgroundId in
-            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(playgroundId)") else { return }
+        pokeNotiListVC.vm.onProfileImageTapped = { [weak self] userId in
+            guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
             self?.navigationController.pushViewController(webView, animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -145,7 +145,7 @@ extension PokeMainViewModel {
     input.profileImageTap
       .compactMap { $0.0 }
       .sink { [weak self] user in
-        self?.onProfileImageTapped?(user.playgroundId)
+        self?.onProfileImageTapped?(user.userId)
       }.store(in: cancelBag)
 
     input.profileImageTap

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/Views/ProfileCardGroupView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/Views/ProfileCardGroupView.swift
@@ -26,7 +26,7 @@ public final class ProfileCardGroupView: UIView, PokeCompatible {
 
   let cancelBag = CancelBag()
 
-  private var friendPlaygroundId: Int?
+  private var friendUserId: Int?
 
   // MARK: - UI Components
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/ViewModel/PokeMyFriendsListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/ViewModel/PokeMyFriendsListViewModel.swift
@@ -105,7 +105,7 @@ extension PokeMyFriendsListViewModel {
             .compactMap { $0 }
             .withUnretained(self)
             .sink { owner, user in
-                owner.onProfileImageTapped?(user.playgroundId)
+                owner.onProfileImageTapped?(user.userId)
             }.store(in: cancelBag)
 
         return output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
@@ -77,15 +77,15 @@ extension PokeMyFriendsViewModel {
                 return value
             }
             .sink {[weak self] userModel, messageModel, isAnonymous in
-                self?.eventTracker.trackClickPokeEvent(clickView: .friend, playgroundId: userModel.playgroundId)
+                self?.eventTracker.trackClickPokeEvent(clickView: .friend, userId: userModel.userId)
                 self?.useCase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous)
             }.store(in: cancelBag)
         
         input.profileImageTap
             .compactMap { $0 }
             .sink { [weak self] user in
-                self?.eventTracker.trackClickMemberProfileEvent(clickView: .friend, playgroundId: user.playgroundId)
-                self?.onProfileImageTapped?(user.playgroundId)
+                self?.eventTracker.trackClickMemberProfileEvent(clickView: .friend, userId: user.userId)
+                self?.onProfileImageTapped?(user.userId)
             }.store(in: cancelBag)
         
         return output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
@@ -71,7 +71,7 @@ extension PokeNotificationViewModel {
         
         input.profileButtonTap
           .sink { [weak self] user in
-            self?.onProfileImageTapped?(user.playgroundId)
+            self?.onProfileImageTapped?(user.userId)
           }.store(in: cancelBag)
 
         return output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
@@ -30,7 +30,7 @@ public final class PokeOnboardingViewModel: PokeOnboardingViewModelType {
     
     public var onNaviBackTapped: (() -> Void)?
     public var onFirstVisitInOnboarding: (() -> Void)?
-    public var onAvartarTapped: ((_ playgroundId: String) -> Void)?
+    public var onAvartarTapped: ((_ userId: String) -> Void)?
     public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
     public var onMyFriendsTapped: (() -> Void)?
     
@@ -79,14 +79,14 @@ extension PokeOnboardingViewModel {
                 return value
             }
             .sink(receiveValue: { [weak self] userModel, messageModel, isAnonymous in
-                self?.eventTracker.trackClickPokeEvent(clickView: .onboarding, playgroundId: userModel.playgroundId)
+                self?.eventTracker.trackClickPokeEvent(clickView: .onboarding, userId: userModel.userId)
                 self?.usecase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous)
             }).store(in: cancelBag)
         
         input.avatarTapped
             .sink(receiveValue: { [weak self] userModel in
-                self?.eventTracker.trackClickMemberProfileEvent(clickView: .onboarding, playgroundId: userModel.playgroundId)
-                self?.onAvartarTapped?(String(describing: userModel.playgroundId))
+                self?.eventTracker.trackClickMemberProfileEvent(clickView: .onboarding, userId: userModel.userId)
+                self?.onAvartarTapped?(String(describing: userModel.userId))
             }).store(in: cancelBag)
         
         input.pullToRefreshTriggered

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PokeUserEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PokeUserEntity.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct PokeUserEntity {
   public let userId: Int
-  public let playgroundId: Int
+//  public let playgroundId: Int
   public let profileImage: String
   public let name: String
   public let generation: Int
@@ -27,7 +27,7 @@ public struct PokeUserEntity {
 
 extension PokeUserEntity: Codable {
   public enum CodingKeys: CodingKey {
-    case userId, playgroundId, profileImage, name, generation, part, pokeNum,
+    case userId, profileImage, name, generation, part, pokeNum,
          message, relationName, mutualRelationMessage, isFirstMeet, isAlreadyPoke,
          isAnonymous, anonymousName, anonymousImage
   }
@@ -36,7 +36,6 @@ extension PokeUserEntity: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     
     self.userId = try container.decode(Int.self, forKey: .userId)
-    self.playgroundId = try container.decode(Int.self, forKey: .playgroundId)
     self.profileImage = try container.decodeIfPresent(String.self, forKey: .profileImage) ?? ""
     self.name = try container.decode(String.self, forKey: .name)
     self.generation = try container.decode(Int.self, forKey: .generation)


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#692

## 🌱 PR Point
- 인증중앙화 작업 머지 후 responseDTO에서 playgroundId가 제거되고, 기존에 있던 userId로 대체되어 해당 부분 반영했습니다.

## 📌 참고 사항
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #692
