### PR TITLE
[Hotfix] #706 - isActive 값을 home의 fetchDashBoard에서 갱신하도록 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -327,6 +327,7 @@ extension HomeForMemberViewModel {
             history: user?.historyList ?? [],
             isAllConfirm: user?.isAllConfirm ?? false
         )
+        UserDefaultKeyList.Auth.isActiveUser = user?.userType == .active // 사용자 활동 중 여부 등록
         fetchedDashBoard = dashBoard
         return dashBoard
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/DashBoard/UserHistoryView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/DashBoard/UserHistoryView.swift
@@ -76,8 +76,9 @@ extension UserHistoryView {
 // MARK: - Methods
 
 extension UserHistoryView {
-    func setData(userType: UserType, recentHistory: Int?, allHistory: [Int]?) {
+    func setData(recentHistory: Int?, allHistory: [Int]?) {
         // 현재 활동 기수 여부 뷰 설정
+        let userType = UserDefaultKeyList.Auth.getUserType()
         let userTypeText = userType.makeDescription(recentHistory: recentHistory ?? 0)
         setUserTypeLabel(with: userType, text: userTypeText)
         guard userType != .visitor else { return }


### PR DESCRIPTION
## 🌴 PR 요약

인증중앙화 이후로, isActive 값을 갱신하는 로직이 누락되어 홈에서 활동 기수 여부가 잘못 노출되는 문제가 있었어요.
해당 문제에 대하여, 홈에서 호출하는 user/main의 isActive 필드에 의존하여 값이 갱신될 수 있도록 수정했어요.

🌱 작업한 브랜치
- #706 

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #706 
