### PR TITLE
[Refactor] #700 - PokeNotificationList의 코디네이터 의존성 제거 방식 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol LegacyPokeFeatureBuildable {
     func makePokeMain(isRouteFromRoot: Bool) -> LegacyPokeMainPresentable
@@ -16,7 +17,7 @@ public protocol LegacyPokeFeatureBuildable {
     func makePokeMyFriendsList(relation: PokeRelation) -> LegacyPokeMyFriendsListPresentable
     func makePokeOnboarding() -> LegacyPokeOnboardingPresentable
     func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable
-    func makePokeNotificationList() -> LegacyPokeNotificationPresentable
+    func makePokeNotificationList(coordinator: Coordinator) -> LegacyPokeNotificationPresentable
     func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable
     func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> LegacyPokeAnonymousFriendUpgradePresentable
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import Domain
+import BaseFeatureDependency
 
 public protocol PokeFeatureBuildable {
     func makePokeMain(isRouteFromRoot: Bool) -> PokeMainPresentable
@@ -16,7 +17,7 @@ public protocol PokeFeatureBuildable {
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
     func makePokeOnboarding() -> PokeOnboardingPresentable
     func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
-    func makePokeNotificationList() -> PokeNotificationPresentable
+    func makePokeNotificationList(coordinator: Coordinator) -> PokeNotificationPresentable
     func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable
     func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> PokeAnonymousFriendUpgradePresentable
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import PokeFeatureInterface
 
 public final class LegacyPokeBuilder {
@@ -51,9 +52,10 @@ extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeNotificationList() -> LegacyPokeNotificationPresentable {
+    public func makePokeNotificationList(coordinator: Coordinator) -> LegacyPokeNotificationPresentable {
         let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
-        let viewModel = PokeNotificationViewModel(usecase: usecase)
+        let viewModel = PokeNotificationViewModel(usecase: usecase,
+                                                  coordinator: coordinator)
         let viewController = PokeNotificationViewController(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeNotificationListCoordinator.swift
@@ -33,7 +33,7 @@ public final class LegacyPokeNotificationListCoordinator: DefaultCoordinator {
 
 extension LegacyPokeNotificationListCoordinator {
     private func showPokeNotificationListView() {
-        var pokeNotiListVC = self.factory.makePokeNotificationList()
+        var pokeNotiListVC = self.factory.makePokeNotificationList(coordinator: self)
                     
         pokeNotiListVC.vm.onPokeButtonTapped = { [weak self] userModel in
             guard let bottomSheet = self?.factory

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -8,6 +8,7 @@
 
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import PokeFeatureInterface
 
 public final class PokeBuilder {
@@ -60,9 +61,10 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeNotificationList() -> PokeFeatureInterface.PokeNotificationPresentable {
+    public func makePokeNotificationList(coordinator: Coordinator) -> PokeFeatureInterface.PokeNotificationPresentable {
         let usecase = DefaultPokeNotificationUsecase(repository: self.pokeNotificationListRepository)
-        let viewModel = PokeNotificationViewModel(usecase: usecase)
+        let viewModel = PokeNotificationViewModel(usecase: usecase,
+                                                  coordinator: coordinator)
         let viewController = PokeNotificationViewController(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -21,7 +21,7 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: PokeFeatureBuildable
-    private let navigationController: UINavigationController
+    private weak var navigationController: UINavigationController?
     private weak var rootController: UINavigationController?
     
     // MARK: - Init
@@ -43,7 +43,7 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
     // MARK: - Navigation
     
     private func showPokeNotificationListView() {
-        var pokeNotiListVC = factory.makePokeNotificationList()
+        var pokeNotiListVC = factory.makePokeNotificationList(coordinator: self)
         
         pokeNotiListVC.vm.onPokeButtonTapped = { [weak self] userModel in
             guard let bottomSheet = self?.factory
@@ -80,18 +80,18 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
             guard let url = URL(string: "\(ExternalURL.Playground.main)/members/\(userId)") else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.navigationController.pushViewController(webView, animated: true)
+            self?.navigationController?.pushViewController(webView, animated: true)
         }
         
         let navController = UINavigationController(rootViewController: pokeNotiListVC.vc)
         rootController = navController
         
         var willAnimate = true
-        if let top = navigationController.topViewController, type(of: top) == type(of: pokeNotiListVC.vc) {
+        if let top = navigationController?.topViewController, type(of: top) == type(of: pokeNotiListVC.vc) {
             willAnimate = false
-            navigationController.popViewController(animated: false)
+            navigationController?.popViewController(animated: false)
         }
         
-        navigationController.pushViewController(pokeNotiListVC.vc, animated: willAnimate)
+        navigationController?.pushViewController(pokeNotiListVC.vc, animated: willAnimate)
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
@@ -15,6 +15,24 @@ import BaseFeatureDependency
 import PokeFeatureInterface
 
 public final class PokeNotificationViewModel: PokeNotificationViewModelType {
+    
+    // MARK: - Trigger
+    
+    public var onNaviBackTapped: (() -> Void)?
+    public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
+    public var onNewFriendAdded: ((_ friendName: String) -> Void)?
+    public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
+    public var onProfileImageTapped: ((Int) -> Void)?
+    
+    // MARK: - Properties
+    
+    private let coordinator: AnyCoordinatorObject
+    private let usecase: PokeNotificationUsecase
+    private let cancelBag = CancelBag()
+    private let eventTracker = PokeEventTracker()
+    
+    // MARK: - Inputs
+    
     public struct Input {
         let viewDidLoaded: Driver<Void>
         let reachToBottom: Driver<Void>
@@ -22,23 +40,16 @@ public final class PokeNotificationViewModel: PokeNotificationViewModelType {
         let profileButtonTap: Driver<PokeUserModel>
     }
     
+    // MARK: - Outputs
+    
     public struct Output {
         let pokeToMeHistoryList = PassthroughSubject<[PokeUserModel], Never>()
         let pokedResult = PassthroughSubject<PokeUserModel, Never>()
     }
     
-    public var onNaviBackTapped: (() -> Void)?
-    public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
-    public var onNewFriendAdded: ((_ friendName: String) -> Void)?
-    public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
-    public var onProfileImageTapped: ((Int) -> Void)?
-
-    private let usecase: PokeNotificationUsecase
-    private let cancelBag = CancelBag()
-    private let eventTracker = PokeEventTracker()
-    
-    init(usecase: PokeNotificationUsecase) {
+    init(usecase: PokeNotificationUsecase, coordinator: Coordinator) {
         self.usecase = usecase
+        self.coordinator = coordinator
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -638,19 +638,19 @@ extension ApplicationCoordinator {
                 ),
                 factory: LegacyPokeBuilder()
             )
+            addDependency(coordinator)
+            coordinator.finishFlow = { [weak self, weak coordinator] in
+                coordinator?.childCoordinators = []
+                self?.removeDependency(coordinator)
+            }
         case .new:
             coordinator = PokeNotificationListCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: PokeBuilder()
             )
         }
-
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
-        }
         
-        addDependency(coordinator)
+        
         coordinator.start()
         
         return coordinator


### PR DESCRIPTION
## 🌴 PR 요약
- PokeNotificationListCoordinator의 의존성 관리 방식을 변경했습니다.

🌱 작업한 브랜치
- feature/#700

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- PokeMain -> PokeNotificationList 플로우와 알림을 통한 딥링크 로직 모두 확인했습니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/a698795b-6bd3-4e58-af1f-515ca688c8b5


## 📮 관련 이슈
- Resolved: #700
