### PR TITLE
[Refactor] #635 - PokeMain의 코디네이터 의존성 제거 방식 변경 및 온보딩 분기처리 로직 수정

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
@@ -48,10 +48,4 @@ extension PokeMainRepository: PokeMainRepositoryInterface {
             .map { $0.toDomain() }
             .eraseToAnyPublisher()
     }
-    
-    public func checkPokeNewUser() -> AnyPublisher<Bool, Error> {
-        pokeService.isNewUser()
-            .map { $0.isNew }
-            .eraseToAnyPublisher()
-    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
@@ -12,5 +12,4 @@ public protocol PokeMainRepositoryInterface: PokeRepositoryInterface {
     func getWhoPokeToMe() -> AnyPublisher<PokeUserModel?, Error>
     func getFriend() -> AnyPublisher<[PokeUserModel], Error>
     func getFriendRandomUser(randomType: String, size: Int) -> AnyPublisher<PokeFriendRandomUserModel, Error>
-    func checkPokeNewUser() -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -17,13 +17,11 @@ public protocol PokeMainUseCase {
   var pokedResponse: PassthroughSubject<PokeUserModel, Never> { get }
   var madeNewFriend: PassthroughSubject<PokeUserModel, Never> { get }
   var errorMessage: PassthroughSubject<String?, Never> { get }
-  var isPokeNewUser: PassthroughSubject<Bool, Never> { get set }
 
   func getWhoPokedToMe()
   func getFriend()
   func getFriendRandomUser(randomType: PokeRandomUserType, size: Int)
   func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool)
-  func checkPokeNewUser()
 }
 
 public class DefaultPokeMainUseCase {
@@ -36,7 +34,6 @@ public class DefaultPokeMainUseCase {
   public let pokedResponse = PassthroughSubject<PokeUserModel, Never>()
   public let madeNewFriend = PassthroughSubject<PokeUserModel, Never>()
   public let errorMessage = PassthroughSubject<String?, Never>()
-  public var isPokeNewUser = PassthroughSubject<Bool, Never>()
 
   public init(repository: PokeMainRepositoryInterface) {
     self.repository = repository
@@ -88,15 +85,5 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
           self?.madeNewFriend.send(user)
         }
       }.store(in: self.cancelBag)
-  }
-
-  public func checkPokeNewUser() {
-    repository.checkPokeNewUser()
-      .catch { error in
-        print("CheckPokeNewUser State: \(error)")
-        return Just(false)
-      }.sink { [weak self] isNewUser in
-        self?.isPokeNewUser.send(isNewUser)
-      }.store(in: cancelBag)
   }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
@@ -9,9 +9,10 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol LegacyPokeFeatureBuildable {
-    func makePokeMain(isRouteFromRoot: Bool) -> LegacyPokeMainPresentable
+    func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> LegacyPokeMainPresentable
     func makePokeMyFriends() -> LegacyPokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> LegacyPokeMyFriendsListPresentable
     func makePokeOnboarding() -> LegacyPokeOnboardingPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -9,9 +9,10 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol PokeFeatureBuildable {
-    func makePokeMain(isRouteFromRoot: Bool) -> PokeMainPresentable
+    func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeMainPresentable
     func makePokeMyFriends() -> PokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
     func makePokeOnboarding() -> PokeOnboardingPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
@@ -14,7 +14,7 @@ import Domain
 
 public protocol PokeMainViewControllable: LegacyViewControllable { }
 
-public protocol PokeMainCoordinatable {
+public protocol PokeMainRoutingTrigger {
   var onNaviBackTap: (() -> Void)? { get set }
   var onPokeNotificationsTap: (() -> Void)? { get set }
   var onMyFriendsTap: (() -> Void)? { get set }
@@ -25,7 +25,7 @@ public protocol PokeMainCoordinatable {
   var switchToOnboarding: (() -> Void)? { get set }
 }
 
-public typealias PokeMainViewModelType = ViewModelType & PokeMainCoordinatable
+public typealias PokeMainViewModelType = ViewModelType & PokeMainRoutingTrigger
 public typealias LegacyPokeMainPresentable = (vc: PokeMainViewControllable, vm: any PokeMainViewModelType)
 
 public typealias PokeMainPresentable = (vc: UIViewController, vm: any PokeMainViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
@@ -22,7 +22,6 @@ public protocol PokeMainRoutingTrigger {
   var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
   var onNewFriendMade: ((String) -> Void)? { get set }
   var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)? { get set }
-  var switchToOnboarding: (() -> Void)? { get set }
 }
 
 public typealias PokeMainViewModelType = ViewModelType & PokeMainRoutingTrigger

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMessageTemplatesPresentable.swift
@@ -23,10 +23,10 @@ public protocol PokeMessageTemplatesViewControllable: UIViewController {
     func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)>
 }
 
-public protocol PokeMessageTemplatesCoordinatable { }
+public protocol PokeMessageTemplatesRoutingTrigger { }
 
-public protocol PokeMessageTemplatesViewModelType: ViewModelType & PokeMessageTemplatesCoordinatable {
+public protocol PokeMessageTemplatesViewModelType: ViewModelType & PokeMessageTemplatesRoutingTrigger {
     var messageType: PokeMessageType { get }
 }
-public typealias LegacyPokeMessageTemplatesPresentable = (vc: LegacyPokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesCoordinatable)
-public typealias PokeMessageTemplatesPresentable = (vc: PokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesCoordinatable)
+public typealias LegacyPokeMessageTemplatesPresentable = (vc: LegacyPokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesRoutingTrigger)
+public typealias PokeMessageTemplatesPresentable = (vc: PokeMessageTemplatesViewControllable, vm: any PokeMessageTemplatesRoutingTrigger)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsListPresentable.swift
@@ -14,11 +14,11 @@ import Domain
 
 public protocol PokeMyFriendsListViewControllable: LegacyViewControllable { }
 
-public protocol PokeMyFriendsListCoordinatable {
+public protocol PokeMyFriendsListRoutingTrigger {
     var onCloseButtonTap: (() -> Void)? { get set }
 }
 
-public protocol PokeMyFriendsListViewModelType: ViewModelType & PokeMyFriendsListCoordinatable {
+public protocol PokeMyFriendsListViewModelType: ViewModelType & PokeMyFriendsListRoutingTrigger {
     var relation: PokeRelation { get }
     var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onProfileImageTapped: ((Int) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMyFriendsPresentable.swift
@@ -14,14 +14,14 @@ import Domain
 
 public protocol PokeMyFriendsViewControllable: LegacyViewControllable { }
 
-public protocol PokeMyFriendsCoordinatable {
+public protocol PokeMyFriendsRoutingTrigger {
     var showFriendsListButtonTap: ((PokeRelation) -> Void)? { get set }
     var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onProfileImageTapped: ((Int) -> Void)? { get set }
     var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)? { get set }
 }
 
-public typealias PokeMyFriendsViewModelType = ViewModelType & PokeMyFriendsCoordinatable
+public typealias PokeMyFriendsViewModelType = ViewModelType & PokeMyFriendsRoutingTrigger
 public typealias LegacyPokeMyFriendsPresentable = (vc: PokeMyFriendsViewControllable, vm: any PokeMyFriendsViewModelType)
 
 public typealias PokeMyFriendsPresentable = (vc: UIViewController, vm: any PokeMyFriendsViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeNotificationPresentable.swift
@@ -14,7 +14,7 @@ import Domain
 
 public protocol PokeNotificationViewControllable: LegacyViewControllable { }
 
-public protocol PokeNotificationCoordinatable {
+public protocol PokeNotificationRoutingTrigger {
     var onNaviBackTapped: (() -> Void)? { get set }
     var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
     var onNewFriendAdded: ((_ friendName: String) -> Void)? { get set }
@@ -22,7 +22,7 @@ public protocol PokeNotificationCoordinatable {
     var onProfileImageTapped: ((Int) -> Void)? { get set }
 }
 
-public typealias PokeNotificationViewModelType = ViewModelType & PokeNotificationCoordinatable
+public typealias PokeNotificationViewModelType = ViewModelType & PokeNotificationRoutingTrigger
 public typealias LegacyPokeNotificationPresentable = (vc: PokeNotificationViewControllable, vm: any PokeNotificationViewModelType)
 
 public typealias PokeNotificationPresentable = (vc: UIViewController, vm: any PokeNotificationViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeOnboardingPresentable.swift
@@ -14,7 +14,7 @@ import Domain
 
 public protocol PokeOnboardingViewControllable: LegacyViewControllable { }
 
-public protocol PokeOnboardingCoordinatable {
+public protocol PokeOnboardingRoutingTrigger {
     var onNaviBackTapped: (() -> Void)? { get set }
     var onFirstVisitInOnboarding: (() -> Void)? { get set }
     var onAvartarTapped: ((_ userId: String) -> Void)? { get set }
@@ -22,7 +22,7 @@ public protocol PokeOnboardingCoordinatable {
     var onMyFriendsTapped: (() -> Void)? { get set }
 }
 
-public typealias PokeOnboardingViewModelType = ViewModelType & PokeOnboardingCoordinatable
+public typealias PokeOnboardingViewModelType = ViewModelType & PokeOnboardingRoutingTrigger
 public typealias LegacyPokeOnboardingPresentable = (vc: PokeOnboardingViewControllable, vm: any PokeOnboardingViewModelType)
 
 public typealias PokeOnboardingPresentable = (vc: UIViewController, vm: any PokeOnboardingViewModelType)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import PokeFeatureInterface
 
 public final class LegacyPokeBuilder {
@@ -20,9 +21,11 @@ public final class LegacyPokeBuilder {
 }
 
 extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
-    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.LegacyPokeMainPresentable {
+    public func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeFeatureInterface.LegacyPokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
-        let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
+        let viewModel = PokeMainViewModel(useCase: useCase,
+                                          coordinator: coordinator,
+                                          isRouteFromRoot: isRouteFromRoot)
         let pokeMainVC = PokeMainVC(viewModel: viewModel)
         return (pokeMainVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
@@ -16,7 +16,7 @@ import Domain
 import WebFeature
 
 public
-final class LegacyPokeCoordinator: DefaultPokeCoordinator {
+final class LegacyPokeCoordinator: BaseCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: LegacyPokeFeatureBuildable
@@ -33,7 +33,7 @@ final class LegacyPokeCoordinator: DefaultPokeCoordinator {
     }
     
     public func showPokeMain(isRouteFromRoot: Bool) {
-        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot)
+        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot, coordinator: self)
         
         pokeMain.vm.onNaviBackTap = { [weak self] in
             self?.router.dismissModule(animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeCoordinator.swift
@@ -73,31 +73,9 @@ final class LegacyPokeCoordinator: BaseCoordinator {
           pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
           self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
         }
-
-        pokeMain.vm.switchToOnboarding = { [weak self] in
-            guard let self = self else { return }
-            self.runPokeOnboardingFlow()
-        }
         
         rootController = pokeMain.vc.asNavigationController
         router.present(rootController, animated: true, modalPresentationSytle: .overFullScreen)
-    }
-    
-    internal func runPokeOnboardingFlow() {
-        let pokeOnboardingCoordinator = LegacyPokeOnboardingCoordinator(
-            router: LegacyRouter(
-                rootController: rootController ?? self.router.asNavigationController
-            ),
-            factory: factory
-        )
-        
-        pokeOnboardingCoordinator.finishFlow = { [weak self, weak pokeOnboardingCoordinator] in
-            pokeOnboardingCoordinator?.childCoordinators = []
-            self?.removeDependency(pokeOnboardingCoordinator)
-        }
-        
-        addDependency(pokeOnboardingCoordinator)
-        pokeOnboardingCoordinator.start()
     }
     
     internal func runPokeNotificationListFlow() {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import PokeFeatureInterface
 
 public final class PokeBuilder {
@@ -28,9 +29,11 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMain(isRouteFromRoot: Bool) -> PokeFeatureInterface.PokeMainPresentable {
+    public func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeFeatureInterface.PokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
-        let viewModel = PokeMainViewModel(useCase: useCase, isRouteFromRoot: isRouteFromRoot)
+        let viewModel = PokeMainViewModel(useCase: useCase,
+                                          coordinator: coordinator,
+                                          isRouteFromRoot: isRouteFromRoot)
         let pokeMainVC = PokeMainVC(viewModel: viewModel)
         
         return (pokeMainVC, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -20,7 +20,7 @@ public final class PokeCoordinator: BaseCoordinator {
     // MARK: - Properties
     
     private let factory: PokeFeatureBuildable
-    private weak var navigationController: UINavigationController? // pokeMain을 prensent하는 부모 네비
+    private weak var navigationController: UINavigationController?  // pokeMain을 prensent하는 부모 네비
     private weak var rootController: UINavigationController?        // pokeMain에서 push할 때 사용
     
     // MARK: - Init
@@ -91,7 +91,7 @@ public final class PokeCoordinator: BaseCoordinator {
     
     internal func runPokeNotificationListFlow() {
         let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
-            navigationController: rootController ?? UIWindow.getRootNavigationController,
+            navigationController: navigationController ?? UIWindow.getRootNavigationController,
             factory: factory
         )
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -82,31 +82,11 @@ public final class PokeCoordinator: BaseCoordinator {
             pokeAnonymousFriendUpgradeVC.modalPresentationStyle = .overFullScreen
             self.rootController?.present(pokeAnonymousFriendUpgradeVC, animated: false)
         }
-
-        pokeMain.vm.switchToOnboarding = { [weak self] in
-            guard let self = self else { return }
-            self.runPokeOnboardingFlow()
-        }
         
         let navController = UINavigationController(rootViewController: pokeMain.vc)
         navController.modalPresentationStyle = .overFullScreen
         rootController = navController
         navigationController?.present(navController, animated: true)
-    }
-    
-    internal func runPokeOnboardingFlow() {
-        let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
-            navigationController: rootController ?? UIWindow.getRootNavigationController,
-            factory: factory
-        )
-        
-        pokeOnboardingCoordinator.finishFlow = { [weak self, weak pokeOnboardingCoordinator] in
-            pokeOnboardingCoordinator?.childCoordinators = []
-            self?.removeDependency(pokeOnboardingCoordinator)
-        }
-        
-        addDependency(pokeOnboardingCoordinator)
-        pokeOnboardingCoordinator.start()
     }
     
     internal func runPokeNotificationListFlow() {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -15,15 +15,15 @@ import BaseFeatureDependency
 import PokeFeatureInterface
 import WebFeature
 
-public final class PokeCoordinator: DefaultPokeCoordinator {
+public final class PokeCoordinator: BaseCoordinator {
 
     // MARK: - Properties
     
     public var finishFlow: (() -> Void)?
     
     private let factory: PokeFeatureBuildable
-    private let navigationController: UINavigationController
-    private weak var rootController: UINavigationController?
+    private weak var navigationController: UINavigationController? // pokeMain을 prensent하는 부모 네비
+    private weak var rootController: UINavigationController?        // pokeMain에서 push할 때 사용
     
     // MARK: - Init
     
@@ -48,8 +48,7 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
                                             coordinator: self)
         
         pokeMain.vm.onNaviBackTap = { [weak self] in
-            self?.navigationController.dismiss(animated: true)
-            self?.finishFlow?()
+            self?.navigationController?.dismiss(animated: true)
         }
         
         pokeMain.vm.onPokeNotificationsTap = { [weak self] in
@@ -64,7 +63,7 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
             guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.navigationController.pushViewController(webView, animated: true)
+            self?.rootController?.pushViewController(webView, animated: true)
         }
         
         pokeMain.vm.onPokeButtonTapped = { [weak self] userModel in
@@ -94,12 +93,12 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
         let navController = UINavigationController(rootViewController: pokeMain.vc)
         navController.modalPresentationStyle = .overFullScreen
         rootController = navController
-        navigationController.present(navController, animated: true)
+        navigationController?.present(navController, animated: true)
     }
     
     internal func runPokeOnboardingFlow() {
         let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
-            navigationController: rootController ?? navigationController,
+            navigationController: rootController ?? UIWindow.getRootNavigationController,
             factory: factory
         )
         
@@ -114,7 +113,7 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
     
     internal func runPokeNotificationListFlow() {
         let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
-            navigationController: rootController ?? navigationController,
+            navigationController: rootController ?? UIWindow.getRootNavigationController,
             factory: factory
         )
         
@@ -129,7 +128,7 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
     
     private func runPokeMyFriendsFlow() {
         let pokeMyFriendsCoordinator = PokeMyFriendsCoordinator(
-            navigationController: rootController ?? navigationController,
+            navigationController: rootController ?? UIWindow.getRootNavigationController,
             factory: factory
         )
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -91,7 +91,7 @@ public final class PokeCoordinator: BaseCoordinator {
     
     internal func runPokeNotificationListFlow() {
         let pokeNotificationListCoordinator = PokeNotificationListCoordinator(
-            navigationController: navigationController ?? UIWindow.getRootNavigationController,
+            navigationController: rootController ?? UIWindow.getRootNavigationController,
             factory: factory
         )
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -19,8 +19,6 @@ public final class PokeCoordinator: BaseCoordinator {
 
     // MARK: - Properties
     
-    public var finishFlow: (() -> Void)?
-    
     private let factory: PokeFeatureBuildable
     private weak var navigationController: UINavigationController? // pokeMain을 prensent하는 부모 네비
     private weak var rootController: UINavigationController?        // pokeMain에서 push할 때 사용

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -16,7 +16,7 @@ import PokeFeatureInterface
 import WebFeature
 
 public final class PokeCoordinator: DefaultPokeCoordinator {
-    
+
     // MARK: - Properties
     
     public var finishFlow: (() -> Void)?
@@ -44,7 +44,8 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
     // MARK: - Navigation
     
     public func showPokeMain(isRouteFromRoot: Bool) {
-        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot)
+        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot,
+                                            coordinator: self)
         
         pokeMain.vm.onNaviBackTap = { [weak self] in
             self?.navigationController.dismiss(animated: true)
@@ -63,7 +64,7 @@ public final class PokeCoordinator: DefaultPokeCoordinator {
             guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.rootController?.pushViewController(webView, animated: true)
+            self?.navigationController.pushViewController(webView, animated: true)
         }
         
         pokeMain.vm.onPokeButtonTapped = { [weak self] userModel in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -17,227 +17,226 @@ import BaseFeatureDependency
 
 internal typealias UserId = Int
 
-public class PokeMainViewModel:
-  PokeMainViewModelType {
-
-  public var onNaviBackTap: (() -> Void)?
-  public var onPokeNotificationsTap: (() -> Void)?
-  public var onMyFriendsTap: (() -> Void)?
-  public var onProfileImageTapped: ((Int) -> Void)?
-  public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
-  public var onNewFriendMade: ((String) -> Void)?
-  public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
-  public var switchToOnboarding: (() -> Void)?
-
-  // MARK: - Properties
-
-  private let useCase: PokeMainUseCase
-  private let isRouteFromRoot: Bool
-  private var cancelBag = CancelBag()
-  private let eventTracker = PokeEventTracker()
-
-  // MARK: - Inputs
-
-  public struct Input {
-    let viewDidLoad: Driver<Void>
-    let naviBackButtonTap: Driver<Void>
-    let pokedSectionHeaderButtonTap: Driver<Void>
-    let friendSectionHeaderButtonTap: Driver<Void>
-    let pokedSectionKokButtonTap: Driver<PokeUserModel?>
-    let friendSectionKokButtonTap: Driver<PokeUserModel?>
-    let nearbyFriendsSectionKokButtonTap: Driver<PokeUserModel?>
-    let refreshRequest: Driver<Void>
-    let profileImageTap: Driver<(PokeUserModel?, PokeAmplitudeEventPropertyValue)>
-  }
-
-  // MARK: - Outputs
-
-  public struct Output {
-    let pokedToMeUser = PassthroughSubject<PokeUserModel, Never>()
-    let pokedUserSectionWillBeHidden = PassthroughSubject<Bool, Never>()
-    let myFriend = PassthroughSubject<PokeUserModel, Never>()
-    let friendsSectionWillBeHidden = PassthroughSubject<Bool, Never>()
-    let friendRandomUsers = PassthroughSubject<PokeFriendRandomUserModel, Never>()
-    let endRefreshLoading = PassthroughSubject<Void, Never>()
-    let pokeResponse = PassthroughSubject<PokeUserModel, Never>()
-    let isLoading = PassthroughSubject<Bool, Never>()
-  }
-
-  // MARK: - initialization
-
-  public init(useCase: PokeMainUseCase, isRouteFromRoot: Bool = false) {
-    self.useCase = useCase
-    self.isRouteFromRoot = isRouteFromRoot
-  }
+public class PokeMainViewModel: PokeMainViewModelType {
+    
+    public var onNaviBackTap: (() -> Void)?
+    public var onPokeNotificationsTap: (() -> Void)?
+    public var onMyFriendsTap: (() -> Void)?
+    public var onProfileImageTapped: ((Int) -> Void)?
+    public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
+    public var onNewFriendMade: ((String) -> Void)?
+    public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
+    public var switchToOnboarding: (() -> Void)?
+    
+    // MARK: - Properties
+    
+    private let useCase: PokeMainUseCase
+    private let isRouteFromRoot: Bool
+    private var cancelBag = CancelBag()
+    private let eventTracker = PokeEventTracker()
+    
+    // MARK: - Inputs
+    
+    public struct Input {
+        let viewDidLoad: Driver<Void>
+        let naviBackButtonTap: Driver<Void>
+        let pokedSectionHeaderButtonTap: Driver<Void>
+        let friendSectionHeaderButtonTap: Driver<Void>
+        let pokedSectionKokButtonTap: Driver<PokeUserModel?>
+        let friendSectionKokButtonTap: Driver<PokeUserModel?>
+        let nearbyFriendsSectionKokButtonTap: Driver<PokeUserModel?>
+        let refreshRequest: Driver<Void>
+        let profileImageTap: Driver<(PokeUserModel?, PokeAmplitudeEventPropertyValue)>
+    }
+    
+    // MARK: - Outputs
+    
+    public struct Output {
+        let pokedToMeUser = PassthroughSubject<PokeUserModel, Never>()
+        let pokedUserSectionWillBeHidden = PassthroughSubject<Bool, Never>()
+        let myFriend = PassthroughSubject<PokeUserModel, Never>()
+        let friendsSectionWillBeHidden = PassthroughSubject<Bool, Never>()
+        let friendRandomUsers = PassthroughSubject<PokeFriendRandomUserModel, Never>()
+        let endRefreshLoading = PassthroughSubject<Void, Never>()
+        let pokeResponse = PassthroughSubject<PokeUserModel, Never>()
+        let isLoading = PassthroughSubject<Bool, Never>()
+    }
+    
+    // MARK: - initialization
+    
+    public init(useCase: PokeMainUseCase, isRouteFromRoot: Bool = false) {
+        self.useCase = useCase
+        self.isRouteFromRoot = isRouteFromRoot
+    }
 }
 
 extension PokeMainViewModel {
-  public func transform(from input: Input, cancelBag: Core.CancelBag) -> Output {
-    let output = Output()
-    self.bindOutput(output: output, cancelBag: cancelBag)
-
-    Publishers.Merge(input.viewDidLoad, input.refreshRequest)
-      .sink { [weak self] _ in
-        self?.useCase.getWhoPokedToMe()
-        self?.useCase.getFriend()
-        self?.useCase.getFriendRandomUser(randomType: .all, size: 2)
-      }.store(in: cancelBag)
-
-    // 콕찌르기 새 유저인지 판별, 새유저인 경우 PokeOnboardingVC로 전환한다.
-    // isRouteFromRoot == true일 때만 로직 실행, isRouteFromRoot는 딥링크를 통해 이동한 경우만 true (update.2025.04.08)
-    input.viewDidLoad
-      .map { [weak self] _ in
-        self?.isRouteFromRoot
-      }
-      .compactMap { $0 }
-      .filter { $0 == true }
-      .sink { [weak self] _ in
-        output.isLoading.send(true)
-        self?.useCase.checkPokeNewUser()
-      }.store(in: cancelBag)
-
-    input.viewDidLoad
-      .sink { [weak self] _ in
-        self?.eventTracker.trackViewEvent(with: .viewPokeMain)
-      }.store(in: cancelBag)
-
-    input.naviBackButtonTap
-      .sink { [weak self] _ in
-        self?.eventTracker.trackViewEvent(with: .clickPokeQuit)
-        self?.onNaviBackTap?()
-      }.store(in: cancelBag)
-
-    input.pokedSectionHeaderButtonTap
-      .sink { [weak self] _ in
-        self?.eventTracker.trackViewEvent(with: .clickPokeAlarmDetail)
-        self?.onPokeNotificationsTap?()
-      }.store(in: cancelBag)
-
-    input.friendSectionHeaderButtonTap
-      .sink { [weak self] _ in
-        self?.onMyFriendsTap?()
-      }.store(in: cancelBag)
-
-    // 답장
-    input.pokedSectionKokButtonTap
-      .compactMap { $0 }
-      .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)> in
-        guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
-        return value
-      }
-      .sink { [weak self] userModel, messageModel, isAnonymous in
-        self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainAlarm)
-        self?.useCase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous, willBeNewFriend: userModel.isFirstMeet)
-      }.store(in: cancelBag)
-
-    // 먼저 찌르기
-    input.friendSectionKokButtonTap
-      .merge(with: input.nearbyFriendsSectionKokButtonTap)
-      .compactMap { $0 }
-      .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)> in
-        guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
-        return value
-      }
-      .sink { [weak self] userModel, messageModel, isAnonymous in
-        self?.useCase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous, willBeNewFriend: false)
-      }.store(in: cancelBag)
-
-    input.profileImageTap
-      .compactMap { $0.0 }
-      .sink { [weak self] user in
-        self?.onProfileImageTapped?(user.userId)
-      }.store(in: cancelBag)
-
-    input.profileImageTap
-      .map { $0.1 }
-      .sink { [weak self] clickView in
-        self?.eventTracker.trackClickMemberProfileEvent(clickView: clickView)
-      }.store(in: cancelBag)
-
-    // Amplitude 트래킹
-    input.friendSectionKokButtonTap
-      .sink { [weak self] _ in
-        self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainFriend)
-      }.store(in: cancelBag)
-
-    input.nearbyFriendsSectionKokButtonTap
-      .sink { [weak self] _ in
-        self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainRecommendNotMyFriend)
-      }.store(in: cancelBag)
-
-    return output
-  }
-
-  private func bindOutput(output: Output, cancelBag: CancelBag) {
-    useCase.pokedToMeUser
-      .compactMap { $0 }
-      .sink { output.pokedToMeUser.send($0) }
-      .store(in: cancelBag)
-
-    useCase.pokedToMeUser
-      .map { $0 == nil }
-      .sink { output.pokedUserSectionWillBeHidden.send($0) }
-      .store(in: cancelBag)
-
-    useCase.myFriend
-      .compactMap { $0.first }
-      .sink { output.myFriend.send($0) }
-      .store(in: cancelBag)
-
-    useCase.myFriend
-      .map { $0.isEmpty }
-      .sink { output.friendsSectionWillBeHidden.send($0) }
-      .store(in: cancelBag)
-
-    useCase.friendRandomUsers
-      .sink { output.friendRandomUsers.send($0) }
-      .store(in: cancelBag)
-
-    Publishers.Zip3(useCase.pokedToMeUser, useCase.myFriend, useCase.friendRandomUsers)
-      .map { _ in Void() }
-      .sink { output.endRefreshLoading.send() }
-      .store(in: cancelBag)
-
-    useCase.pokedResponse
-      .sink { output.pokeResponse.send($0) }
-      .store(in: cancelBag)
-
-    // 다른 뷰에서 찌르기를 했을 때 메인 뷰의 해당 유저의 찌르기 버튼을 비활성화 하기 위해 NotificationCenter로 찌르기 이벤트를 받아온다.
-    let notiName = NotiList.makeNotiName(list: .pokedResponse)
-    NotificationCenter.default.publisher(for: notiName)
-      .compactMap { $0.object as? PokeUserModel }
-      .sink { output.pokeResponse.send($0) }
-      .store(in: cancelBag)
-
-    useCase.pokedResponse
-      .sink { [weak self] user in
-        guard let self else { return }
-        ToastUtils.showMDSToast(type: .success, text: I18N.Poke.pokeSuccess)
-        if user.isAnonymous {
-          if user.pokeNum == 5 || user.pokeNum == 6 || user.pokeNum == 11 || user.pokeNum == 12 {
-            onAnonymousFriendUpgrade?(user)
-          }
-        }
-      }.store(in: cancelBag)
-
-    useCase.madeNewFriend
-      .sink { [weak self] userModel in
-        let name = userModel.isAnonymous ? userModel.anonymousName : userModel.name
-        self?.onNewFriendMade?(name)
-      }.store(in: cancelBag)
-
-    useCase.errorMessage
-      .compactMap { $0 }
-      .sink { message in
-        ToastUtils.showMDSToast(type: .alert, text: message)
-      }.store(in: cancelBag)
-
-    useCase.isPokeNewUser
-      .sink { [weak self] isNewUser in
-        output.isLoading.send(false)
-        if isNewUser {
-          self?.switchToOnboarding?()
-        }
-      }.store(in: cancelBag)
-  }
+    public func transform(from input: Input, cancelBag: Core.CancelBag) -> Output {
+        let output = Output()
+        self.bindOutput(output: output, cancelBag: cancelBag)
+        
+        Publishers.Merge(input.viewDidLoad, input.refreshRequest)
+            .sink { [weak self] _ in
+                self?.useCase.getWhoPokedToMe()
+                self?.useCase.getFriend()
+                self?.useCase.getFriendRandomUser(randomType: .all, size: 2)
+            }.store(in: cancelBag)
+        
+        // 콕찌르기 새 유저인지 판별, 새유저인 경우 PokeOnboardingVC로 전환한다.
+        // isRouteFromRoot == true일 때만 로직 실행, isRouteFromRoot는 딥링크를 통해 이동한 경우만 true (update.2025.04.08)
+        input.viewDidLoad
+            .map { [weak self] _ in
+                self?.isRouteFromRoot
+            }
+            .compactMap { $0 }
+            .filter { $0 == true }
+            .sink { [weak self] _ in
+                output.isLoading.send(true)
+                self?.useCase.checkPokeNewUser()
+            }.store(in: cancelBag)
+        
+        input.viewDidLoad
+            .sink { [weak self] _ in
+                self?.eventTracker.trackViewEvent(with: .viewPokeMain)
+            }.store(in: cancelBag)
+        
+        input.naviBackButtonTap
+            .sink { [weak self] _ in
+                self?.eventTracker.trackViewEvent(with: .clickPokeQuit)
+                self?.onNaviBackTap?()
+            }.store(in: cancelBag)
+        
+        input.pokedSectionHeaderButtonTap
+            .sink { [weak self] _ in
+                self?.eventTracker.trackViewEvent(with: .clickPokeAlarmDetail)
+                self?.onPokeNotificationsTap?()
+            }.store(in: cancelBag)
+        
+        input.friendSectionHeaderButtonTap
+            .sink { [weak self] _ in
+                self?.onMyFriendsTap?()
+            }.store(in: cancelBag)
+        
+        // 답장
+        input.pokedSectionKokButtonTap
+            .compactMap { $0 }
+            .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)> in
+                guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
+                return value
+            }
+            .sink { [weak self] userModel, messageModel, isAnonymous in
+                self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainAlarm)
+                self?.useCase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous, willBeNewFriend: userModel.isFirstMeet)
+            }.store(in: cancelBag)
+        
+        // 먼저 찌르기
+        input.friendSectionKokButtonTap
+            .merge(with: input.nearbyFriendsSectionKokButtonTap)
+            .compactMap { $0 }
+            .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)> in
+                guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
+                return value
+            }
+            .sink { [weak self] userModel, messageModel, isAnonymous in
+                self?.useCase.poke(userId: userModel.userId, message: messageModel, isAnonymous: isAnonymous, willBeNewFriend: false)
+            }.store(in: cancelBag)
+        
+        input.profileImageTap
+            .compactMap { $0.0 }
+            .sink { [weak self] user in
+                self?.onProfileImageTapped?(user.userId)
+            }.store(in: cancelBag)
+        
+        input.profileImageTap
+            .map { $0.1 }
+            .sink { [weak self] clickView in
+                self?.eventTracker.trackClickMemberProfileEvent(clickView: clickView)
+            }.store(in: cancelBag)
+        
+        // Amplitude 트래킹
+        input.friendSectionKokButtonTap
+            .sink { [weak self] _ in
+                self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainFriend)
+            }.store(in: cancelBag)
+        
+        input.nearbyFriendsSectionKokButtonTap
+            .sink { [weak self] _ in
+                self?.eventTracker.trackClickPokeEvent(clickView: .pokeMainRecommendNotMyFriend)
+            }.store(in: cancelBag)
+        
+        return output
+    }
+    
+    private func bindOutput(output: Output, cancelBag: CancelBag) {
+        useCase.pokedToMeUser
+            .compactMap { $0 }
+            .sink { output.pokedToMeUser.send($0) }
+            .store(in: cancelBag)
+        
+        useCase.pokedToMeUser
+            .map { $0 == nil }
+            .sink { output.pokedUserSectionWillBeHidden.send($0) }
+            .store(in: cancelBag)
+        
+        useCase.myFriend
+            .compactMap { $0.first }
+            .sink { output.myFriend.send($0) }
+            .store(in: cancelBag)
+        
+        useCase.myFriend
+            .map { $0.isEmpty }
+            .sink { output.friendsSectionWillBeHidden.send($0) }
+            .store(in: cancelBag)
+        
+        useCase.friendRandomUsers
+            .sink { output.friendRandomUsers.send($0) }
+            .store(in: cancelBag)
+        
+        Publishers.Zip3(useCase.pokedToMeUser, useCase.myFriend, useCase.friendRandomUsers)
+            .map { _ in Void() }
+            .sink { output.endRefreshLoading.send() }
+            .store(in: cancelBag)
+        
+        useCase.pokedResponse
+            .sink { output.pokeResponse.send($0) }
+            .store(in: cancelBag)
+        
+        // 다른 뷰에서 찌르기를 했을 때 메인 뷰의 해당 유저의 찌르기 버튼을 비활성화 하기 위해 NotificationCenter로 찌르기 이벤트를 받아온다.
+        let notiName = NotiList.makeNotiName(list: .pokedResponse)
+        NotificationCenter.default.publisher(for: notiName)
+            .compactMap { $0.object as? PokeUserModel }
+            .sink { output.pokeResponse.send($0) }
+            .store(in: cancelBag)
+        
+        useCase.pokedResponse
+            .sink { [weak self] user in
+                guard let self else { return }
+                ToastUtils.showMDSToast(type: .success, text: I18N.Poke.pokeSuccess)
+                if user.isAnonymous {
+                    if user.pokeNum == 5 || user.pokeNum == 6 || user.pokeNum == 11 || user.pokeNum == 12 {
+                        onAnonymousFriendUpgrade?(user)
+                    }
+                }
+            }.store(in: cancelBag)
+        
+        useCase.madeNewFriend
+            .sink { [weak self] userModel in
+                let name = userModel.isAnonymous ? userModel.anonymousName : userModel.name
+                self?.onNewFriendMade?(name)
+            }.store(in: cancelBag)
+        
+        useCase.errorMessage
+            .compactMap { $0 }
+            .sink { message in
+                ToastUtils.showMDSToast(type: .alert, text: message)
+            }.store(in: cancelBag)
+        
+        useCase.isPokeNewUser
+            .sink { [weak self] isNewUser in
+                output.isLoading.send(false)
+                if isNewUser {
+                    self?.switchToOnboarding?()
+                }
+            }.store(in: cancelBag)
+    }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -19,6 +19,8 @@ internal typealias UserId = Int
 
 public class PokeMainViewModel: PokeMainViewModelType {
     
+    // MARK: - Trigger
+    
     public var onNaviBackTap: (() -> Void)?
     public var onPokeNotificationsTap: (() -> Void)?
     public var onMyFriendsTap: (() -> Void)?
@@ -34,6 +36,7 @@ public class PokeMainViewModel: PokeMainViewModelType {
     private let isRouteFromRoot: Bool
     private var cancelBag = CancelBag()
     private let eventTracker = PokeEventTracker()
+    private let coordinator: AnyCoordinatorObject           /// Coordinator 프로토콜이 레거시에서만 사용되기 때문
     
     // MARK: - Inputs
     
@@ -63,9 +66,10 @@ public class PokeMainViewModel: PokeMainViewModelType {
     }
     
     // MARK: - initialization
-    
-    public init(useCase: PokeMainUseCase, isRouteFromRoot: Bool = false) {
+    // TODO: - Coordinator를 AnyCoordinatorObject로 변경
+    public init(useCase: PokeMainUseCase, coordinator: Coordinator, isRouteFromRoot: Bool = false) {
         self.useCase = useCase
+        self.coordinator = coordinator
         self.isRouteFromRoot = isRouteFromRoot
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -28,7 +28,6 @@ public class PokeMainViewModel: PokeMainViewModelType {
     public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
     public var onNewFriendMade: ((String) -> Void)?
     public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
-    public var switchToOnboarding: (() -> Void)?
     
     // MARK: - Properties
     
@@ -84,19 +83,6 @@ extension PokeMainViewModel {
                 self?.useCase.getWhoPokedToMe()
                 self?.useCase.getFriend()
                 self?.useCase.getFriendRandomUser(randomType: .all, size: 2)
-            }.store(in: cancelBag)
-        
-        // 콕찌르기 새 유저인지 판별, 새유저인 경우 PokeOnboardingVC로 전환한다.
-        // isRouteFromRoot == true일 때만 로직 실행, isRouteFromRoot는 딥링크를 통해 이동한 경우만 true (update.2025.04.08)
-        input.viewDidLoad
-            .map { [weak self] _ in
-                self?.isRouteFromRoot
-            }
-            .compactMap { $0 }
-            .filter { $0 == true }
-            .sink { [weak self] _ in
-                output.isLoading.send(true)
-                self?.useCase.checkPokeNewUser()
             }.store(in: cancelBag)
         
         input.viewDidLoad
@@ -233,14 +219,6 @@ extension PokeMainViewModel {
             .compactMap { $0 }
             .sink { message in
                 ToastUtils.showMDSToast(type: .alert, text: message)
-            }.store(in: cancelBag)
-        
-        useCase.isPokeNewUser
-            .sink { [weak self] isNewUser in
-                output.isLoading.send(false)
-                if isNewUser {
-                    self?.switchToOnboarding?()
-                }
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/ViewModel/PokeMyFriendsListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/ViewModel/PokeMyFriendsListViewModel.swift
@@ -18,6 +18,8 @@ import BaseFeatureDependency
 public class PokeMyFriendsListViewModel:
     PokeMyFriendsListViewModelType {
     
+    // MARK: - Trigger
+    
     public var onCloseButtonTap: (() -> Void)?
     public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
     public var onProfileImageTapped: ((Int) -> Void)?

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -571,7 +571,7 @@ extension ApplicationCoordinator {
                 self?.removeDependency(legacyPokeCoordinator)
             }
             coordinator = legacyPokeCoordinator
-            
+            addDependency(coordinator)
         case .new:
             let newCoordinator = PokeCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
@@ -580,8 +580,7 @@ extension ApplicationCoordinator {
             
             coordinator = newCoordinator
         }
-
-        addDependency(coordinator)
+        
         coordinator.start()
         
         return coordinator

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -555,27 +555,6 @@ extension ApplicationCoordinator {
 // MARK: - PokeFlow
 
 extension ApplicationCoordinator {
-//    @discardableResult
-//    internal func runPokeFlow() -> BaseCoordinator {
-//        var coordinator = makePokeCoordinator()
-//        
-//        addDependency(coordinator)
-//        coordinator.start()
-//        
-//        switch Config.coordinatorFlag {
-//        case .legacy:
-//            coordinator.finishFlow = { [weak self, weak coordinator] in
-//                coordinator?.childCoordinators = []
-//                self?.removeDependency(coordinator)
-//            }
-//        case .new:
-//            <#code#>
-//        }
-//        
-//        
-//        return coordinator
-//    }
-    
     @discardableResult
     internal func runPokeFlow() -> BaseCoordinator {
         var coordinator: BaseCoordinator

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -555,44 +555,55 @@ extension ApplicationCoordinator {
 // MARK: - PokeFlow
 
 extension ApplicationCoordinator {
-    @discardableResult
-    internal func runPokeFlow() -> DefaultCoordinator {
-        var coordinator = makePokeCoordinator()
-        
-        addDependency(coordinator)
-        coordinator.start()
-        
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
-        }
-        
-        return coordinator
-    }
+//    @discardableResult
+//    internal func runPokeFlow() -> BaseCoordinator {
+//        var coordinator = makePokeCoordinator()
+//        
+//        addDependency(coordinator)
+//        coordinator.start()
+//        
+//        switch Config.coordinatorFlag {
+//        case .legacy:
+//            coordinator.finishFlow = { [weak self, weak coordinator] in
+//                coordinator?.childCoordinators = []
+//                self?.removeDependency(coordinator)
+//            }
+//        case .new:
+//            <#code#>
+//        }
+//        
+//        
+//        return coordinator
+//    }
     
     @discardableResult
-    internal func makePokeCoordinator() -> DefaultPokeCoordinator {
-        var coordinator: DefaultPokeCoordinator
+    internal func runPokeFlow() -> BaseCoordinator {
+        var coordinator: BaseCoordinator
         
         switch Config.coordinatorFlag {
         case .legacy:
-            coordinator = LegacyPokeCoordinator(
+            let legacyPokeCoordinator = LegacyPokeCoordinator(
                 router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
                 factory: LegacyPokeBuilder()
             )
+            
+            legacyPokeCoordinator.finishFlow = { [weak self, weak legacyPokeCoordinator] in
+                legacyPokeCoordinator?.childCoordinators = []
+                self?.removeDependency(legacyPokeCoordinator)
+            }
+            coordinator = legacyPokeCoordinator
+            
         case .new:
-            coordinator = PokeCoordinator(
+            let newCoordinator = PokeCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: PokeBuilder()
             )
+            
+            coordinator = newCoordinator
         }
 
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
-        }
-        
         addDependency(coordinator)
+        coordinator.start()
         
         return coordinator
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/PokeDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/PokeDeepLink.swift
@@ -18,12 +18,8 @@ public struct PokeDeepLink: DeepLinkExecutable {
     public func execute(with coordinator: Coordinator, queryItems: [URLQueryItem]?) -> Coordinator? {
         guard let coordinator = coordinator as? ApplicationCoordinator else { return nil }
         
-        let pokeCoordinator = coordinator.makePokeCoordinator()
+        coordinator.runPokeFlow()
         
-        if self.isDestination == true {
-            pokeCoordinator.showPokeMain(isRouteFromRoot: true)
-        }
-        
-        return pokeCoordinator
+        return coordinator
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- PokeMainCoordinator의 의존성 제거 방식을 변경했습니다.
- 온보딩  분기처리 로직 변경

🌱 작업한 브랜치
- feature/#635

## 🌱 PR Point
### 🌿 **콕찌르기 화면전환 플로우**
<img width="4221" height="1751" alt="image" src="https://github.com/user-attachments/assets/73c8cbdc-a7f3-48f2-b400-3f729db3db24" />

### 🌿  PokeMain의 온보딩 로직 제거
온보딩 분기처리 로직이 반복되어 수정했습니다.  

홈 뷰모델 내의 콕찌르기 분기처리 로직입니다.
```swift
case .appService(let model):
    if model.serviceName == "콕찌르기" {
        owner.useCase.checkPokeNewUser()
            .sink { isPokeNewUser in
                owner.onPoke?(isPokeNewUser)
             }.store(in: cancelBag)
         } else {
     owner.onAppServiceCellTapped?(model.deepLink)
}
```
그런데 PokeMain 뷰모델에서도 온보딩 노출 여부를 결정하는 로직이 있었습니다.
이 경우 HomeVC → PokeMainVC → PokeOnboardingVc로 온보딩을 띄우기 전 메인뷰를 로드하는 불필요한 과정이 존재하게 됩니다.

딥링크로 진입시에도 불필요한 로직이라고 판단되어 PokeMain에서 온보딩을 판단하는 로직을 모두 제거했습니다.

### 🌿 콕찌르기 딥링크 분기처리 제거
AppCoordinator에서 
- 콕찌르기 코디네이터를 생성만 하는 `makePokeCoordinator`와 
- 콕찌르기 로직을 실행하는 `runPokeFlow`  

두 개의 메소드가 존재했습니다.

makePokeCoordinator는 PokeDeepLink에서 사용 중이었고,
- 딥링크를 통한 콕찌르기 진입인지,
- 앱 내 화면전환인지

분기처리를 해주는 용도로 보입니다.

그러나 **현재 콕찌르기는 항상 딥링크로 이동**하고 있기 때문에 불필요한 분기처리라고 생각되어 `runPokeFlow`로 통합했습니다.

## 코디네이터 관련 프로토콜
현재 구조는 아래와 같습니다.
<img width="1753" height="1310" alt="image" src="https://github.com/user-attachments/assets/9febd57d-1d34-4a89-ae45-d559e4166b30" />
- 각 피처 코디네이터들이 BaseCoordinator를 상속
- 뷰모델은 AnyCoordinatorObject 프로토콜 타입으로 코디네이터를 소유하고 있는 구조

레거시 코디네이터와 혼용하여 쓸 수 있도록 만든 구조인데, **리팩토링 작업이 완료될 경우 BaseCoordinator 가 가지고 있는 속성 및 메소드가 불필요**해지기 때문에 **하나의 프로토콜로 통합**하면 좋을 것 같습니다.



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 온보딩 로직과 딥링크를 테스트한 후 PR을 올려야하는데, 현재 서버 로직 이상으로 인해 완전히 테스트해보지 못했습니다.
- 다음 배포 QA 때 콕찌르기 온보딩, 콕찌르기 알림, 콕찌르기 딥링크 테스트도 함께 진행하도록 하겠습니다.
- 혹시 dev에서 콕찌르기 한 번도 하지 않은 분이 있다면 온보딩이 잘 나오는지 확인 부탁드립니다.


## 📸 스크린샷

https://github.com/user-attachments/assets/617cd6f3-8c60-4e0f-be7d-ca44e25ccd25



## 📮 관련 이슈
- Resolved: #635
