### PR TITLE
[Fix]#711 간헐적으로 한마디 편집 버튼 활성화 안되는 이슈

### DIFF
--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
@@ -68,7 +68,6 @@ extension SentenceEditVC {
     private func bindViewModels() {
         let textViewTextChanged = NotificationCenter.default
             .publisher(for: UITextView.textDidChangeNotification, object: self.textView)
-            .dropFirst()
             .map { ($0.object as? UITextView)?.text }
             .compactMap { $0 }
             .eraseToAnyPublisher()


### PR DESCRIPTION
## 🌴 PR 요약
간헐적으로 한마디 편집 버튼 활성화 안되는 이슈 해결했습니다 ~
첫번째 이벤트를 무시하는 dropFirst()를 삭제해주었어요 

🌱 작업한 브랜치
- fix/#711

## 🌱 PR Point
수정이 적어서 머쓱하네요

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| |<img src = "https://github.com/user-attachments/assets/d50aebd9-2061-4999-9d5f-ecd45994f1e5" width ="250"> |
## 📮 관련 이슈
- Resolved: #711 
