### PR TITLE
[Refactor] #715 - 메모리 누수 60MB → 44MB로 안정화 & 솝트로그 인증 로직 변경

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/Combine+UIKit/Publisher+UIGesture.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/Combine+UIKit/Publisher+UIGesture.swift
@@ -35,6 +35,7 @@ final class GestureSubscription<S: Subscriber>: Subscription where S.Input == Ge
     private var subscriber: S?
     private var gestureType: GestureType
     private weak var view: UIView?
+    private var gesture: UIGestureRecognizer?
     
     init(subscriber: S, view: UIView?, gestureType: GestureType) {
         self.subscriber = subscriber
@@ -47,12 +48,25 @@ final class GestureSubscription<S: Subscriber>: Subscription where S.Input == Ge
         let gesture = gestureType.get()
         gesture.addTarget(self, action: #selector(self.handler))
         self.view?.addGestureRecognizer(gesture)
+        self.gesture = gesture
     }
     
     func request(_ demand: Subscribers.Demand) { }
     
     func cancel() {
+        removeGesture()
         self.subscriber = nil
+    }
+    
+    deinit {
+        removeGesture()
+    }
+    
+    private func removeGesture() {
+        guard let gesture = self.gesture else { return }
+        gesture.removeTarget(self, action: #selector(self.handler))
+        self.view?.removeGestureRecognizer(gesture)
+        self.gesture = nil
     }
     
     @objc

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/UserNotFoundBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/UserNotFoundBuildable.swift
@@ -8,9 +8,10 @@
 
 import Foundation
 
+import UIKit
 import BaseFeatureDependency
 
-public protocol UserNotFoundViewControllable: LegacyViewControllable {
+public protocol UserNotFoundViewControllable: UIViewController {
     var onLoginHelpButtonTapped: (() -> Void)? { get set }
     var onLoginRetryButtonTapped: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -104,7 +104,7 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
 
 extension AuthCoordinator {
     private func runUserNotFoundFlow() {
-        var userNotFoundVC = self.factory.makeUserNotFound()
+        let userNotFoundVC = self.factory.makeUserNotFound()
         userNotFoundVC.onLoginRetryButtonTapped = { [weak self] in
             self?.navigationController.popToRootViewController(animated: true)
         }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -43,8 +43,9 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
             self?.finishFlow?(userType)
         }
         
-        signIn.vm.onLoginHelpButtonTapped = { [weak self] in
-            self?.showLoginHelpBottomSheet(on: signIn.vc)
+        signIn.vm.onLoginHelpButtonTapped = { [weak self, weak viewController = signIn.vc] in
+            guard let viewController else { return }
+            self?.showLoginHelpBottomSheet(on: viewController)
         }
         
         signIn.vm.onVisitorButtonTapped = { [weak self] in
@@ -108,8 +109,9 @@ extension AuthCoordinator {
             self?.navigationController.popToRootViewController(animated: true)
         }
         
-        userNotFoundVC.onLoginHelpButtonTapped = { [weak self] in
-            self?.showLoginHelpBottomSheet(on: userNotFoundVC.viewController)
+        userNotFoundVC.onLoginHelpButtonTapped = { [weak self, weak viewController = userNotFoundVC.viewController] in
+            guard let viewController else { return }
+            self?.showLoginHelpBottomSheet(on: viewController)
         }
         
         self.navigationController.pushViewController(userNotFoundVC.viewController, animated: true)

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Foundation/CoordinatorFlag.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Foundation/CoordinatorFlag.swift
@@ -20,9 +20,9 @@ public enum CoordinatorFlag {
 extension Config {
     public static let coordinatorFlag: CoordinatorFlag = {
         #if DEV || PROD
-        return .legacy
+        return .new
         #else
-        return .legacy
+        return .new
         #endif
     }()
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/CalendarDetailScene/VC/HomeCalendarDetailVC.swift
@@ -90,11 +90,6 @@ final class HomeCalendarDetailVC: UIViewController, HomeCalendarDetailViewContro
         super.viewWillAppear(animated)
         self.setGestureDelegate()
     }
-    
-    deinit {
-        collectionView.dataSource = nil
-        collectionView.delegate = nil
-    }
 }
 
 // MARK: - UI & Layout

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -86,6 +86,7 @@ final class CalendarCardCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.cancelBag.cancel()
         self.cancelBag = CancelBag()
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/DefaultPost/DefaultPostCVC.swift
@@ -157,6 +157,7 @@ final class DefaultPostCVC: UICollectionViewCell {
         model = nil
         profileImageView.setPlaceholder()
         updateVisibility(for: .latest) // visible 상태는 기본적으로 latest와 같음
+        self.cancelBag.cancel()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/RecentPost/LatestPostFooterView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/RecentPost/LatestPostFooterView.swift
@@ -46,6 +46,7 @@ final class LatestPostFooterView: UICollectionReusableView {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        cancelBag.cancel()
         cancelBag = CancelBag()
         bind()
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Survey/SurveyCVC.swift
@@ -50,6 +50,7 @@ final class SurveyCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.cancelBag.cancel()
         self.cancelBag = CancelBag()
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
@@ -28,27 +28,27 @@ extension HomeForMemberVC {
     }
     
     func createLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout { sectionIndex, env in
+        return UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
             guard let sectionKind = HomeForMemberSectionLayoutKind(rawValue: sectionIndex)
-            else { return self.createEmptySection() }
+            else { return self?.createEmptySection() }
             
             switch sectionKind {
             case .dashBoard:
-                return self.createDashBoardSection()
+                return self?.createDashBoardSection()
             case .calendar:
-                return self.createCalendarSection()
+                return self?.createCalendarSection()
             case .mainProduct:
-                return self.createMainProductSection()
+                return self?.createMainProductSection()
             case .appService:
-                return self.createAppServiceSection()
+                return self?.createAppServiceSection()
             case .popularPosts:
-                return self.createPopularPostsSection()
+                return self?.createPopularPostsSection()
             case .socialLinks:
-                return self.createSocialLinksSection()
+                return self?.createSocialLinksSection()
             case .survey:
-                return self.createSurveySection()
+                return self?.createSurveySection()
             case .latestPosts:
-                return self.createLatestPostsSection()
+                return self?.createLatestPostsSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForVisitorCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForVisitorCompositionalLayout.swift
@@ -24,16 +24,16 @@ extension HomeForVisitorVC {
     }
     
     func createLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout { sectionIndex, env in
-            guard let sectionKind = HomeForVisitorSectionLayoutKind(rawValue: sectionIndex) else { return self.createEmptySection() }
+        return UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
+            guard let sectionKind = HomeForVisitorSectionLayoutKind(rawValue: sectionIndex) else { return self?.createEmptySection() }
             
             switch sectionKind {
             case .dashBoard:
-                return self.createDashBoardSection()
+                return self?.createDashBoardSection()
             case .mainProduct:
-                return self.createMainProductSection()
+                return self?.createMainProductSection()
             case .appService:
-                return self.createAppServiceSection()
+                return self?.createAppServiceSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -24,8 +24,6 @@ extension HomeForMemberVC {
             guard let self else { return }
             cell.configureCell(model: item, userType: self.viewModel.userType)
             
-            cell.cancelBag.cancel() // 이전 구독 해제
-            
             cell.attendanceButtonTap
                 .withUnretained(self)
                 .sink { owner, _ in
@@ -48,7 +46,8 @@ extension HomeForMemberVC {
     }
     
     func createPopularPostCellRegistration() -> PopularPostCellRegistration {
-        collectionView.createCellRegistration { cell, index, item in
+        collectionView.createCellRegistration { [weak self] cell, index, item in
+            guard let self else { return }
             cell.configureCell(model: item, index: index, cellType: .popular)
             cell.setPostInfo(model: item, section: .latestPosts)
             
@@ -62,7 +61,8 @@ extension HomeForMemberVC {
     }
     
     func createLatestPostCellRegistration() -> LatestPostCellRegistration {
-        collectionView.createCellRegistration { cell, index, item in
+        collectionView.createCellRegistration { [weak self] cell, index, item in
+            guard let self else { return }
             cell.configureCell(model: item, index: index, cellType: .latest)
             cell.setPostInfo(model: item, section: .realTimeFeed)
             
@@ -99,7 +99,8 @@ extension HomeForMemberVC {
     func createHeaderRegistration() -> HeaderRegistration {
         collectionView.createSupplementaryRegistration(
             elementKind: UICollectionView.elementKindSectionHeader
-        ) { headerView, indexPath in
+        ) { [weak self] headerView, indexPath in
+            guard let self else { return }
             guard let sectionKind = HomeForMemberSectionLayoutKind(rawValue: indexPath.section) else { return }
             headerView.configureView(sectionKind: sectionKind)
             

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -155,7 +155,7 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
     public func showHomeForVisitor() {
         var homeForVisitor = factory.makeHomeForVisitor()
         
-        homeForVisitor.vm.onAppServiceCellTapped = {
+        homeForVisitor.vm.onAppServiceCellTapped = { [weak self] in
             AlertUtils.presentAlertVC(
                 type: .titleDescription,
                 title: I18N.Home.PopUp.needToLogin,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -33,7 +33,7 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
     private let userType: UserType
     private let navigationController: UINavigationController
     
-    public private(set) var rootViewController: UIViewController?
+    public private(set) weak var rootViewController: UIViewController?
     
     // MARK: - Init
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
@@ -135,7 +135,7 @@ public final class LegacyHomeCoordinator: DefaultHomeCoordinator {
     public func showHomeForVisitor() {
         var homeForVisitor = factory.makeHomeForVisitor()
         
-        homeForVisitor.vm.onAppServiceCellTapped = {
+        homeForVisitor.vm.onAppServiceCellTapped = { [weak self] in
             AlertUtils.presentAlertVC(
                 type: .titleDescription,
                 title: I18N.Home.PopUp.needToLogin,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -63,6 +63,8 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     }
     
     deinit {
+        outlineAnimationTimer?.invalidate()
+        outlineAnimationTimer = nil
         cancelBag.cancel()
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -62,6 +62,10 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        cancelBag.cancel()
+    }
+    
     // MARK: - View Life Cycle
     
     public override func viewDidLoad() {

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
@@ -59,6 +59,7 @@ final class HomeDefaultHeaderView: UICollectionReusableView {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.cancelBag.cancel()
+        self.cancelBag = CancelBag()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Views/HomeDefaultHeaderView.swift
@@ -58,7 +58,7 @@ final class HomeDefaultHeaderView: UICollectionReusableView {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        self.cancelBag = CancelBag()
+        self.cancelBag.cancel()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -75,9 +75,6 @@ extension ApplicationCoordinator: SoptlogCoordinatorDelegate {
         switch destination {
         case .dailySoptune:
             self.runDailySoptuneFlow()
-        case .signIn:
-            clearChildViewControllers()
-            self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
         case .webLink(let url):
             self.handleWebLink(webLink: url)
         }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -26,6 +26,7 @@ extension ApplicationCoordinator: TabBarCoordinatorDelegate {
         case .soptlog:
             self.selectedTab(.soptlog)
         case .signIn:
+            clearChildViewControllers()
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
             self.removeDependency(coordinator)
         }
@@ -46,6 +47,7 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
         case .setting(let userType):
             runMyPageFlow(of: userType)
         case .signIn:
+            clearChildViewControllers()
             runSignInFlow(by: .rootWindow(animated: true, message: nil))
             removeDependency(coordinator)
         case .notification:
@@ -74,6 +76,7 @@ extension ApplicationCoordinator: SoptlogCoordinatorDelegate {
         case .dailySoptune:
             self.runDailySoptuneFlow()
         case .signIn:
+            clearChildViewControllers()
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
         case .webLink(let url):
             self.handleWebLink(webLink: url)
@@ -98,11 +101,19 @@ extension ApplicationCoordinator: NotificationCoordinatorDelegate {
 
 extension ApplicationCoordinator: MyPageCoordinatorDelegate {
     public func myPageCoordinator(_ coordinator: MyPageCoordinator, to destination: MyPageCoordinatorDestination) {
+        clearChildViewControllers()
         switch destination {
         case .signIn:
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
         case .signInWithToast:
             self.runSignInFlow(by: .rootWindow(animated: true, message: I18N.Setting.Withdrawal.withdrawalSuccess))
         }
+    }
+}
+
+extension ApplicationCoordinator {
+    private func clearChildViewControllers() {
+        self.homeNavigationController.viewControllers.removeAll()
+        self.soptlogNavigationController.viewControllers.removeAll()
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -35,8 +35,8 @@ public final class ApplicationCoordinator: BaseCoordinator {
     internal let rootNavigationController: UINavigationController
     
     private weak var legacyRootController: UINavigationController?
-    private let homeNavigationController = UINavigationController()
-    private let soptlogNavigationController = UINavigationController()
+    let homeNavigationController = UINavigationController()
+    let soptlogNavigationController = UINavigationController()
     weak var tabBarController: UITabBarController?
     
     private weak var homeCoordinator: DefaultHomeCoordinator?

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -342,8 +342,6 @@ extension ApplicationCoordinator {
                     switch destination {
                     case .dailySoptune:
                         self?.runDailySoptuneFlow()
-                    case .signIn:
-                        self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
                     case .webLink(let url):
                         self?.handleWebLink(webLink: url)
                     }
@@ -804,8 +802,6 @@ extension ApplicationCoordinator {
                 switch destination {
                 case .dailySoptune:
                     self?.runDailySoptuneFlow()
-                case .signIn:
-                    self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
                 case .webLink(let url):
                     self?.handleWebLink(webLink: url)
                 }
@@ -813,8 +809,7 @@ extension ApplicationCoordinator {
         case .new:
             let newCoordinator = SoptlogCoordinator(
                 navigationController: soptlogNavigationController,
-                factory: SoptlogBuilder(),
-                userType: type
+                factory: SoptlogBuilder()
             )
             newCoordinator.delegate = self
             coordinator = newCoordinator

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogCoordinatorDestination.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogCoordinatorDestination.swift
@@ -10,6 +10,5 @@ import Foundation
 
 public enum SoptlogCoordinatorDestination {
     case dailySoptune
-    case signIn
     case webLink(url: String)
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -17,7 +17,6 @@ public protocol SoptlogCoordinatable {
     var onToolTipTapped: ((CGRect) -> Void)? { get set }
     var onSoptuneTapped: (() -> Void)? { get set }
     var onNetworkError: (() -> Void)? { get set }
-    var onNeedSignIn: (() -> Void)? { get set }
 }
 public typealias SoptlogViewModelType = ViewModelType & SoptlogCoordinatable
 public typealias LegacySoptlogPresentable = (vc: SoptlogViewControllable, vm: any SoptlogViewModelType)

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SoptlogCompositinalLayout.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SoptlogCompositinalLayout.swift
@@ -16,14 +16,14 @@ extension SoptlogVC {
     }
     
     func createLayout() -> UICollectionViewCompositionalLayout {
-        let layout = UICollectionViewCompositionalLayout { sectionIndex, env in
-            guard let sectionKind = SoptlogSectionLayoutKind(rawValue: sectionIndex) else { return self.createEmptySection() }
+        let layout = UICollectionViewCompositionalLayout { [weak self] sectionIndex, env in
+            guard let sectionKind = SoptlogSectionLayoutKind(rawValue: sectionIndex) else { return self?.createEmptySection() }
             
             switch sectionKind {
-            case .introduce: return self.createIntroduceSection()
-            case .appService: return self.createAppServiceSection()
-            case .editProfile: return self.createEditProfileSection()
-            case .alarm: return self.createAlarmSection()
+            case .introduce: return self?.createIntroduceSection()
+            case .appService: return self?.createAppServiceSection()
+            case .editProfile: return self?.createEditProfileSection()
+            case .alarm: return self?.createAlarmSection()
             }
         }
         

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/LegacySoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/LegacySoptlogCoordinator.swift
@@ -71,10 +71,6 @@ public final class LegacySoptlogCoordinator: DefaultSoptlogCoordinator {
             AlertUtils.presentNetworkAlertVC()
         }
         
-        soptlog.vm.onNeedSignIn = { [weak self] in
-            self?.requestCoordinating?(.signIn)
-        }
-        
         self.rootViewController = soptlog.vc.viewController
         self.router.push(soptlog.vc)
     }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -30,7 +30,6 @@ public final class SoptlogCoordinator: DefaultSoptlogCoordinator {
     public var finishFlow: (() -> Void)?
     
     private let factory: SoptlogFeatureBuildable
-    private let userType: UserType
     private let navigationController: UINavigationController
     
     public private(set) weak var rootViewController: UIViewController?
@@ -39,23 +38,16 @@ public final class SoptlogCoordinator: DefaultSoptlogCoordinator {
     
     public init(
         navigationController: UINavigationController,
-        factory: SoptlogFeatureBuildable,
-        userType: UserType
+        factory: SoptlogFeatureBuildable
     ) {
         self.navigationController = navigationController
         self.factory = factory
-        self.userType = userType
     }
     
     // MARK: - Coordinator Life Cycle
     
     public override func start() {
-        switch userType {
-        case .visitor:
-            self.rootViewController = UIViewController()
-        case .active, .inactive:
-            showSoptlog()
-        }
+        showSoptlog()
     }
     
     // MARK: - Navigation
@@ -81,11 +73,6 @@ public final class SoptlogCoordinator: DefaultSoptlogCoordinator {
         
         soptlog.vm.onNetworkError = {
             AlertUtils.presentNetworkAlertVC()
-        }
-        
-        soptlog.vm.onNeedSignIn = { [weak self] in
-            guard let self else { return }
-            self.delegate?.soptlogCoordinator(self, to: .signIn)
         }
         
         self.rootViewController = soptlog.vc

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -33,7 +33,7 @@ public final class SoptlogCoordinator: DefaultSoptlogCoordinator {
     private let userType: UserType
     private let navigationController: UINavigationController
     
-    public private(set) var rootViewController: UIViewController?
+    public private(set) weak var rootViewController: UIViewController?
     
     // MARK: - Init
     

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -32,13 +32,15 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     private lazy var naviBar = OPNavigationBar(self, type: .none)
         .addMiddleLabel(title: I18N.Soptlog.navigationTitle, font: DSKitFontFamily.Suit.medium.font(size: 16))
     
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout()).then {
-        $0.isScrollEnabled = true
-        $0.showsHorizontalScrollIndicator = false
-        $0.showsVerticalScrollIndicator = false
-        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        $0.backgroundColor = .clear
-    }
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createLayout())
+        collectionView.isScrollEnabled = true
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        collectionView.backgroundColor = .clear
+        return collectionView
+    }()
     
     // MARK: - Initialization
     
@@ -65,11 +67,6 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.viewWillAppear.send()
-    }
-    
-    deinit {
-        collectionView.delegate = nil
-        collectionView.dataSource = nil
     }
 }
 

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -42,7 +42,6 @@ public class SoptlogViewModel: SoptlogViewModelType {
     public var onToolTipTapped: ((CGRect) -> Void)?
     public var onSoptuneTapped: (() -> Void)?
     public var onNetworkError: (() -> Void)?
-    public var onNeedSignIn: (() -> Void)?
     
     
     // MARK: - initialization
@@ -69,7 +68,7 @@ extension SoptlogViewModel {
                             self.onNetworkError?()
                             return Empty().eraseToAnyPublisher()
                         case .authFailed:
-                            self.onNeedSignIn?()
+                            print("인증에 실패했습니다.")
                             return Empty().eraseToAnyPublisher()
                         }
                     }


### PR DESCRIPTION
## 🌴 PR 요약
- 홈플로우에서 발생하는 메모리 누수를 해결했습니다.

🌱 작업한 브랜치
- feature/#715

## 🌱 PR Point
~~#716 이 머지되지 않아 Legacy 피처에서 진행했습니다. (누수는 legacy, new가 공통으로 사용하는 로직에서 발생)~~

## 🌿 메모리 누수 원인
### **1. compositionalLayout 클로저에서 발생**
<img width="1017" height="271" alt="image" src="https://github.com/user-attachments/assets/f2e046c9-f432-48eb-99d1-248c2f518293" />
- `HomeForVisitorCompositionalLayout`, `SoptlogCompositionalLayout`의 클로저에서 발생하는 self 강한 참조 제거했습니다.

<br>

### **2. 중첩 클로저의 self 참조로 인해 발생하는 누수 제거**
<img width="833" height="316" alt="image" src="https://github.com/user-attachments/assets/a0b3f866-9d90-43d7-a94a-add663bc1d7d" />
- `onAppServiceCellTapped` 클로저에서 중첩 클로저의 self참조로 인해 발생하는 누수 제거했습니다.

<br>

### **3. ViewController 순환참조**
<img width="1305" height="261" alt="image" src="https://github.com/user-attachments/assets/7a9f95f2-d384-496b-84ec-4734d9d8f3b1" />
<img width="1293" height="106" alt="image" src="https://github.com/user-attachments/assets/cd10ae47-3f82-44d6-8dd4-1e4612cb0a58" />

- `onLoginHelpButtonTapped`에서 발생하는 VC 참조 제거했습니다.
- `VC → VM → VM의 클로저 → 클로저 구현부에서 VC 강한 참조 → VM...` 으로 발생
- 사진과 같이 VC를 weak로 캡처하려했으나 리팩토링 전 VC는 프로토콜 타입(ViewControllable)이기 때문에 캡처 불가
- ~~#716 머지 후 해당 부분 반영할 예정~~ 
- UIViewController로 변경 후 반영 완료했습니다.

<br>

### **4. CellRegistration에서 발생하는 누수 제거**
<img width="981" height="636" alt="image" src="https://github.com/user-attachments/assets/7cc2e05d-da68-4e87-8bc4-94631d23c96e" />
- 셀 등록 과정에서createCellRegistration의 클로저 내부에서 self 사용하고 있어 누수가 발생했습니다.
    - cell의 publisher 구독 시 `withUnretained(self)`
- 각 cell이 재사용되기 전 cancelBag.cancel()로 명시적으로 구독을 해제하도록 추가했습니다.

<br>

### **5. 네비게이션 스택 미초기화로 인한 메모리 누수**
**AS-IS**
<img width="520" height="40" alt="image" src="https://github.com/user-attachments/assets/766560d9-695a-42a6-884c-81c49ace7981" />
최상위 코디네이터인 앱 코디네이터는 `homeNaivgationController`와 `soptlogNavigationController` 인스턴스를 소유하고 있는 상태입니다. 해당 NVC는 각 코디네이터에 주입되어 자식 컨트롤러를 가집니다.

<img width="611" height="634" alt="스크린샷 2025-10-08 오후 5 53 24" src="https://github.com/user-attachments/assets/48ae4148-a219-4e96-a1de-69fabfe7d9b7" />
<img width="1788" height="160" alt="image" src="https://github.com/user-attachments/assets/239a2e40-7f33-45a6-9291-5a6776384c5e" />
<img width="1826" height="92" alt="image" src="https://github.com/user-attachments/assets/f39a2ef8-9cd0-4254-9528-4a7872676f5f" />

HomeNVC와 SoptlogNVC는 **앱 코디네이터가 소유하고 있고, 앱 코디네이터는 메모리에서 해제되지 않으므로 자식 컨트롤러가 계속해서 쌓이는 문제가 발생**했습니다.

**TO-BE**
<img width="1034" height="134" alt="image" src="https://github.com/user-attachments/assets/62042f4b-49b2-4114-9d41-741aed6156df" />
<img width="1172" height="186" alt="image" src="https://github.com/user-attachments/assets/5f83fe67-d8c7-44b4-b977-46553f1e0013" />

따라서 로그인 플로우 진입 시 기존 NVC의 네비게이션스택을 초기화하는 `clearChildViewControllers` 메소드를 구현해 누수를 방지했습니다.

<br>


### 6. 홈코디네이터와 솝트로그코디네이터의 rootVC 참조 제거

| 홈코디네이터 | 솝트로그 코디네이터 |
| :-- | :-- |
| <img width="393" height="184" alt="image" src="https://github.com/user-attachments/assets/723c6a29-314a-4338-8508-d3dbd2c5498c" /> | <img width="359" height="216" alt="image" src="https://github.com/user-attachments/assets/e7dd54d0-3b39-4d12-9302-65649afd25c9" /> |

네비게이션 스택 초기화 이후에도 인스턴스가 1개씩 남아있는 문제가 발생하여 각 코디네이터에서 사용하는 rootVC를 약한참조로 변경했습니다.


### 7. Gesture 구독에서 발생하는 누수 제거
6번까지 고치고 나니 누수가 201개가 생겨서 눈물이 앞을 가렸는데요,, 다행히 원인은 하나였습니다.
| Instruments | 메모리 그래프 |
| :-- | :-- |
| <img width="1429" height="420" alt="image" src="https://github.com/user-attachments/assets/23279ba7-8bbc-4da2-8c63-aeaea46c400a" /> |  <img width="528" height="1002" alt="image" src="https://github.com/user-attachments/assets/89aff2f3-e406-4050-87fe-7db6de1ee673" /> |
| <img width="1711" height="456" alt="image" src="https://github.com/user-attachments/assets/f1c43944-db33-401a-8003-4569d4324fc0" /> | <img width="527" height="1011" alt="image" src="https://github.com/user-attachments/assets/fbe61b1f-850d-43bd-9449-4a1908f948fd" /> |


**프로파일링 결과**
<img width="892" height="301" alt="image" src="https://github.com/user-attachments/assets/87e875ff-bdc3-497c-a7f6-11e218d4f56a" />

<img width="922" height="495" alt="image" src="https://github.com/user-attachments/assets/42c55356-424c-449a-874d-6ff905b1022c" />

1. gesturePublisher 생성 시 발생하는 누수 없음 (https://github.com/sopt-makers/SOPT-iOS/pull/553/commits/d881d64e6ed13784822b9dd5909775022489e935 에서 해결)
2. gesturePublisher를 구독하는 순간 receive 메소드 내에서 GestureSubscription 생성
3. 생성자에서 configureGesture 호출
4. gesture에 addTarget 추가, gestureRecognizer가 self(Subscription)를 강하게 참조
5. GestureSubscription의 view는 Recognizer 참조

VC가 잘 해제되는 경우 순환참조가 없기 때문에 Recognizer가 잘 해제되지만, 간헐적으로 누수가 발생해서 안전하게 target과 recognizer를 제거하는 메소드를 추가했습니다.

<br>

## 🌿 앞으로 피처 플래그는 `.new`만 사용
<img width="2612" height="1600" alt="image" src="https://github.com/user-attachments/assets/86a5f10e-7713-4758-a73f-0875bf04fc58" />

AuthFeature의 Coordinator에서 Router 의존성이 제거됨에 따라,
인증 중앙화 이후 버전에서는 legacy 코디네이터를 통한 화면 전환이 불가합니다.

<br>

## 🌿 솝트로그 비회원 로직 처리 변경
| TabBarViewModel | SoptlogViewModel |
| :-- | :-- |
| <img width="425" height="203" alt="image" src="https://github.com/user-attachments/assets/1ad686d0-e5ef-4b08-afb8-cacd6ce2b58b" /> | <img width="549" height="301" alt="image" src="https://github.com/user-attachments/assets/8a8f6f89-c9a8-452e-a96b-24ec65d4ece9" /> |

비회원으로 솝트로그 진입 시 예외처리 로직이 TabBar와 Soptlog에서 중복 처리되고 있었습니다.
비회원일 때는 솝트로그 화면을 그릴 필요가 없다고 판단되어 솝트로그 로직을 제거했습니다. (https://github.com/sopt-makers/SOPT-iOS/pull/717/commits/2d2fde0ff098500c1f98e2a049a08106758eb63c)


<br>


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- ~~#716 머지 후 메모리 누수 한 번 더 체크할 예정입니다.~~ 체크 완료
- HomeForMemberVC에서 사용하지 않는 Timer를 제거했습니다.

## 📸 스크린샷
| AS-IS | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/44663ff9-ddd3-4c5c-8d02-c77e0ea90b64" /> |
| :-- | :-- |
| TO-BE  | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2b0471c3-fcdb-4dc7-b431-7c03a4639ebd" /> |

## 📮 관련 이슈
- Resolved: #715
