### PR TITLE
[Refactor] #622 - AuthFlow에서의 Router 의존성 제거

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
@@ -58,4 +58,50 @@ public enum ViewControllerUtils {
             })
         }
     }
+    
+    /// 기존 navigationController 유지, snapshot으로 화면전환
+    public
+    static func setRootNavigationController(window: UIWindow, navigationController: UINavigationController, withAnimation: Bool) {
+        if !withAnimation {
+            window.rootViewController = navigationController
+            window.makeKeyAndVisible()
+            return
+        }
+
+        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
+            navigationController.view.addSubview(snapshot)
+            window.rootViewController = navigationController
+            window.makeKeyAndVisible()
+            
+            UIView.animate(withDuration: 0.4, animations: {
+                snapshot.layer.opacity = 0
+            }, completion: { _ in
+                snapshot.removeFromSuperview()
+            })
+        }
+    }
+    
+    /// 기존 navigationController 유지, snapshot으로 화면전환 및 완료 핸들러 필요할 때 사용
+    public
+    static func setRootNavigationController(window: UIWindow, navigationController: UINavigationController, withAnimation: Bool, completion: @escaping ((UIWindow) -> Void)) {
+        if !withAnimation {
+            window.rootViewController = navigationController
+            window.makeKeyAndVisible()
+            completion(window)
+            return
+        }
+
+        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
+            navigationController.view.addSubview(snapshot)
+            window.rootViewController = navigationController
+            window.makeKeyAndVisible()
+            completion(window)
+            
+            UIView.animate(withDuration: 0.4, animations: {
+                snapshot.layer.opacity = 0
+            }, completion: { _ in
+                snapshot.removeFromSuperview()
+            })
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
@@ -25,6 +25,7 @@ public enum ViewControllerUtils {
         if !withAnimation {
             window.rootViewController = viewController
             window.makeKeyAndVisible()
+            completion?(window)
             return
         }
 
@@ -52,6 +53,7 @@ public enum ViewControllerUtils {
         if !withAnimation {
             window.rootViewController = navigationController
             window.makeKeyAndVisible()
+            completion?(window)
             return
         }
 

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
@@ -29,12 +29,11 @@ public enum ViewControllerUtils {
             return
         }
 
-        if let snapshot = window.snapshotView(afterScreenUpdates: true),
-           let completion = completion {
+        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
             viewController.view.addSubview(snapshot)
             window.rootViewController = viewController
             window.makeKeyAndVisible()
-            completion(window)
+            completion?(window)
             
             UIView.animate(withDuration: 0.4, animations: {
                 snapshot.layer.opacity = 0
@@ -57,12 +56,11 @@ public enum ViewControllerUtils {
             return
         }
 
-        if let snapshot = window.snapshotView(afterScreenUpdates: true),
-           let completion = completion {
+        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
             navigationController.view.addSubview(snapshot)
             window.rootViewController = navigationController
             window.makeKeyAndVisible()
-            completion(window)
+            completion?(window)
             
             UIView.animate(withDuration: 0.4, animations: {
                 snapshot.layer.opacity = 0

--- a/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/setRootViewController.swift
@@ -16,36 +16,20 @@ import UIKit
           
 */
 public enum ViewControllerUtils {
+    /// viewController를 윈도우의 rootVC로 지정, snapshot으로 화면전환 시 사용
     public
-    static func setRootViewController(window: UIWindow, viewController: UIViewController, withAnimation: Bool) {
+    static func setRootViewController(window: UIWindow,
+                                      viewController: UIViewController,
+                                      withAnimation: Bool,
+                                      completion: ((UIWindow) -> Void)? = nil) {
         if !withAnimation {
             window.rootViewController = viewController
             window.makeKeyAndVisible()
             return
         }
 
-        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
-            viewController.view.addSubview(snapshot)
-            window.rootViewController = viewController
-            window.makeKeyAndVisible()
-            
-            UIView.animate(withDuration: 0.4, animations: {
-                snapshot.layer.opacity = 0
-            }, completion: { _ in
-                snapshot.removeFromSuperview()
-            })
-        }
-    }
-    
-    public
-    static func setRootViewController(window: UIWindow, viewController: UIViewController, withAnimation: Bool, completion: @escaping ((UIWindow) -> Void)) {
-        if !withAnimation {
-            window.rootViewController = viewController
-            window.makeKeyAndVisible()
-            return
-        }
-
-        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
+        if let snapshot = window.snapshotView(afterScreenUpdates: true),
+           let completion = completion {
             viewController.view.addSubview(snapshot)
             window.rootViewController = viewController
             window.makeKeyAndVisible()
@@ -59,39 +43,20 @@ public enum ViewControllerUtils {
         }
     }
     
-    /// 기존 navigationController 유지, snapshot으로 화면전환
+    /// 기존 navigationController 유지, snapshot으로 화면전환 시 사용
     public
-    static func setRootNavigationController(window: UIWindow, navigationController: UINavigationController, withAnimation: Bool) {
+    static func setRootNavigationController(window: UIWindow,
+                                            navigationController: UINavigationController,
+                                            withAnimation: Bool,
+                                            completion: ((UIWindow) -> Void)? = nil) {
         if !withAnimation {
             window.rootViewController = navigationController
             window.makeKeyAndVisible()
             return
         }
 
-        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
-            navigationController.view.addSubview(snapshot)
-            window.rootViewController = navigationController
-            window.makeKeyAndVisible()
-            
-            UIView.animate(withDuration: 0.4, animations: {
-                snapshot.layer.opacity = 0
-            }, completion: { _ in
-                snapshot.removeFromSuperview()
-            })
-        }
-    }
-    
-    /// 기존 navigationController 유지, snapshot으로 화면전환 및 완료 핸들러 필요할 때 사용
-    public
-    static func setRootNavigationController(window: UIWindow, navigationController: UINavigationController, withAnimation: Bool, completion: @escaping ((UIWindow) -> Void)) {
-        if !withAnimation {
-            window.rootViewController = navigationController
-            window.makeKeyAndVisible()
-            completion(window)
-            return
-        }
-
-        if let snapshot = window.snapshotView(afterScreenUpdates: true) {
+        if let snapshot = window.snapshotView(afterScreenUpdates: true),
+           let completion = completion {
             navigationController.view.addSubview(snapshot)
             window.rootViewController = navigationController
             window.makeKeyAndVisible()

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/ChangeSocialAccountPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/ChangeSocialAccountPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -18,4 +20,4 @@ public protocol ChangeSocialAccountRoutingTrigger {
 
 public typealias ChangeSocialAccountViewModelType = ViewModelType & ChangeSocialAccountRoutingTrigger
 
-public typealias ChangeSocialAccountPresentable = (vc: ChangeSocialAccountViewControllable, vm: any ChangeSocialAccountViewModelType)
+public typealias ChangeSocialAccountPresentable = (vc: UIViewController, vm: any ChangeSocialAccountViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SearchSocialAccountPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SearchSocialAccountPresentable.swift
@@ -6,16 +6,18 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
 
 public protocol SearchSocialAccountViewControllable: LegacyViewControllable { }
 
-public protocol SearchSocialAccountCoordinatable {
+public protocol SearchSocialAccountRoutingTrigger {
     var searchSocialAccountSucceed: ((OAuthProvider) -> Void)? { get set }
 }
 
-public typealias SearchSocialAccountViewModelType = ViewModelType & SearchSocialAccountCoordinatable
+public typealias SearchSocialAccountViewModelType = ViewModelType & SearchSocialAccountRoutingTrigger
 
-public typealias SearchSocialAccountPresentable = (vc: SearchSocialAccountViewControllable, vm: any SearchSocialAccountViewModelType)
+public typealias SearchSocialAccountPresentable = (vc: UIViewController, vm: any SearchSocialAccountViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignInPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import Foundation
 import BaseFeatureDependency
 import Core
@@ -22,4 +24,4 @@ public protocol SignInRoutingTrigger {
 
 public typealias SignInViewModelType = ViewModelType & SignInRoutingTrigger
 
-public typealias SignInPresentable = (vc: SignInViewControllable, vm: any SignInViewModelType)
+public typealias SignInPresentable = (vc: UIViewController, vm: any SignInViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignUpPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/SignUpPresentable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2024 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import BaseFeatureDependency
 import Core
 import Domain
@@ -21,4 +23,4 @@ public typealias PhoneVerifyViewModelType = ViewModelType
 
 public typealias SignUpViewModelType = ViewModelType & SignUpRoutingTrigger
 
-public typealias SignUpPresentable = (vc: SignUpViewControllable, vm: any SignUpViewModelType)
+public typealias SignUpPresentable = (vc: UIViewController, vm: any SignUpViewModelType)

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
@@ -12,7 +12,7 @@ import Domain
 @_exported import AuthFeatureInterface
 import BaseFeatureDependency
 
-public final class AuthBuilder: AuthFeatureViewBuildable {
+public final class AuthBuilder {
     
     @Injected public var repository: SignInRepositoryInterface
     @Injected public var oauthRepository: CoreOAuthRepositoryInterface
@@ -21,7 +21,9 @@ public final class AuthBuilder: AuthFeatureViewBuildable {
     @Injected public var tokenRepository: AuthTokensRepositoryInterface
     
     public init() { }
+}
     
+extension AuthBuilder: AuthFeatureViewBuildable {
     public func makeSignIn() -> SignInPresentable {
         let useCase = DefaultSignInUseCase(
             repository: repository,
@@ -84,5 +86,4 @@ public final class AuthBuilder: AuthFeatureViewBuildable {
         let vc = SearchSocialAccountVC(viewModel: vm, phoneVerifyViewModel: phoneVM)
         return (vc, vm)
     }
-    
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import UIKit
 import BaseFeatureDependency
 import AuthFeatureInterface
 import Core
@@ -19,16 +20,16 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
     public var finishFlow: ((UserType) -> Void)?
 
     private let factory: AuthFeatureViewBuildable
-    private let router: LegacyRouter
+    private let navigationController: UINavigationController
     private var url: String?
 
     public init(
-        router: LegacyRouter,
+        navigationController: UINavigationController,
         factory: AuthFeatureViewBuildable,
         url: String? = nil
     ) {
+        self.navigationController = navigationController
         self.factory = factory
-        self.router = router
         self.url = url
     }
 
@@ -60,38 +61,43 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
         
         switch style {
         case .modal:
-            router.present(
-                signIn.vc,
-                animated: false,
-                modalPresentationSytle: .fullScreen,
-                modalTransitionStyle: .crossDissolve
-            )
+            signIn.vc.modalPresentationStyle = .fullScreen
+            signIn.vc.modalTransitionStyle = .crossDissolve
+            navigationController.present(signIn.vc, animated: false)
         case .root:
-            router.replaceRootWindow(signIn.vc, withAnimation: false)
-            router.hideTitles()
+            self.navigationController.isNavigationBarHidden = true
+            self.navigationController.setViewControllers([signIn.vc], animated: false)
+            ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
+                                                            navigationController: self.navigationController,
+                                                            withAnimation: false)
         case .rootWindow(let animated, let message):
+            self.navigationController.isNavigationBarHidden = true
+            self.navigationController.setViewControllers([signIn.vc], animated: false)
+            
             guard !animated else {
-                router.replaceRootWindow(signIn.vc, withAnimation: true)
-                router.hideTitles()
+                ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
+                                                                navigationController: self.navigationController,
+                                                                withAnimation: true)
                 return
             }
 
             guard let message else {
-                router.replaceRootWindow(signIn.vc, withAnimation: true)
-                router.hideTitles()
+                ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
+                                                          navigationController: self.navigationController,
+                                                          withAnimation: true)
                 return
             }
 
-            router.replaceRootWindow(signIn.vc, withAnimation: true) { newWindow in
+            ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
+                                                      navigationController: self.navigationController,
+                                                      withAnimation: true) { newWindow in
                 Toast.show(
                     message: message,
                     view: newWindow
                 )
             }
-            router.hideTitles()
         case .push: break
         }
-        
     }
 }
 
@@ -99,54 +105,54 @@ extension AuthCoordinator {
     private func runUserNotFoundFlow() {
         var userNotFoundVC = self.factory.makeUserNotFound()
         userNotFoundVC.onLoginRetryButtonTapped = { [weak self] in
-            self?.router.popToRootModule(animated: true)
+            self?.navigationController.popToRootViewController(animated: true)
         }
         
         userNotFoundVC.onLoginHelpButtonTapped = { [weak self] in
-            self?.showLoginHelpBottomSheet(on: userNotFoundVC)
+            self?.showLoginHelpBottomSheet(on: userNotFoundVC.viewController)
         }
         
-        self.router.push(userNotFoundVC)
+        self.navigationController.pushViewController(userNotFoundVC.viewController, animated: true)
     }
     
     private func runSignUpFlow() {
         var signUpVC = self.factory.makeSignUp()
         
         signUpVC.vm.onSignUpSuccess = { [weak self] in
-            self?.router.popToRootModule(animated: true)
+            self?.navigationController.popToRootViewController(animated: true)
         }
         
         signUpVC.vm.onLoginHelpButtonTapped = { [weak self] in
             guard let url = URL(string: ExternalURL.SOPT.memberVerifyGoogleForm) else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.router.asNavigationController.pushViewController(webView, animated: true)
+            self?.navigationController.pushViewController(webView, animated: true)
         }
         
-        self.router.push(signUpVC.vc)
+        self.navigationController.pushViewController(signUpVC.vc, animated: true)
     }
     
     private func runChangeSocialFlow() {
         var changeSocialAccount = self.factory.makeChangeSocialAccount()
         
         changeSocialAccount.vm.changeSocialAccountSucceed = { [weak self] in
-            self?.router.popToRootModule(animated: true)
+            self?.navigationController.popToRootViewController(animated: true)
         }
         
-        self.router.push(changeSocialAccount.vc)
+        self.navigationController.pushViewController(changeSocialAccount.vc, animated: true)
     }
     
     private func runSearchSocialFlow() {
         var searchSocialAccount = self.factory.makeSearchSocialAccount()
         
         searchSocialAccount.vm.searchSocialAccountSucceed = { [weak self] _ in
-            self?.router.popToRootModule(animated: true)
+            self?.navigationController.popToRootViewController(animated: true)
         }
         
-        self.router.push(searchSocialAccount.vc)
+        self.navigationController.pushViewController(searchSocialAccount.vc, animated: true)
     }
     
-    private func showLoginHelpBottomSheet(on vc: LegacyViewControllable) {
+    private func showLoginHelpBottomSheet(on vc: UIViewController) {
         guard let bottomSheetVC = self.factory.makeLoginHelpBottomSheet().viewController as? LoginHelpBottomSheetVC
         else { return Void() }
         
@@ -171,11 +177,7 @@ extension AuthCoordinator {
                 prefersGrabberVisible: false)
         )
         
-        self.router.showBottomSheet(
-            manager: bottomSheetManager,
-            toPresent: bottomSheetVC,
-            on: vc.viewController
-        )
+        bottomSheetManager.present(toPresent: bottomSheetVC, on: vc)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -68,7 +68,9 @@ public final class ApplicationCoordinator: BaseCoordinator {
                 case .legacy:
                     return LegacyAuthCoordinator(router: self.router, factory: LegacyAuthBuilder(), url: option?.url)
                 case .new:
-                    return AuthCoordinator(router: self.router, factory: AuthBuilder(), url: option?.url)
+                    return AuthCoordinator(navigationController: self.rootNavigationController,
+                                           factory: AuthBuilder(),
+                                           url: option?.url)
                 }
             }
         )
@@ -526,7 +528,7 @@ extension ApplicationCoordinator {
         
         switch Config.coordinatorFlag {
         case .legacy:
-            var legacyStampCoordinator = LegacyStampCoordinator(
+            let legacyStampCoordinator = LegacyStampCoordinator(
                 router: LegacyRouter(
                     rootController: UIWindow.getRootNavigationController
                 ),


### PR DESCRIPTION
## 🌴 PR 요약
- AuthFlow에서의 Router 의존성을 제거했습니다.

🌱 작업한 브랜치
- feature/#622

## 🌱 PR Point
### setRootNavigationController 메소드 추가
Splash플로우에서 인증화면으로 전환 시 윈도우의 rootVC를 변경해주어야 하는데요,
기존의 `setRootViewController` 메소드는 NVC로 감싸지 않기 때문에 AuthVC 이후 화면전환 로직이 실행되지 않는 문제가 발생했습니다.

인증 플로우의 화면전환을 가능하게 하려면 두 가지 방법을 시도할 수 있었습니다.


**🌵 1. 새로운 NavigationController 사용**
```
let VC = UINavigationController(rootViewController: vc)
window.rootViewController = navigationController
window.makeKeyAndVisible()
```
이 방식은 AuthCoordinator가 AppCoordinator로부터 주입받은 NVC를 사용하지 않습니다.
따라서 **새로 생성된 UINavigationController 인스턴스를 별도로 저장해 관리해야 합니다.**

이 로직을 메서드로 분리하는 경우, **화면 전환 메서드가 NVC 인스턴스를 반환해야 하는 문제**가 생겼습니다.
분리하지 않는 경우, AuthFlow 진입 방식(모달, 루트 등)에 따라 새 인스턴스를 생성하는 코드가 중복되었습니다.

<br>

**🌵 2. SplashVC를 띄운 navigationController를 그대로 사용**
따라서 새로운 NavigationController를 생성하지 않고,
`setViewControllers(_:animated:)` 메서드를 활용해 주입받은 NVC를 그대로 재사용했습니다.

이 방법은 구조적으로 단순하지만, 자연스러운 화면 전환 애니메이션이 제공되지 않는 단점이 있습니다.
이를 보완하기 위해 **setRootNavigationController**라는 메서드를 분리하여 스냅샷 기반 전환을 구현했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 홈 플로우 메모리 누수
| 비회원 | 회원 |
| :--: | :--: |
| <img height="600" alt="스크린샷 2025-10-07 오전 4 02 00" src="https://github.com/user-attachments/assets/d19e5618-5b56-4f1b-b93b-c4d71077c189" /> | <img height="600" alt="스크린샷 2025-10-07 오전 4 06 08" src="https://github.com/user-attachments/assets/cd967040-c7e1-41b4-89bb-5fbfdfca8aea" /> |

-`로그인뷰 → 홈화면 진입 → 마이페이지 → 로그아웃(비회원일 경우 로그인) → 로그인뷰`로 전환 시 HomeVC에서 메모리 누수가 발생하고 있습니다. 
- 처음 Auth 플로우를 진행하고 그 이후로 홈 화면, 인증 로직이 하나씩 추가되기 때문에 인증 로직과 관련된 인스턴스가 항상 1개 더 많이 생기게 됩니다.
- 이번 PR과 관련있는 부분은 아니라 #715 에서 리팩토링 진행하겠습니다!



### QA
회원탈퇴 API가 되지 않는 상황이기 때문에 회원가입 로직 화면 전환은 끝까지 테스트해보지 못했습니다. 다음에 플랫폼 팀에게 말해서 같이 QA해요~

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #622
