### PR TITLE
[Feat] #673 - 홈화면 앰플리튜드 연동

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventPropertyKey.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventPropertyKey.swift
@@ -15,4 +15,10 @@ public enum AmplitudeEventPropertyKey: String {
     // 콕 찌르기 피쳐 관련 Key
     case viewProfile = "view_profile" // 멤버 프로필 id
     case friendType = "friend_type"
+    
+    // 홈 피쳐 관련 Key
+    case postRanking = "post_ranking"
+    case sectionName = "section_name"
+    case postID = "post_id"
+    case category = "category"
 }

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventPropertyKey.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventPropertyKey.swift
@@ -21,4 +21,7 @@ public enum AmplitudeEventPropertyKey: String {
     case sectionName = "section_name"
     case postID = "post_id"
     case category = "category"
+    case promoName = "promo_name"
+    case destinationURL = "destination_url"
+    case destinationType = "destination_type"
 }

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -47,6 +47,7 @@ public enum AmplitudeEventType: String {
     case clickPost = "click_post"
     case clickEmpty = "click_empty"
     case clickViewAll = "click_view_all"
+    case clickPromo = "click_promo"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -44,6 +44,7 @@ public enum AmplitudeEventType: String {
     case clickTodaySoptuneMenu = "click_todaysoptmadi_menu"
     case clickSoptampMenu = "click_soptamp_menu"
     case clickPostMember = "click_post_member"
+    case clickPost = "click_post"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -43,6 +43,7 @@ public enum AmplitudeEventType: String {
     case clickPokeMenu = "click_poke_menu"
     case clickTodaySoptuneMenu = "click_todaysoptmadi_menu"
     case clickSoptampMenu = "click_soptamp_menu"
+    case clickPostMember = "click_post_member"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -46,6 +46,7 @@ public enum AmplitudeEventType: String {
     case clickPostMember = "click_post_member"
     case clickPost = "click_post"
     case clickEmpty = "click_empty"
+    case clickViewAll = "click_view_all"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Amplitude/AmplitudeEventType.swift
@@ -45,6 +45,7 @@ public enum AmplitudeEventType: String {
     case clickSoptampMenu = "click_soptamp_menu"
     case clickPostMember = "click_post_member"
     case clickPost = "click_post"
+    case clickEmpty = "click_empty"
     
     // 콕 찌르기 클릭 이벤트
     case clickPoke = "click_poke"

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomeLatestPostsTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomeLatestPostsTransform.swift
@@ -22,7 +22,8 @@ extension HomeLatestPostsResponseEntity {
             content: self.content,
             webLink: self.webLink,
             id: self.id,
-            isOutdated: self.isOutdated
+            isOutdated: self.isOutdated,
+            userId: self.userId
         )
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/HomePopularPostsTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/HomePopularPostsTransform.swift
@@ -22,7 +22,8 @@ extension HomePopularPostsResponseEntity {
             title: self.title,
             content: self.content,
             webLink: self.webLink,
-            id: self.id
+            id: self.id,
+            userId: self.userId
         )
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomeLatestPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomeLatestPostsModel.swift
@@ -18,6 +18,7 @@ public struct HomeLatestPostModel {
     public let webLink: String
     public let id: Int?
     public let isOutdated: Bool
+    public let userId: Int?
 
     public init(
         profileImage: String?,
@@ -28,7 +29,8 @@ public struct HomeLatestPostModel {
         content: String,
         webLink: String,
         id: Int?,
-        isOutdated: Bool
+        isOutdated: Bool,
+        userId: Int?
     ) {
         self.profileImage = profileImage
         self.name = name
@@ -39,5 +41,6 @@ public struct HomeLatestPostModel {
         self.webLink = webLink
         self.id = id
         self.isOutdated = isOutdated
+        self.userId = userId
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/HomePopularPostsModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/HomePopularPostsModel.swift
@@ -18,6 +18,7 @@ public struct HomePopularPostModel {
     public let content: String
     public let webLink: String
     public let id: Int?
+    public let userId: Int?
 
     public init(
         profileImage: String?,
@@ -28,7 +29,8 @@ public struct HomePopularPostModel {
         title: String,
         content: String,
         webLink: String,
-        id: Int?
+        id: Int?,
+        userId: Int?
     ) {
         self.profileImage = profileImage
         self.name = name
@@ -39,5 +41,6 @@ public struct HomePopularPostModel {
         self.content = content
         self.webLink = webLink
         self.id = id
+        self.userId = userId
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
@@ -29,6 +29,7 @@ public protocol HomeForMemberCoordinatable {
     var onPopularPostCellTapped: ((String) -> Void)? { get set }
     var onLatestPostCellTapped: ((String) -> Void)? { get set }
     var onViewAllContentButtonTapped: ((String) -> Void)? { get set }
+    var onProfileImageViewTapped: ((Int) -> Void)? { get set }
 }
 public typealias HomeForMemberViewModelType = ViewModelType & HomeForMemberCoordinatable
 public typealias LegacyHomeForMemberPresentable = (vc: HomeForMemberViewControllable, vm: any HomeForMemberViewModelType)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
@@ -1,0 +1,20 @@
+//
+//  HomeAmplitudeEventPropertyValue.swift
+//  HomeFeature
+//
+//  Created by Jae Hyun Lee on 9/6/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+
+enum HomeAmplitudeEventPropertyValue: String, AmplitudeEventPropertyValueConvertible {
+    case latestPosts = "latest_posts"
+    case realTimeFeed = "realtime_feed"
+
+    func toString() -> String {
+        self.rawValue
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
@@ -14,6 +14,7 @@ enum HomeAmplitudeEventPropertyValue: String, AmplitudeEventPropertyValueConvert
     case latestPosts = "latest_posts"
     case realTimeFeed = "realtime_feed"
     case homeBanner = "home_banner"
+    case homeFAB = "home_fab"
     case app = "app"
     case web = "web"
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeAmplitudeEventPropertyValue.swift
@@ -13,6 +13,9 @@ import Core
 enum HomeAmplitudeEventPropertyValue: String, AmplitudeEventPropertyValueConvertible {
     case latestPosts = "latest_posts"
     case realTimeFeed = "realtime_feed"
+    case homeBanner = "home_banner"
+    case app = "app"
+    case web = "web"
 
     func toString() -> String {
         self.rawValue

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -75,8 +75,8 @@ struct HomeEventTracker {
     }
     
     func trackClickPromo(
-        promoName: String? = "",
-        destinationURL: String? = "",
+        promoName: String? = nil,
+        destinationURL: String? = nil,
         destinationType: HomeAmplitudeEventPropertyValue
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -34,4 +34,21 @@ struct HomeEventTracker {
         
         AmplitudeInstance.shared.track(eventType: .clickPostMember, eventProperties: properties)
     }
+    
+    func trackClickPost(
+        postRanking: Int,
+        sectionName: HomeAmplitudeEventPropertyValue,
+        postID: Int,
+        category: Int
+    ) {
+        let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
+            .add(key: .postRanking, value: postRanking)
+            .add(key: .sectionName, value: sectionName)
+            .add(key: .postID, value: postID)
+            .add(key: .category, value: category)
+            .addViewType()
+            .build()
+        
+        AmplitudeInstance.shared.track(eventType: .clickPost, eventProperties: properties)
+    }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -19,7 +19,7 @@ struct HomeEventTracker {
     }
     
     func trackClickPostMember(
-        postRanking: Int,
+        postRanking: Int?,
         sectionName: HomeAmplitudeEventPropertyValue,
         postID: Int?,
         category: String
@@ -31,7 +31,7 @@ struct HomeEventTracker {
             .add(key: .category, value: category)
             .addViewType()
             .build()
-        
+            
         AmplitudeInstance.shared.track(eventType: .clickPostMember, eventProperties: properties)
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -51,4 +51,16 @@ struct HomeEventTracker {
         
         AmplitudeInstance.shared.track(eventType: .clickPost, eventProperties: properties)
     }
+    
+    func trackClickEmpty(
+        sectionName: HomeAmplitudeEventPropertyValue,
+        category: Int
+    ) {
+        let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
+            .add(key: .sectionName, value: sectionName)
+            .add(key: .category, value: category)
+            .build()
+        
+        AmplitudeInstance.shared.track(eventType: .clickEmpty, eventProperties: properties)
+    }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -38,7 +38,7 @@ struct HomeEventTracker {
     func trackClickPost(
         postRanking: Int? = 0, // NOTE: 최신 게시물일 경우, 랭킹이 존재하지 않고 0으로 처리합니다.
         sectionName: HomeAmplitudeEventPropertyValue,
-        postID: String,
+        postID: Int? = 0,
         category: String
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
@@ -75,8 +75,8 @@ struct HomeEventTracker {
     }
     
     func trackClickPromo(
-        promoName: String,
-        destinationURL: String,
+        promoName: String? = "",
+        destinationURL: String? = "",
         destinationType: HomeAmplitudeEventPropertyValue
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -1,0 +1,20 @@
+//
+//  HomeEventTracker.swift
+//  HomeFeature
+//
+//  Created by Jae Hyun Lee on 9/6/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Core
+import HomeFeatureInterface
+
+struct HomeEventTracker {
+    func trackAmplitude(event: AmplitudeEventType?) {
+        if let event {
+            AmplitudeInstance.shared.trackWithUserType(event: event)
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -17,4 +17,21 @@ struct HomeEventTracker {
             AmplitudeInstance.shared.trackWithUserType(event: event)
         }
     }
+    
+    func trackClickPostMember(
+        postRanking: Int,
+        sectionName: HomeAmplitudeEventPropertyValue,
+        postID: Int,
+        category: Int
+    ) {
+        let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
+            .add(key: .postRanking, value: postRanking)
+            .add(key: .sectionName, value: sectionName)
+            .add(key: .postID, value: postID)
+            .add(key: .category, value: category)
+            .addViewType()
+            .build()
+        
+        AmplitudeInstance.shared.track(eventType: .clickPostMember, eventProperties: properties)
+    }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -74,4 +74,19 @@ struct HomeEventTracker {
         AmplitudeInstance.shared.track(eventType: .clickViewAll, eventProperties: properties)
     }
     
+    func trackClickPromo(
+        promoName: String,
+        destinationURL: String,
+        destinationType: HomeAmplitudeEventPropertyValue
+    ) {
+        let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
+            .add(key: .sectionName, value: .homeBanner)
+            .add(key: .promoName, value: promoName)
+            .add(key: .destinationURL, value: destinationURL)
+            .add(key: .destinationType, value: destinationType)
+            .build()
+        
+        AmplitudeInstance.shared.track(eventType: .clickPromo, eventProperties: properties)
+    }
+    
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -21,8 +21,8 @@ struct HomeEventTracker {
     func trackClickPostMember(
         postRanking: Int,
         sectionName: HomeAmplitudeEventPropertyValue,
-        postID: Int,
-        category: Int
+        postID: Int?,
+        category: String
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
             .add(key: .postRanking, value: postRanking)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -36,10 +36,10 @@ struct HomeEventTracker {
     }
     
     func trackClickPost(
-        postRanking: Int,
+        postRanking: Int? = 0, // NOTE: 최신 게시물일 경우, 랭킹이 존재하지 않고 0으로 처리합니다.
         sectionName: HomeAmplitudeEventPropertyValue,
-        postID: Int,
-        category: Int
+        postID: String,
+        category: String
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
             .add(key: .postRanking, value: postRanking)
@@ -54,7 +54,7 @@ struct HomeEventTracker {
     
     func trackClickEmpty(
         sectionName: HomeAmplitudeEventPropertyValue,
-        category: Int
+        category: String
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
             .add(key: .sectionName, value: sectionName)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -63,4 +63,15 @@ struct HomeEventTracker {
         
         AmplitudeInstance.shared.track(eventType: .clickEmpty, eventProperties: properties)
     }
+    
+    func trackClickViewAll(
+        sectionName: HomeAmplitudeEventPropertyValue
+    ) {
+        let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
+            .add(key: .sectionName, value: sectionName)
+            .build()
+        
+        AmplitudeInstance.shared.track(eventType: .clickViewAll, eventProperties: properties)
+    }
+    
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/Amplitude/HomeEventTracker.swift
@@ -75,12 +75,13 @@ struct HomeEventTracker {
     }
     
     func trackClickPromo(
+        sectionName: HomeAmplitudeEventPropertyValue,
         promoName: String? = nil,
         destinationURL: String? = nil,
         destinationType: HomeAmplitudeEventPropertyValue
     ) {
         let properties = AmplitudeEventPropertyBuilder<HomeAmplitudeEventPropertyValue>()
-            .add(key: .sectionName, value: .homeBanner)
+            .add(key: .sectionName, value: sectionName)
             .add(key: .promoName, value: promoName)
             .add(key: .destinationURL, value: destinationURL)
             .add(key: .destinationType, value: destinationType)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -29,6 +29,15 @@ enum PostCellType {
     case empty
 }
 
+// 앰플리튜드 이벤트 트래킹을 위한 구조체입니다.
+struct PostInfo {
+    var postRanking: Int? = 0
+    let sectionName: HomeAmplitudeEventPropertyValue
+    var postID: Int? = 0
+    let category: String
+    let userID: Int?
+}
+
 final class DefaultPostCVC: UICollectionViewCell {
     
     // MARK: - Properties
@@ -37,10 +46,10 @@ final class DefaultPostCVC: UICollectionViewCell {
     private let shapeLayer = CAShapeLayer()
     var onAnimationCompleted: (() -> Void)?
     private var isOutlineAnimationCancelled = false
-    private var userID: Int?
+    private var model: PostInfo?
     
     lazy var profileImageViewTap = profileImageView.gesture()
-        .compactMap { [weak self] _ in self?.userID }
+        .compactMap { [weak self] _ in self?.model }
         .asDriver()
     
     var cancelBag = CancelBag()
@@ -144,7 +153,6 @@ final class DefaultPostCVC: UICollectionViewCell {
         emptySubLabel.text = nil
         emptyTitleLabel.text = nil
         emptyImageView.image = nil
-        userID = nil
         cancelBag = CancelBag()
         profileImageView.setPlaceholder()
         updateVisibility(for: .latest) // visible 상태는 기본적으로 latest와 같음
@@ -296,7 +304,6 @@ extension DefaultPostCVC {
         // NOTE: 사용자의 이름 값이 존재하지 않을 경우, 엠티뷰 레이아웃이 그려집니다.
         if let name = model.name, !name.isEmpty {
             self.userNameLabel.text = name
-            self.userID = model.userID
             updateVisibility(for: cellType)
         } else {
             self.emptySubLabel.text = model.title
@@ -342,6 +349,17 @@ extension DefaultPostCVC {
         self.postTitleLabel.text = model.title
         self.postContentLabel.text = model.content
         self.postContentLabel.setLineSpacing(lineSpacing: 1)
+    }
+    
+    // 앰플리튜드 이벤트 트래킹을 위해 세팅합니다.
+    func setPostInfo(model: some PostDisplayable, section: HomeAmplitudeEventPropertyValue) {
+        self.model = PostInfo(
+            postRanking: model.ranking,
+            sectionName: section,
+            postID: model.postID,
+            category: model.category,
+            userID: model.userID
+        )
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -37,6 +37,13 @@ final class DefaultPostCVC: UICollectionViewCell {
     private let shapeLayer = CAShapeLayer()
     var onAnimationCompleted: (() -> Void)?
     private var isOutlineAnimationCancelled = false
+    private var userID: Int?
+    
+    lazy var profileImageViewTap = profileImageView.gesture()
+        .compactMap { [weak self] _ in self?.userID }
+        .asDriver()
+    
+    var cancelBag = CancelBag()
         
     // MARK: - UI & Layout
 
@@ -137,6 +144,8 @@ final class DefaultPostCVC: UICollectionViewCell {
         emptySubLabel.text = nil
         emptyTitleLabel.text = nil
         emptyImageView.image = nil
+        userID = nil
+        cancelBag = CancelBag()
         profileImageView.setPlaceholder()
         updateVisibility(for: .latest) // visible 상태는 기본적으로 latest와 같음
     }
@@ -287,6 +296,7 @@ extension DefaultPostCVC {
         // NOTE: 사용자의 이름 값이 존재하지 않을 경우, 엠티뷰 레이아웃이 그려집니다.
         if let name = model.name, !name.isEmpty {
             self.userNameLabel.text = name
+            self.userID = model.userID
             updateVisibility(for: cellType)
         } else {
             self.emptySubLabel.text = model.title

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -154,6 +154,7 @@ final class DefaultPostCVC: UICollectionViewCell {
         emptyTitleLabel.text = nil
         emptyImageView.image = nil
         cancelBag = CancelBag()
+        model = nil
         profileImageView.setPlaceholder()
         updateVisibility(for: .latest) // visible 상태는 기본적으로 latest와 같음
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -50,11 +50,12 @@ extension HomeForMemberVC {
     func createPopularPostCellRegistration() -> PopularPostCellRegistration {
         collectionView.createCellRegistration { cell, index, item in
             cell.configureCell(model: item, index: index, cellType: .popular)
+            cell.setPostInfo(model: item, section: .latestPosts)
             
             cell.profileImageViewTap
                 .withUnretained(self)
-                .sink { owner, userID in
-                    owner.profileImageViewTapped.send(userID)
+                .sink { owner, info in
+                    owner.profileImageViewTapped.send(info)
                 }
                 .store(in: cell.cancelBag)
         }
@@ -63,11 +64,12 @@ extension HomeForMemberVC {
     func createLatestPostCellRegistration() -> LatestPostCellRegistration {
         collectionView.createCellRegistration { cell, index, item in
             cell.configureCell(model: item, index: index, cellType: .latest)
+            cell.setPostInfo(model: item, section: .realTimeFeed)
             
             cell.profileImageViewTap
                 .withUnretained(self)
-                .sink { owner, userID in
-                    owner.profileImageViewTapped.send(userID)
+                .sink { owner, info in
+                    owner.profileImageViewTapped.send(info)
                 }
                 .store(in: cell.cancelBag)
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -50,12 +50,26 @@ extension HomeForMemberVC {
     func createPopularPostCellRegistration() -> PopularPostCellRegistration {
         collectionView.createCellRegistration { cell, index, item in
             cell.configureCell(model: item, index: index, cellType: .popular)
+            
+            cell.profileImageViewTap
+                .withUnretained(self)
+                .sink { owner, userID in
+                    owner.profileImageViewTapped.send(userID)
+                }
+                .store(in: cell.cancelBag)
         }
     }
     
     func createLatestPostCellRegistration() -> LatestPostCellRegistration {
         collectionView.createCellRegistration { cell, index, item in
             cell.configureCell(model: item, index: index, cellType: .latest)
+            
+            cell.profileImageViewTap
+                .withUnretained(self)
+                .sink { owner, userID in
+                    owner.profileImageViewTapped.send(userID)
+                }
+                .store(in: cell.cancelBag)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -142,6 +142,12 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
             self.delegate?.homeCoordinator(self, to: .webLink(url: url))
         }
         
+        homeForMember.vm.onProfileImageViewTapped = { [weak self] userID in
+            guard let self else { return }
+            let url = "\(ExternalURL.Playground.main)/members/\(userID)"
+            self.delegate?.homeCoordinator(self, to: .webLink(url: url))
+        }
+        
         rootViewController = homeForMember.vc
         navigationController.pushViewController(homeForMember.vc, animated: true)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
@@ -122,6 +122,11 @@ public final class LegacyHomeCoordinator: DefaultHomeCoordinator {
             self?.requestCoordinating?(.webLink(url: url))
         }
         
+        homeForMember.vm.onProfileImageViewTapped = { [weak self] userID in
+            let url = "\(ExternalURL.Playground.main)/members/\(userID)"
+            self?.requestCoordinating?(.webLink(url: url))
+        }
+        
         rootViewController = homeForMember.vc.viewController
         
         router.push(homeForMember.vc)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -74,6 +74,8 @@ struct HomePresentationModel {
         let id: String
         let serverID: Int?
         let userID: Int?
+        let ranking: Int?
+        let postID: Int?
     }
 
     struct LatestPost: Identifiable, Hashable {
@@ -88,6 +90,8 @@ struct HomePresentationModel {
         let isOutdated: Bool
         let serverID: Int?
         let userID: Int?
+        let ranking: Int?
+        let postID: Int?
     }
     
     struct Survey: Identifiable, Hashable {
@@ -176,7 +180,9 @@ extension HomePopularPostModel {
             webLink: self.webLink,
             id: self.stableID,
             serverID: self.id,
-            userID: self.userId
+            userID: self.userId,
+            ranking: self.rank,
+            postID: self.id
         )
     }
 }
@@ -201,7 +207,9 @@ extension HomeLatestPostModel {
             webLink: self.webLink,
             isOutdated: self.isOutdated,
             serverID: self.id,
-            userID: self.userId
+            userID: self.userId,
+            ranking: 0, // NOTE: 최신글의 경우 0
+            postID: self.id
         )
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -73,6 +73,7 @@ struct HomePresentationModel {
         let webLink: String
         let id: String
         let serverID: Int?
+        let userID: Int?
     }
 
     struct LatestPost: Identifiable, Hashable {
@@ -86,6 +87,7 @@ struct HomePresentationModel {
         let webLink: String
         let isOutdated: Bool
         let serverID: Int?
+        let userID: Int?
     }
     
     struct Survey: Identifiable, Hashable {
@@ -173,7 +175,8 @@ extension HomePopularPostModel {
             content: self.content,
             webLink: self.webLink,
             id: self.stableID,
-            serverID: self.id
+            serverID: self.id,
+            userID: self.userId
         )
     }
 }
@@ -197,7 +200,8 @@ extension HomeLatestPostModel {
             content: self.content,
             webLink: self.webLink,
             isOutdated: self.isOutdated,
-            serverID: self.id
+            serverID: self.id,
+            userID: self.userId
         )
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/HomePresentationModel.swift
@@ -72,6 +72,7 @@ struct HomePresentationModel {
         let content: String
         let webLink: String
         let id: String
+        let serverID: Int?
     }
 
     struct LatestPost: Identifiable, Hashable {
@@ -84,6 +85,7 @@ struct HomePresentationModel {
         let content: String
         let webLink: String
         let isOutdated: Bool
+        let serverID: Int?
     }
     
     struct Survey: Identifiable, Hashable {
@@ -170,7 +172,8 @@ extension HomePopularPostModel {
             title: self.title,
             content: self.content,
             webLink: self.webLink,
-            id: self.stableID
+            id: self.stableID,
+            serverID: self.id
         )
     }
 }
@@ -193,7 +196,8 @@ extension HomeLatestPostModel {
             title: self.title,
             content: self.content,
             webLink: self.webLink,
-            isOutdated: self.isOutdated
+            isOutdated: self.isOutdated,
+            serverID: self.id
         )
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
@@ -17,7 +17,7 @@ protocol PostDisplayable {
     var title: String { get }
     var content: String { get }
     var webLink: String { get }
-    var id: String { get } // 서버에서 내려오는 값은 Int?
+    var id: String { get }
     var postID: Int? { get }
     var userID: Int? { get }
     var ranking: Int? { get }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
@@ -18,5 +18,7 @@ protocol PostDisplayable {
     var content: String { get }
     var webLink: String { get }
     var id: String { get } // 서버에서 내려오는 값은 Int?
+    var postID: Int? { get }
     var userID: Int? { get }
+    var ranking: Int? { get }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Models/Protocol/PostDisplayable.swift
@@ -18,4 +18,5 @@ protocol PostDisplayable {
     var content: String { get }
     var webLink: String { get }
     var id: String { get } // 서버에서 내려오는 값은 Int?
+    var userID: Int? { get }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -31,6 +31,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     private(set) var surveyButtonTapped = PassthroughSubject<Void, Never>()
     private(set) var viewAllButtonTapped = PassthroughSubject<Void, Never>()
     private var socialLinkButtonTapped = PassthroughSubject<HomePresentationModel.SocialLink, Never>()
+    private(set) var profileImageViewTapped = PassthroughSubject<Int, Never>()
     
     private var isFirstAppear = true
     private var isExtendedButtonHidden: Bool = false
@@ -287,7 +288,8 @@ extension HomeForMemberVC {
             extendedFloatingButtonTapped: floatingButtonTapped.asDriver(),
             surveyButtonTapped: surveyButtonTapped.asDriver(),
             socialLinkButtonTapped: socialLinkButtonTapped.asDriver(),
-            viewAllButtonTapped: viewAllButtonTapped.asDriver()
+            viewAllButtonTapped: viewAllButtonTapped.asDriver(),
+            profileImageViewTapped: profileImageViewTapped.asDriver()
         )
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -31,7 +31,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     private(set) var surveyButtonTapped = PassthroughSubject<Void, Never>()
     private(set) var viewAllButtonTapped = PassthroughSubject<Void, Never>()
     private var socialLinkButtonTapped = PassthroughSubject<HomePresentationModel.SocialLink, Never>()
-    private(set) var profileImageViewTapped = PassthroughSubject<Int, Never>()
+    private(set) var profileImageViewTapped = PassthroughSubject<PostInfo, Never>()
     
     private var isFirstAppear = true
     private var isExtendedButtonHidden: Bool = false

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -18,6 +18,7 @@ import HomeFeatureInterface
 import BaseFeatureDependency
 
 public class HomeForMemberViewModel: HomeForMemberViewModelType {
+    
     // MARK: - Properties
     
     private let useCase: HomeUseCase
@@ -43,6 +44,8 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
         .init(socialLink: .instagram),
         .init(socialLink: .youtube)
     ]
+    
+    private let eventTracker = HomeEventTracker()
     
     // MARK: - Inputs
     
@@ -125,7 +128,7 @@ extension HomeForMemberViewModel {
                     AmplitudeInstance.shared.trackWithUserType(event: .clickAllCalendar)
                 case .productService(let model):
                     owner.onMainProductCellTapped?(model.product.serviceDomainLink)
-                    owner.trackAmplitude(event: model.product.toAmplitudeEventTypeNew)
+                    owner.eventTracker.trackAmplitude(event: model.product.toAmplitudeEventTypeNew)
                 case .appService(let model):
                     if model.serviceName == "콕찌르기" {
                         owner.useCase.checkPokeNewUser()
@@ -197,12 +200,6 @@ extension HomeForMemberViewModel {
 // MARK: - Methods
 
 extension HomeForMemberViewModel {
-    private func trackAmplitude(event: AmplitudeEventType?) {
-        if let event {
-            AmplitudeInstance.shared.trackWithUserType(event: event)
-        }
-    }
-    
     private func requestAuthorizationForNotification() {
         guard self.userType != .visitor,
               UserDefaultKeyList.Auth.hasAccessToken(),

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -25,11 +25,11 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     private var cancelBag = CancelBag()
     
     let userType: UserType = UserDefaultKeyList.Auth.getUserType()
-    private var floatingButtonUrl: String = ""
     
     private var fetchedDashBoard: HomePresentationModel.DashBoard?
     private var fetchedRecentSchedule: HomePresentationModel.RecentSchedule?
     private var fetchedSurvey: HomePresentationModel.Survey?
+    private var fetchedFABInfo: HomeFloatingButtonPresentationModel?
             
     let productServiceList: [HomePresentationModel.ProductService] = [
         .init(product: .playgroundCommunity),
@@ -113,7 +113,7 @@ extension HomeForMemberViewModel {
             .sink { owner, floatingButtonModel in
                 let presentationModel = floatingButtonModel.toPresentationModel()
                 output.floatingButtonInfo.send(presentationModel)
-                owner.floatingButtonUrl = presentationModel.url
+                owner.fetchedFABInfo = presentationModel
             }.store(in: cancelBag)
         
         input.cellTapped
@@ -181,7 +181,13 @@ extension HomeForMemberViewModel {
         input.extendedFloatingButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                owner.onExtendedFloatingButtonTapped?(owner.floatingButtonUrl)
+                guard let fetchedFABInfo = owner.fetchedFABInfo else { return }
+                owner.onExtendedFloatingButtonTapped?(fetchedFABInfo.url)
+                owner.eventTracker.trackClickPromo(
+                    promoName: fetchedFABInfo.actionButtonName,
+                    destinationURL: fetchedFABInfo.url,
+                    destinationType: .app
+                )
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -59,6 +59,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
         let surveyButtonTapped: Driver<Void>
         let socialLinkButtonTapped: Driver<HomePresentationModel.SocialLink>
         let viewAllButtonTapped: Driver<Void>
+        let profileImageViewTapped: Driver<Int>
     }
     
     // MARK: - Outputs
@@ -86,6 +87,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public var onPopularPostCellTapped: ((String) -> Void)?
     public var onLatestPostCellTapped: ((String) -> Void)?
     public var onViewAllContentButtonTapped: ((String) -> Void)?
+    public var onProfileImageViewTapped: ((Int) -> Void)?
     
     // MARK: - initialization
     
@@ -212,6 +214,13 @@ extension HomeForMemberViewModel {
             .sink { owner, _ in
                 owner.onViewAllContentButtonTapped?(ExternalURL.Playground.main)
                 owner.eventTracker.trackClickViewAll(sectionName: .latestPosts)
+            }
+            .store(in: cancelBag)
+        
+        input.profileImageViewTapped
+            .withUnretained(self)
+            .sink { owner, userID in
+                owner.onProfileImageViewTapped?(userID)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -208,6 +208,7 @@ extension HomeForMemberViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onViewAllContentButtonTapped?(ExternalURL.Playground.main)
+                owner.eventTracker.trackClickViewAll(sectionName: .latestPosts)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -181,12 +181,12 @@ extension HomeForMemberViewModel {
         input.extendedFloatingButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                let fetchedFABInfo = owner.fetchedFABInfo
-                owner.onExtendedFloatingButtonTapped?(fetchedFABInfo?.url ?? "")
+                guard let info = owner.fetchedFABInfo, !info.url.isEmpty else { return }
+                owner.onExtendedFloatingButtonTapped?(info.url)
                 owner.eventTracker.trackClickPromo(
                     sectionName: .homeFAB,
-                    promoName: fetchedFABInfo?.actionButtonName,
-                    destinationURL: fetchedFABInfo?.url,
+                    promoName: info.actionButtonName,
+                    destinationURL: info.url,
                     destinationType: .app
                 )
             }
@@ -195,12 +195,13 @@ extension HomeForMemberViewModel {
         input.surveyButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                let survey = owner.fetchedSurvey
-                owner.onSurveyButtonTapped?(survey?.linkURL ?? "")
+                guard let survey = owner.fetchedSurvey, !survey.linkURL.isEmpty else { return }
+
+                owner.onSurveyButtonTapped?(survey.linkURL)
                 owner.eventTracker.trackClickPromo(
                     sectionName: .homeBanner,
-                    promoName: survey?.title,
-                    destinationURL: survey?.linkURL,
+                    promoName: survey.title,
+                    destinationURL: survey.linkURL,
                     destinationType: .web
                 )
             }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -184,6 +184,7 @@ extension HomeForMemberViewModel {
                 let fetchedFABInfo = owner.fetchedFABInfo
                 owner.onExtendedFloatingButtonTapped?(fetchedFABInfo?.url ?? "")
                 owner.eventTracker.trackClickPromo(
+                    sectionName: .homeFAB,
                     promoName: fetchedFABInfo?.actionButtonName,
                     destinationURL: fetchedFABInfo?.url,
                     destinationType: .app
@@ -197,6 +198,7 @@ extension HomeForMemberViewModel {
                 let survey = owner.fetchedSurvey
                 owner.onSurveyButtonTapped?(survey?.linkURL ?? "")
                 owner.eventTracker.trackClickPromo(
+                    sectionName: .homeBanner,
                     promoName: survey?.title,
                     destinationURL: survey?.linkURL,
                     destinationType: .web

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -144,7 +144,7 @@ extension HomeForMemberViewModel {
                     owner.eventTracker.trackClickPost(
                         postRanking: model.rank,
                         sectionName: .realTimeFeed,
-                        postID: model.id,
+                        postID: model.serverID,
                         category: model.category
                     )
                 case .latestPost(let model):
@@ -243,7 +243,7 @@ extension HomeForMemberViewModel {
         if let name = model.name, !name.isEmpty {
             eventTracker.trackClickPost(
                 sectionName: .latestPosts,
-                postID: model.id,
+                postID: model.serverID,
                 category: model.category
             )
         } else {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -142,8 +142,15 @@ extension HomeForMemberViewModel {
                     owner.onSocialLinkButtonTapped?(type.socialLink.serviceDomainLink)
                 case .popularPost(let model):
                     owner.onPopularPostCellTapped?(model.webLink)
+                    owner.eventTracker.trackClickPost(
+                        postRanking: model.rank,
+                        sectionName: .realTimeFeed,
+                        postID: model.id,
+                        category: model.category
+                    )
                 case .latestPost(let model):
                     owner.onLatestPostCellTapped?(model.webLink)
+                    owner.trackLatestPostEvent(model: model)
                 default: break
                 }
             }
@@ -216,6 +223,22 @@ extension HomeForMemberViewModel {
             if granted {
                 self.useCase.registerPushToken()
             }
+        }
+    }
+    
+    private func trackLatestPostEvent(model: HomePresentationModel.LatestPost) {
+        // 이름 필드의 유무에 따라, 엠티 뷰의 유무를 결정하며 이벤트도 분리해 처리합니다.
+        if let name = model.name, !name.isEmpty {
+            eventTracker.trackClickPost(
+                sectionName: .latestPosts,
+                postID: model.id,
+                category: model.category
+            )
+        } else {
+            eventTracker.trackClickEmpty(
+                sectionName: .latestPosts,
+                category: model.category
+            )
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -59,7 +59,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
         let surveyButtonTapped: Driver<Void>
         let socialLinkButtonTapped: Driver<HomePresentationModel.SocialLink>
         let viewAllButtonTapped: Driver<Void>
-        let profileImageViewTapped: Driver<Int>
+        let profileImageViewTapped: Driver<PostInfo>
     }
     
     // MARK: - Outputs
@@ -219,8 +219,17 @@ extension HomeForMemberViewModel {
         
         input.profileImageViewTapped
             .withUnretained(self)
-            .sink { owner, userID in
-                owner.onProfileImageViewTapped?(userID)
+            .sink { owner, model in
+                if let userID = model.userID {
+                    owner.onProfileImageViewTapped?(userID)
+                    owner.eventTracker.trackClickPostMember(
+                        postRanking: model.postRanking,
+                        sectionName: model.sectionName,
+                        postID: model.postID,
+                        category: model.category
+                    )
+                }
+                
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -29,7 +29,7 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     private var fetchedDashBoard: HomePresentationModel.DashBoard?
     private var fetchedRecentSchedule: HomePresentationModel.RecentSchedule?
     private var fetchedSurvey: HomePresentationModel.Survey?
-    private var fetchedFABInfo: HomeFloatingButtonPresentationModel?
+    private var fetchedFloatingButtonInfo: HomeFloatingButtonPresentationModel?
             
     let productServiceList: [HomePresentationModel.ProductService] = [
         .init(product: .playgroundCommunity),
@@ -115,7 +115,7 @@ extension HomeForMemberViewModel {
             .sink { owner, floatingButtonModel in
                 let presentationModel = floatingButtonModel.toPresentationModel()
                 output.floatingButtonInfo.send(presentationModel)
-                owner.fetchedFABInfo = presentationModel
+                owner.fetchedFloatingButtonInfo = presentationModel
             }.store(in: cancelBag)
         
         input.cellTapped
@@ -183,7 +183,7 @@ extension HomeForMemberViewModel {
         input.extendedFloatingButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                guard let info = owner.fetchedFABInfo, !info.url.isEmpty else { return }
+                guard let info = owner.fetchedFloatingButtonInfo, !info.url.isEmpty else { return }
                 owner.onExtendedFloatingButtonTapped?(info.url)
                 owner.eventTracker.trackClickPromo(
                     sectionName: .homeFAB,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -26,7 +26,6 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     
     let userType: UserType = UserDefaultKeyList.Auth.getUserType()
     private var floatingButtonUrl: String = ""
-    private var surveyButtonURL: String = ""
     
     private var fetchedDashBoard: HomePresentationModel.DashBoard?
     private var fetchedRecentSchedule: HomePresentationModel.RecentSchedule?
@@ -189,7 +188,13 @@ extension HomeForMemberViewModel {
         input.surveyButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                owner.onSurveyButtonTapped?(owner.surveyButtonURL)
+                guard let survey = owner.fetchedSurvey else { return }
+                owner.onSurveyButtonTapped?(survey.linkURL)
+                owner.eventTracker.trackClickPromo(
+                    promoName: survey.title,
+                    destinationURL: survey.linkURL,
+                    destinationType: .web
+                )
             }
             .store(in: cancelBag)
         
@@ -256,9 +261,7 @@ extension HomeForMemberViewModel {
             async let appService = useCase.getAppServicesAsync()
             async let popularPosts = useCase.getPopularPostsAsync()
             async let latestPosts = useCase.getLatestPostsAsync()
-            
-            self.surveyButtonURL = try await survey.linkURL
-            
+                        
             model = HomePresentationModel(
                 dashBoard: try await dashBoard,
                 recentSchedule: try await recentSchedule,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -181,11 +181,11 @@ extension HomeForMemberViewModel {
         input.extendedFloatingButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                guard let fetchedFABInfo = owner.fetchedFABInfo else { return }
-                owner.onExtendedFloatingButtonTapped?(fetchedFABInfo.url)
+                let fetchedFABInfo = owner.fetchedFABInfo
+                owner.onExtendedFloatingButtonTapped?(fetchedFABInfo?.url ?? "")
                 owner.eventTracker.trackClickPromo(
-                    promoName: fetchedFABInfo.actionButtonName,
-                    destinationURL: fetchedFABInfo.url,
+                    promoName: fetchedFABInfo?.actionButtonName,
+                    destinationURL: fetchedFABInfo?.url,
                     destinationType: .app
                 )
             }
@@ -194,11 +194,11 @@ extension HomeForMemberViewModel {
         input.surveyButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                guard let survey = owner.fetchedSurvey else { return }
-                owner.onSurveyButtonTapped?(survey.linkURL)
+                let survey = owner.fetchedSurvey
+                owner.onSurveyButtonTapped?(survey?.linkURL ?? "")
                 owner.eventTracker.trackClickPromo(
-                    promoName: survey.title,
-                    destinationURL: survey.linkURL,
+                    promoName: survey?.title,
+                    destinationURL: survey?.linkURL,
                     destinationType: .web
                 )
             }
@@ -322,6 +322,7 @@ extension HomeForMemberViewModel {
         if let cached = fetchedSurvey { return cached }
         let entity = try await useCase.getSurveyInfoAsync()
         let survey = entity.toPresentation()
+        fetchedSurvey = survey
         return survey
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeLatestPostsResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomeLatestPostsResponseEntity.swift
@@ -22,4 +22,5 @@ public struct HomeLatestPostsResponseEntity: Decodable {
     public let webLink: String
     public let id: Int?
     public let isOutdated: Bool
+    public let userId: Int?
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomePopularPostsResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/HomePopularPostsResponseEntity.swift
@@ -22,4 +22,5 @@ public struct HomePopularPostsResponseEntity: Decodable {
     public let content: String
     public let webLink: String
     public let id: Int?
+    public let userId: Int?
 }


### PR DESCRIPTION
## 🌴 PR 요약

- 홈화면 앰플리튜드를 연동했어요. [앰플리튜드 문서 바로가기](https://www.notion.so/sopt-makers/23376042aac28095bac7ff33e4ca1301#23376042aac280f6b451f16dcf7f7340)

🌱 작업한 브랜치
- #673 

## 🌱 PR Point


1️⃣ **HomeEventTrakcer**
- `HomeEventTrakcer`라는 struct를 만들어서 홈에서의 이벤트 트래킹 관련 함수들을 정리했어요. 
- (기존 다른 피처의 이벤트 트래커랑 유사합니다..!)

***

2️⃣ **PresentationModel -> PostModel -> serverID 필드 추가**
- **서버에서 내려오는 post의 ID값은 옵셔널**이에요.
- 디퍼블에서 각 아이템이 고유한 아이디값을 가지고 있어야 하는데, 상기의 이유로 고유하지 않아 `stableID`라는 이름으로 고유한 ID값(카테고리 등의 값 조합)을 임의로 생성해 사용하고 있었는데요,
- 프로퍼티 중 서버에서 내려온 ID 값을 그대로 사용해야 할 니즈가 있어 `serverID` 필드를 추가했습니다.

***

3️⃣ **Post Cell -> ProfileImageView 터치 이벤트**
- 기획에 따르면, **게시물의 프로필 뷰를 터치하면 플그 프로필 WebView를 띄워주어야** 하는데요.
- 기존에 서버에서 userID를 함께 내려주지 않아 [명세가 아직 업데이트 되지 않았어요](https://www.notion.so/sopt-makers/26276042aac281f8a826ddad42a2c9ea) 구현하지 못하고 있었습니다.
- 문의 결과, 해당 데이터에 필드 추가해주셔서 해당 부분 구현해 앰플 연동까지 했습니다!


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

생략

## 📮 관련 이슈
- Resolved: #673 
