### PR TITLE
[chore]#704 - 솦탬프 버튼 텍스트 36기 랭킹에서 개인별 랭킹으로 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -422,7 +422,7 @@ extension MissionListVC {
     }
     
     private func configureCurrentGenerationButton(with generation: String) {
-        let attributedStr = NSMutableAttributedString(string: "\(generation)기 랭킹")
+        let attributedStr = NSMutableAttributedString(string: "개인별 랭킹")
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitColors.Color.black, range: NSMakeRange(0, attributedStr.length))
         self.currentGenerationRankFloatingButton.setAttributedTitle(attributedStr, for: .normal)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -312,7 +312,7 @@ extension MissionListVC {
                 
                 self?.usersActiveGenerationStatus = generationStatus
                 self?.remakeButtonConstraint()
-                self?.configureCurrentGenerationButton(with: String(describing: generationStatus.currentGeneration))
+                self?.configurePersonalRankingButton()
             }.store(in: self.cancelBag)
         
         output.needNetworkAlert
@@ -421,7 +421,7 @@ extension MissionListVC {
         self.floatingButtonStackView.addArrangedSubviews(self.currentGenerationRankFloatingButton, self.partRankingFloatingButton)
     }
     
-    private func configureCurrentGenerationButton(with generation: String) {
+    private func configurePersonalRankingButton() {
         let attributedStr = NSMutableAttributedString(string: "개인별 랭킹")
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitColors.Color.black, range: NSMakeRange(0, attributedStr.length))


### PR DESCRIPTION
## 🌴 PR 요약
솦탬프 버튼 텍스트를 36기 랭킹에서 개인별 랭킹으로 변경했습니다

🌱 작업한 브랜치
- refactor/#704 - soptamp-ButtonLabel

## 🌱 PR Point
- 간단한 텍스트 변경이라 string 리소스로 따로 관리하진 않았습니다. 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- xcode를 업데이트 했더니 iOS26버전으로 동작하더라구요 그래서 아카이브와 배포는 아직 업데이트 안하신분이 해주셔야될것 같습니다! ㅠ(하단 탭바가 리퀴드 글라스로 변경되어있어요 ,,,)
<img width="200" height="2622" alt="image" src="https://github.com/user-attachments/assets/f5fae9a8-8f96-49cc-8f7f-f6a70fbc6233" />


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|텍스트 변경|<img width="300" height="2622" alt="image" src="https://github.com/user-attachments/assets/da39da1f-7bd7-4638-9c71-f32459388ef5" />|

## 📮 관련 이슈
- Resolved: #704 
