### PR TITLE
[Fix] #710 - 콕찌르기 리스트: 스크롤 움직이면 프로필 사진 깜박이는 이슈

### DIFF
--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
@@ -203,7 +203,7 @@ public final class PokeProfileListView: UIView, PokeCompatible {
     }
     
     func clearProfileImage() {
-        self.profileImageView.clearProfileImage()
+        self.profileImageView.setPlaceholder()
     }
     
     @discardableResult

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
@@ -202,6 +202,10 @@ public final class PokeProfileListView: UIView, PokeCompatible {
         self.setData(with: newUserModel)
     }
     
+    func clearProfileImage() {
+        self.profileImageView.clearProfileImage()
+    }
+    
     @discardableResult
     func setButtonIsEnabled(to isEnabled: Bool) -> Self {
         self.kokButton.isEnabled = isEnabled

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
@@ -13,9 +13,9 @@ import Core
 import Domain
 
 public final class PokeProfileListView: UIView, PokeCompatible {
-
-  // MARK: - Properties
-
+    
+    // MARK: - Properties
+    
     lazy var kokButtonTap: Driver<PokeUserModel?> = kokButton.tap
         .withUnretained(self)
         .map{ owner, _ in owner.user}
@@ -28,208 +28,208 @@ public final class PokeProfileListView: UIView, PokeCompatible {
         .map({ owner, _ in
             owner.user
         }).asDriver()
-
-  var viewType: ProfileListType
-  var user: PokeUserModel?
-
-  // MARK: - UI Components
-
-  private let profileImageView = CustomProfileImageView()
-
-  private lazy var kokButton = PKokButton()
-
-  private let nameLabel: UILabel = {
-    let label = UILabel()
-    label.textColor = DSKitAsset.Colors.gray30.color
-    label.font = UIFont.MDS.heading7.font
-    return label
-  }()
-
-  private let partLabel: UILabel = {
-    let label = UILabel()
-    label.textColor = DSKitAsset.Colors.gray300.color
-    label.font = UIFont.MDS.label5.font
-    return label
-  }()
-
-  private let kokCountLabel: UILabel = {
-    let label = UILabel()
-    label.textColor = DSKitAsset.Colors.gray30.color
-    label.font = UIFont.MDS.heading7.font
-    return label
-  }()
-
-  private let dividerView: UIView = {
-    let view = UIView()
-    view.backgroundColor = DSKitAsset.Colors.gray800.color
-    view.isHidden = true
-    return view
-  }()
-
-  // MARK: - initialization
-
-  init(viewType: ProfileListType) {
-    self.viewType = viewType
-    super.init(frame: .zero)
-    self.setUI()
-    self.setLayout()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  // MARK: - UI & Layout
-
-  private func setUI() {
-    self.backgroundColor = .clear
-  }
-
-  private func setLayout() {
-    self.addSubviews(profileImageView, nameLabel, partLabel, kokCountLabel, kokButton, dividerView)
-
-    self.viewType == .main ? setLayoutWithMainType() : setLayoutWithDefaultType()
-  }
-
-  private func setLayoutWithMainType() {
-    self.snp.makeConstraints { make in
-      make.height.equalTo(44)
+    
+    var viewType: ProfileListType
+    var user: PokeUserModel?
+    
+    // MARK: - UI Components
+    
+    private let profileImageView = CustomProfileImageView()
+    
+    private lazy var kokButton = PKokButton()
+    
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = DSKitAsset.Colors.gray30.color
+        label.font = UIFont.MDS.heading7.font
+        return label
+    }()
+    
+    private let partLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = DSKitAsset.Colors.gray300.color
+        label.font = UIFont.MDS.label5.font
+        return label
+    }()
+    
+    private let kokCountLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = DSKitAsset.Colors.gray30.color
+        label.font = UIFont.MDS.heading7.font
+        return label
+    }()
+    
+    private let dividerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = DSKitAsset.Colors.gray800.color
+        view.isHidden = true
+        return view
+    }()
+    
+    // MARK: - initialization
+    
+    init(viewType: ProfileListType) {
+        self.viewType = viewType
+        super.init(frame: .zero)
+        self.setUI()
+        self.setLayout()
     }
-
-    profileImageView.snp.makeConstraints { make in
-      make.leading.equalToSuperview()
-      make.centerY.equalToSuperview()
-      make.width.equalTo(40)
-      make.height.equalTo(40)
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-
-    nameLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.equalTo(profileImageView.snp.trailing).offset(8)
+    
+    // MARK: - UI & Layout
+    
+    private func setUI() {
+        self.backgroundColor = .clear
     }
-
-    partLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.equalTo(nameLabel.snp.trailing).offset(4)
+    
+    private func setLayout() {
+        self.addSubviews(profileImageView, nameLabel, partLabel, kokCountLabel, kokButton, dividerView)
+        
+        self.viewType == .main ? setLayoutWithMainType() : setLayoutWithDefaultType()
     }
-
-    partLabel.snp.contentCompressionResistanceHorizontalPriority = 249
-
-    kokCountLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.greaterThanOrEqualTo(partLabel.snp.trailing).offset(8)
-      make.trailing.equalTo(kokButton.snp.leading).offset(-12)
+    
+    private func setLayoutWithMainType() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(44)
+        }
+        
+        profileImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.centerY.equalToSuperview()
+            make.width.equalTo(40)
+            make.height.equalTo(40)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(profileImageView.snp.trailing).offset(8)
+        }
+        
+        partLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(nameLabel.snp.trailing).offset(4)
+        }
+        
+        partLabel.snp.contentCompressionResistanceHorizontalPriority = 249
+        
+        kokCountLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.greaterThanOrEqualTo(partLabel.snp.trailing).offset(8)
+            make.trailing.equalTo(kokButton.snp.leading).offset(-12)
+        }
+        
+        kokCountLabel.snp.contentCompressionResistanceHorizontalPriority = 1000
+        
+        kokButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview()
+        }
+        
+        dividerView.snp.makeConstraints { make in
+            make.leading.bottom.trailing.equalToSuperview()
+            make.height.equalTo(1)
+        }
     }
-
-    kokCountLabel.snp.contentCompressionResistanceHorizontalPriority = 1000
-
-    kokButton.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.trailing.equalToSuperview()
+    
+    private func setLayoutWithDefaultType() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(70)
+        }
+        
+        profileImageView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().inset(20)
+            make.width.equalTo(50)
+            make.height.equalTo(50)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(profileImageView.snp.trailing).offset(10)
+        }
+        
+        partLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(nameLabel.snp.trailing).offset(8)
+        }
+        
+        partLabel.snp.contentCompressionResistanceHorizontalPriority = 249
+        
+        kokCountLabel.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.greaterThanOrEqualTo(partLabel.snp.trailing).offset(8)
+            make.trailing.equalTo(kokButton.snp.leading).offset(-14)
+        }
+        
+        kokCountLabel.snp.contentCompressionResistanceHorizontalPriority = 1000
+        
+        kokButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().inset(20)
+        }
+        
+        dividerView.snp.makeConstraints { make in
+            make.leading.bottom.trailing.equalToSuperview()
+            make.height.equalTo(1)
+        }
     }
-
-    dividerView.snp.makeConstraints { make in
-      make.leading.bottom.trailing.equalToSuperview()
-      make.height.equalTo(1)
+    
+    // MARK: - Methods
+    
+    func setData(with model: PokeUserModel) {
+        self.user = model
+        self.profileImageView.setImage(
+            with: model.isAnonymous ? model.anonymousImage : model.profileImage,
+            relation: model.pokeRelation
+        )
+        self.partLabel.text = "\(model.generation)기 \(model.part)"
+        self.kokCountLabel.text = "\(model.pokeNum)콕"
+        self.kokButton.isEnabled = !model.isAlreadyPoke
+        self.partLabel.isHidden = model.isAnonymous
+        if model.isAnonymous {
+            self.nameLabel.text = model.anonymousName
+            return
+        }
+        self.nameLabel.text = model.name
     }
-  }
-
-  private func setLayoutWithDefaultType() {
-    self.snp.makeConstraints { make in
-      make.height.equalTo(70)
+    
+    func changeUIAfterPoke(newUserModel: PokeUserModel) {
+        guard let user, user.userId == newUserModel.userId else { return }
+        
+        self.setData(with: newUserModel)
     }
-
-    profileImageView.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.equalToSuperview().inset(20)
-      make.width.equalTo(50)
-      make.height.equalTo(50)
+    
+    @discardableResult
+    func setButtonIsEnabled(to isEnabled: Bool) -> Self {
+        self.kokButton.isEnabled = isEnabled
+        return self
     }
-
-    nameLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.equalTo(profileImageView.snp.trailing).offset(10)
+    
+    @discardableResult
+    func setBackgroundColor(with color: UIColor) -> Self {
+        self.backgroundColor = color
+        return self
     }
-
-    partLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.equalTo(nameLabel.snp.trailing).offset(8)
+    
+    @discardableResult
+    func setDividerViewIsHidden(to isHidden: Bool) -> Self {
+        self.dividerView.isHidden = isHidden
+        return self
     }
-
-    partLabel.snp.contentCompressionResistanceHorizontalPriority = 249
-
-    kokCountLabel.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.leading.greaterThanOrEqualTo(partLabel.snp.trailing).offset(8)
-      make.trailing.equalTo(kokButton.snp.leading).offset(-14)
+    
+    @discardableResult
+    func setDividerViewColor(with color: UIColor) -> Self {
+        self.dividerView.backgroundColor = color
+        return self
     }
-
-    kokCountLabel.snp.contentCompressionResistanceHorizontalPriority = 1000
-
-    kokButton.snp.makeConstraints { make in
-      make.centerY.equalToSuperview()
-      make.trailing.equalToSuperview().inset(20)
-    }
-
-    dividerView.snp.makeConstraints { make in
-      make.leading.bottom.trailing.equalToSuperview()
-      make.height.equalTo(1)
-    }
-  }
-
-  // MARK: - Methods
-
-  func setData(with model: PokeUserModel) {
-    self.user = model
-    self.profileImageView.setImage(
-      with: model.isAnonymous ? model.anonymousImage : model.profileImage,
-      relation: model.pokeRelation
-    )
-    self.partLabel.text = "\(model.generation)기 \(model.part)"
-    self.kokCountLabel.text = "\(model.pokeNum)콕"
-    self.kokButton.isEnabled = !model.isAlreadyPoke
-    self.partLabel.isHidden = model.isAnonymous
-    if model.isAnonymous {
-      self.nameLabel.text = model.anonymousName
-      return
-    }
-    self.nameLabel.text = model.name
-  }
-
-  func changeUIAfterPoke(newUserModel: PokeUserModel) {
-    guard let user, user.userId == newUserModel.userId else { return }
-
-    self.setData(with: newUserModel)
-  }
-
-  @discardableResult
-  func setButtonIsEnabled(to isEnabled: Bool) -> Self {
-    self.kokButton.isEnabled = isEnabled
-    return self
-  }
-
-  @discardableResult
-  func setBackgroundColor(with color: UIColor) -> Self {
-    self.backgroundColor = color
-    return self
-  }
-
-  @discardableResult
-  func setDividerViewIsHidden(to isHidden: Bool) -> Self {
-    self.dividerView.isHidden = isHidden
-    return self
-  }
-
-  @discardableResult
-  func setDividerViewColor(with color: UIColor) -> Self {
-    self.dividerView.backgroundColor = color
-    return self
-  }
 }
 
 extension PokeProfileListView {
-  enum ProfileListType {
-    case main
-    case `default`
-  }
+    enum ProfileListType {
+        case main
+        case `default`
+    }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/Cell/PokeMyFriendsListTVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsListScene/Cell/PokeMyFriendsListTVC.swift
@@ -65,5 +65,6 @@ extension PokeMyFriendsListTVC {
     
     override func prepareForReuse() {
         self.cancelBag.cancel()
+        self.profileListView.clearProfileImage()
     }
 }

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
@@ -46,10 +46,6 @@ public final class CustomProfileImageView: UIImageView {
         self.image = DSKitAsset.Assets.iconDefaultProfile.image
     }
     
-    public func clearProfileImage() {
-        self.image = DSKitAsset.Assets.iconDefaultProfile.image
-    }
-    
     @discardableResult
     public func hideBorder() -> Self {
         self.layer.borderWidth = 0

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/CustomProfileImageView.swift
@@ -46,6 +46,10 @@ public final class CustomProfileImageView: UIImageView {
         self.image = DSKitAsset.Assets.iconDefaultProfile.image
     }
     
+    public func clearProfileImage() {
+        self.image = DSKitAsset.Assets.iconDefaultProfile.image
+    }
+    
     @discardableResult
     public func hideBorder() -> Self {
         self.layer.borderWidth = 0


### PR DESCRIPTION
## 🌴 PR 요약

- 콕찌르기 리스트: 스크롤 움직이면 프로필 사진 깜박이는 이슈

🌱 작업한 브랜치
- #710 

## 🌱 PR Point

- prepareForReuse에서 profileImageView의 image를 default 처리하도록 추가했어요.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #710 
