### PR TITLE
[Chore] #697 - 솝마디에서 콕찌르기 영역 hidden 처리

### DIFF
--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/DailySoptuneScene/VC/DailySoptuneResultVC.swift
@@ -47,7 +47,6 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
     private lazy var dailySoptuneResultContentView = DailySoptuneResultContentView()
     
     // 콕 찌르기 부분
-    
     private let dailySoptuneResultPokeView = DailySoptuneResultPokeView()
     
     // 오늘의 부적 받기 버튼
@@ -76,6 +75,7 @@ public final class DailySoptuneResultVC: UIViewController, DailySoptuneResultVie
         self.setStackView()
         self.setLayout()
         self.bindViewModels()
+        self.hiddenPokeView() // NOTE: 기획의 요청에 따라 hidden 처리합니다.
     }
 }
 
@@ -160,6 +160,12 @@ private extension DailySoptuneResultVC {
             .sink { owner, updatedUser in
                 owner.dailySoptuneResultPokeView.changeUIAfterPoke(newUserModel: updatedUser)
             }.store(in: cancelBag)
+    }
+    
+    // NOTE: 기획의 요청에 따라 PokeView를 hidden합니다.
+    // 이후 PokeView가 다시 보여져야 한다면, 해당 함수를 제거해주세요.
+    func hiddenPokeView() {
+        dailySoptuneResultPokeView.isHidden = true
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약
기획의 요청으로, 솝마디에서 콕찌르기 영역을 hidden 처리합니다.

🌱 작업한 브랜치
- #697 

## 🌱 PR Point
- 추후에 해당 영역이 다시 보여질 수 있는 니즈가 존재해, 단순 hidden 처리만 해두었습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #697 
