### PR TITLE
[Refactor] #632 - AuthFlow의 코디네이터 의존성 제거 방식 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthFeatureBuildable_Refactor.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/AuthFeatureBuildable_Refactor.swift
@@ -7,9 +7,10 @@
 //
 
 import Foundation
+import BaseFeatureDependency
 
 public protocol AuthFeatureViewBuildable {
-    func makeSignIn() -> SignInPresentable
+    func makeSignIn(coordinator: Coordinator) -> SignInPresentable
     func makeLoginHelpBottomSheet() -> LoginHelpBottomSheetPresentable
     func makeUserNotFound() -> UserNotFoundPresentable
     func makeSignUp() -> SignUpPresentable

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/LoginHelpBottomSheetPresentable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/LoginHelpBottomSheetPresentable.swift
@@ -10,10 +10,10 @@ import BaseFeatureDependency
 import Core
 import Domain
 
-public protocol LoginHelpBottomSheetViewControllable: LegacyViewControllable { 
+public protocol LoginHelpBottomSheetRoutingTrigger: LegacyViewControllable {
     var onWantToKnowLoginAccountButtonDidTap: (() -> Void)? { get set }
     var onResetSocialAccountButtonDidTap: (() -> Void)? { get set }
     var onInquireToKakaoTalkButtonDidTap: (() -> Void)? { get set }
 }
 
-public typealias LoginHelpBottomSheetPresentable = LoginHelpBottomSheetViewControllable
+public typealias LoginHelpBottomSheetPresentable = LoginHelpBottomSheetRoutingTrigger

--- a/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/UserNotFoundBuildable.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Interface/Sources/UserNotFoundBuildable.swift
@@ -11,9 +11,9 @@ import Foundation
 import UIKit
 import BaseFeatureDependency
 
-public protocol UserNotFoundViewControllable: UIViewController {
+public protocol UserNotFoundRoutingTrigger: UIViewController {
     var onLoginHelpButtonTapped: (() -> Void)? { get set }
     var onLoginRetryButtonTapped: (() -> Void)? { get set }
 }
 
-public typealias UserNotFoundPresentable = UserNotFoundViewControllable
+public typealias UserNotFoundPresentable = UserNotFoundRoutingTrigger

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthBuilder.swift
@@ -24,14 +24,14 @@ public final class AuthBuilder {
 }
     
 extension AuthBuilder: AuthFeatureViewBuildable {
-    public func makeSignIn() -> SignInPresentable {
+    public func makeSignIn(coordinator: Coordinator) -> SignInPresentable {
         let useCase = DefaultSignInUseCase(
             repository: repository,
             oauthRepository: oauthRepository,
             coreRepository: coreRepository,
             tokenRepository: tokenRepository
         )
-        let vm = SignInViewModel(useCase: useCase)
+        let vm = SignInViewModel(useCase: useCase, coordinator: coordinator)
         let vc = SignInVC(viewModel: vm)
         return (vc, vm)
     }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -160,18 +160,18 @@ extension AuthCoordinator {
         guard let bottomSheetVC = self.factory.makeLoginHelpBottomSheet().viewController as? LoginHelpBottomSheetVC
         else { return Void() }
         
-        bottomSheetVC.onResetSocialAccountButtonDidTap = { [weak self] in
-            bottomSheetVC.dismiss(animated: true)
+        bottomSheetVC.onResetSocialAccountButtonDidTap = { [weak self, weak bottomSheetVC] in
+            bottomSheetVC?.dismiss(animated: true)
             self?.runChangeSocialFlow()
         }
         
-        bottomSheetVC.onWantToKnowLoginAccountButtonDidTap = { [weak self] in
-            bottomSheetVC.dismiss(animated: true)
+        bottomSheetVC.onWantToKnowLoginAccountButtonDidTap = { [weak self, weak bottomSheetVC] in
+            bottomSheetVC?.dismiss(animated: true)
             self?.runSearchSocialFlow()
         }
         
-        bottomSheetVC.onInquireToKakaoTalkButtonDidTap = { 
-            bottomSheetVC.dismiss(animated: true)
+        bottomSheetVC.onInquireToKakaoTalkButtonDidTap = { [weak bottomSheetVC] in
+            bottomSheetVC?.dismiss(animated: true)
             openExternalLink(urlStr: ExternalURL.KakaoTalk.serviceProposal)
         }
         

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -20,7 +20,7 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
     public var finishFlow: ((UserType) -> Void)?
 
     private let factory: AuthFeatureViewBuildable
-    private let navigationController: UINavigationController
+    private weak var navigationController: UINavigationController?
     private var url: String?
 
     public init(
@@ -60,37 +60,39 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
             self?.runSignUpFlow()
         }
         
+        guard let navigationController = self.navigationController else { return }
+        
         switch style {
         case .modal:
             signIn.vc.modalPresentationStyle = .fullScreen
             signIn.vc.modalTransitionStyle = .crossDissolve
             navigationController.present(signIn.vc, animated: false)
         case .root:
-            self.navigationController.isNavigationBarHidden = true
-            self.navigationController.setViewControllers([signIn.vc], animated: false)
+            navigationController.isNavigationBarHidden = true
+            navigationController.setViewControllers([signIn.vc], animated: false)
             ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
-                                                            navigationController: self.navigationController,
+                                                            navigationController: navigationController,
                                                             withAnimation: false)
         case .rootWindow(let animated, let message):
-            self.navigationController.isNavigationBarHidden = true
-            self.navigationController.setViewControllers([signIn.vc], animated: false)
+            navigationController.isNavigationBarHidden = true
+            navigationController.setViewControllers([signIn.vc], animated: false)
             
             guard !animated else {
                 ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
-                                                                navigationController: self.navigationController,
+                                                                navigationController: navigationController,
                                                                 withAnimation: true)
                 return
             }
 
             guard let message else {
                 ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
-                                                          navigationController: self.navigationController,
+                                                          navigationController: navigationController,
                                                           withAnimation: true)
                 return
             }
 
             ViewControllerUtils.setRootNavigationController(window: UIWindow.keyWindowGetter!,
-                                                      navigationController: self.navigationController,
+                                                      navigationController: navigationController,
                                                       withAnimation: true) { newWindow in
                 Toast.show(
                     message: message,
@@ -106,7 +108,7 @@ extension AuthCoordinator {
     private func runUserNotFoundFlow() {
         let userNotFoundVC = self.factory.makeUserNotFound()
         userNotFoundVC.onLoginRetryButtonTapped = { [weak self] in
-            self?.navigationController.popToRootViewController(animated: true)
+            self?.navigationController?.popToRootViewController(animated: true)
         }
         
         userNotFoundVC.onLoginHelpButtonTapped = { [weak self, weak viewController = userNotFoundVC.viewController] in
@@ -114,44 +116,44 @@ extension AuthCoordinator {
             self?.showLoginHelpBottomSheet(on: viewController)
         }
         
-        self.navigationController.pushViewController(userNotFoundVC.viewController, animated: true)
+        self.navigationController?.pushViewController(userNotFoundVC.viewController, animated: true)
     }
     
     private func runSignUpFlow() {
         var signUpVC = self.factory.makeSignUp()
         
         signUpVC.vm.onSignUpSuccess = { [weak self] in
-            self?.navigationController.popToRootViewController(animated: true)
+            self?.navigationController?.popToRootViewController(animated: true)
         }
         
         signUpVC.vm.onLoginHelpButtonTapped = { [weak self] in
             guard let url = URL(string: ExternalURL.SOPT.memberVerifyGoogleForm) else { return }
             
             let webView = SOPTWebView(startWith: url)
-            self?.navigationController.pushViewController(webView, animated: true)
+            self?.navigationController?.pushViewController(webView, animated: true)
         }
         
-        self.navigationController.pushViewController(signUpVC.vc, animated: true)
+        self.navigationController?.pushViewController(signUpVC.vc, animated: true)
     }
     
     private func runChangeSocialFlow() {
         var changeSocialAccount = self.factory.makeChangeSocialAccount()
         
         changeSocialAccount.vm.changeSocialAccountSucceed = { [weak self] in
-            self?.navigationController.popToRootViewController(animated: true)
+            self?.navigationController?.popToRootViewController(animated: true)
         }
         
-        self.navigationController.pushViewController(changeSocialAccount.vc, animated: true)
+        self.navigationController?.pushViewController(changeSocialAccount.vc, animated: true)
     }
     
     private func runSearchSocialFlow() {
         var searchSocialAccount = self.factory.makeSearchSocialAccount()
         
         searchSocialAccount.vm.searchSocialAccountSucceed = { [weak self] _ in
-            self?.navigationController.popToRootViewController(animated: true)
+            self?.navigationController?.popToRootViewController(animated: true)
         }
         
-        self.navigationController.pushViewController(searchSocialAccount.vc, animated: true)
+        self.navigationController?.pushViewController(searchSocialAccount.vc, animated: true)
     }
     
     private func showLoginHelpBottomSheet(on vc: UIViewController) {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -34,7 +34,7 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
     }
 
     public override func start(by style: CoordinatorStartingOption) {
-        var signIn = factory.makeSignIn()
+        var signIn = factory.makeSignIn(coordinator: self)
         
         //TODO: 딥링크 URL 자동로그인 로직
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Coordinator/AuthCoordinator.swift
@@ -15,13 +15,18 @@ import Core
 import DSKit
 import WebFeature
 
-public final class AuthCoordinator: DefaultAuthCoordinator {
+public protocol AuthCoordinatorDelegate: AnyObject {
+    func authCoordinator(_ coordinator: AuthCoordinator, userType: UserType)
+}
 
+public final class AuthCoordinator: DefaultAuthCoordinator {
+    // TODO: DefaultAuthCoordinator가 BaseCoordinator만 채택하도록 변경
     public var finishFlow: ((UserType) -> Void)?
 
     private let factory: AuthFeatureViewBuildable
     private weak var navigationController: UINavigationController?
     private var url: String?
+    public weak var delegate: AuthCoordinatorDelegate?
 
     public init(
         navigationController: UINavigationController,
@@ -39,8 +44,9 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
         //TODO: 딥링크 URL 자동로그인 로직
 
         signIn.vm.onSignInSuccess = { [weak self]  in
+            guard let self else { return }
             let userType = UserDefaultKeyList.Auth.getUserType()
-            self?.finishFlow?(userType)
+            self.delegate?.authCoordinator(self, userType: userType)
         }
         
         signIn.vm.onLoginHelpButtonTapped = { [weak self, weak viewController = signIn.vc] in
@@ -49,7 +55,8 @@ public final class AuthCoordinator: DefaultAuthCoordinator {
         }
         
         signIn.vm.onVisitorButtonTapped = { [weak self] in
-            self?.finishFlow?(.visitor)
+            guard let self else { return }
+            self.delegate?.authCoordinator(self, userType: .visitor)
         }
         
         signIn.vm.onSocialLoginFail = { [weak self] in

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
@@ -14,7 +14,7 @@ import Core
 import DSKit
 import Domain
 
-public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomSheetViewControllable {
+public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomSheetRoutingTrigger {
     
     private static let i18n = I18N.SignIn.Refactor.self
     public var onWantToKnowLoginAccountButtonDidTap: (() -> Void)?

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInViewModel.swift
@@ -11,10 +11,13 @@ import Combine
 import Core
 import Domain
 
-import AuthFeatureInterface
+import BaseFeatureDependency
 
 public class SignInViewModel: SignInViewModelType {
     
+    // MARK: - Properties
+    
+    private let coordinator: AnyCoordinatorObject
     private let useCase: SignInUseCase
     private var cancelBag = CancelBag()
   
@@ -47,8 +50,9 @@ public class SignInViewModel: SignInViewModelType {
     
     // MARK: - init
   
-    public init(useCase: SignInUseCase) {
+    public init(useCase: SignInUseCase, coordinator: Coordinator) {
         self.useCase = useCase
+        self.coordinator = coordinator
     }
 }
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
@@ -12,7 +12,7 @@ import BaseFeatureDependency
 import Core
 import DSKit
 
-public final class UserNotFoundVC: UIViewController, UserNotFoundViewControllable {
+public final class UserNotFoundVC: UIViewController, UserNotFoundRoutingTrigger {
 
     // MARK: - Properties
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -27,7 +27,6 @@ public final class HomeCoordinator: DefaultHomeCoordinator {
     // MARK: - Properties
     
     public var requestCoordinating: ((HomeCoordinatorDestination) -> Void)?
-    public var finishFlow: (() -> Void)?
     
     private let factory: HomeFeatureBuildable
     private let userType: UserType

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -41,7 +41,6 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     var latestPostAnimationTask: Task<Void, Never>?
     var fetchDataTask: Task<Void, Never>?
     
-    var outlineAnimationTimer: Timer?
     var currentIndex = 0
     
     // MARK: - UI Components
@@ -63,8 +62,6 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     }
     
     deinit {
-        outlineAnimationTimer?.invalidate()
-        outlineAnimationTimer = nil
         cancelBag.cancel()
     }
     

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -10,11 +10,20 @@ import Foundation
 
 import Core
 
+import AuthFeature
 import HomeFeature
 import SoptlogFeature
 import TabBarFeature
 import AppMyPageFeature
 import NotificationFeature
+
+// MARK: - AuthCoordinatorDelegate
+
+extension ApplicationCoordinator: AuthCoordinatorDelegate {
+    public func authCoordinator(_ coordinator: AuthCoordinator, userType: UserType) {
+        self.runTabBarFlow(type: userType)
+    }
+}
 
 // MARK: - TabBarCoordinatorDelegate
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -245,26 +245,41 @@ extension ApplicationCoordinator {
     ) {
         @Injected var coordinator: DefaultAuthCoordinator
         
-        coordinator.finishFlow = { [weak self, weak coordinator] userType in
-            Config.coordinatorFlag == .legacy
-            ? self?.runLegacyTabBarFlow(type: userType)
-            : self?.runTabBarFlow(type: userType)
-            self?.removeDependency(coordinator)
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator.finishFlow = { [weak self, weak coordinator] userType in
+                Config.coordinatorFlag == .legacy
+                ? self?.runLegacyTabBarFlow(type: userType)
+                : self?.runTabBarFlow(type: userType)
+                self?.removeDependency(coordinator)
+            }
+            addDependency(coordinator)
+        case .new:
+            let coordinator = coordinator as? AuthCoordinator
+            coordinator?.delegate = self
         }
-        addDependency(coordinator)
+        
         coordinator.start(by: style)
     }
     
     private func runSignInSuccessFlow(with url: String) {
         childCoordinators = []
         @Injected var coordinator: DefaultAuthCoordinator
-        coordinator.finishFlow = { [weak self, weak coordinator] userType in
-            Config.coordinatorFlag == .legacy
-            ? self?.runLegacyTabBarFlow(type: userType)
-            : self?.runTabBarFlow(type: userType)
-            self?.removeDependency(coordinator)
+        
+        switch Config.coordinatorFlag {
+        case .legacy:
+            coordinator.finishFlow = { [weak self, weak coordinator] userType in
+                Config.coordinatorFlag == .legacy
+                ? self?.runLegacyTabBarFlow(type: userType)
+                : self?.runTabBarFlow(type: userType)
+                self?.removeDependency(coordinator)
+            }
+            addDependency(coordinator)
+        case .new:
+            let coordinator = coordinator as? AuthCoordinator
+            coordinator?.delegate = self
         }
-        addDependency(coordinator)
+        
         coordinator.start(by: .rootWindow(animated: false, message: nil))
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- AuthFlow의 코디네이터 의존성 제거 방식을 변경했습니다.

🌱 작업한 브랜치
- feature/#632

## 🌱 PR Point
다른 Flow의 Coordinator들은 BaseCoordinator 클래스를 상속받는 구조로 설계했는데요,
이는 finishFlow가 delegate로 대체되어, 각 Coordinator가 start() 메소드만 구현하면 되기 때문입니다.

반면 AuthCoordinator는 앱 코디네이터에서 BaseCoordinator 타입을 사용하지 않았습니다.

현재 `AuthCoordinator`는 앱코디네이터에서 `DefaultAuthCoordinator` 타입으로 DI에 등록하고 있습니다.
아직 레거시 코드가 완전히 제거되지 않았기 때문에, **AuthCoordinator와 LegacyAuthCoordinator를 모두 표현할 수 있는 타입이 필요**했습니다. 때문에 `DefaultAuthCoordinator`를 유지하였고,
레거시 코드가 정리되면 `AuthCoordinator`로 의존성을 등록할 수 있기 때문에 `DefaultAuthCoordinator`는 제거할 예정입니다.

이제 레거시 코드 제거 작업만 남았네요ㅎㅎ
빠른 작업도 좋지만,, 안전하게 제거하는 것도 중요하다고 생각해서 
- 제거 대상 코드 목록을 정리하고
- 코디네이터를 어떻게 테스트할 수 있는지 고민

해보겠습니다~!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- HomeForMemberVC에서 사용하지 않는 Timer 변수 제거했습니다.
- LoginBottomSheet에서 발생하는 순환참조 제거했습니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/b96f937c-52d6-4ac6-81e6-9369710707e8


## 📮 관련 이슈
- Resolved: #632
