### PR TITLE
[Chore] #708 - 제거하지 못한 userType 파라미터 제거

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DashBoard/DashBoardCardCVC.swift
@@ -90,14 +90,14 @@ extension DashBoardCardCVC {
             self.descriptionLabel.text = I18N.Home.DashBoard.UserHistory.encourage
             self.descriptionLabel.setLineSpacing(lineSpacing: 5)
             self.rightArrowWithCircleImageView.isHidden = true
-            userHistoryView.setData(userType: userType, recentHistory: nil, allHistory: nil)
+            userHistoryView.setData(recentHistory: nil, allHistory: nil)
         case .active, .inactive:
             guard let model else { return }
             self.descriptionLabel.attributedText = model.description
             self.descriptionLabel.modifyLineSpacing(lineSpacing: 5)
             self.rightArrowWithCircleImageView.isHidden = false
             guard let history = model.history else { return }
-            userHistoryView.setData(userType: userType, recentHistory: history.first, allHistory: history)
+            userHistoryView.setData(recentHistory: history.first, allHistory: history)
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
UserHistoryView.setData()를 호출할 때, userType 파라미터를 제거했어야 했는데 이전 pr에서 누락했네요..
이를 수정해서 반영합니다.

🌱 작업한 브랜치
- feature/#

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #708 
