### PR TITLE
[Refactor] #721 - TabBarFlow의 코디네이터 의존성 제거 방식 변경 

### DIFF
--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -273,87 +273,87 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     internal func runLegacyTabBarFlow(type: UserType? = nil, initSelectedTabIndex: Int = 0) {
-        defer {
-            bindNotification()
-        }
-        
-        self.childCoordinators = []
-        
-        let tabBarBuilder = TabBarBuilder()
-        let userType = type ?? UserDefaultKeyList.Auth.getUserType()
-
-        let homeCoordinator = runHomeFlow(type: userType)
-        guard let homeVC = homeCoordinator.rootViewController else { return }
-    
-        let soptlogCoordinator = runSoptlogFlow(type: userType)
-        guard let soptlogVC = soptlogCoordinator.rootViewController else { return }
-                
-        let (tabbarController, viewModel) = tabBarBuilder.makeTabBar(
-            with: [homeVC,
-                   soptlogVC],
-            userType: userType
-        )
-        
-        let coordinator = LegacyTabBarCoordinator(
-            router: router,
-            factory: (tabbarController, viewModel),
-            items: [
-                homeVC,
-                soptlogVC
-            ]
-        )
-        
-        self.legacyRootController = tabbarController.asNavigationController
-        self.tabBarController = tabbarController
-        
-        self.tabBarController?.selectedIndex = initSelectedTabIndex
-        
-        // 각 코디네이터 실행
-        coordinator.requestCoordinating = { [weak self, weak coordinator] destination in
-            switch destination {
-            case .home:
-                self?.homeCoordinator?.requestCoordinating = { [weak self, weak coordinator] destination in
-                    switch destination {
-                    case .attendance:
-                        self?.runAttendanceFlow()
-                    case .setting(let userType):
-                        self?.runMyPageFlow(of: userType)
-                    case .signIn:
-                        self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
-                        self?.removeDependency(coordinator)
-                    case .notification:
-                        self?.runNotificationFlow()
-                    case .soptlog:
-                        self?.tabBarController?.selectedIndex = 1
-                    case .deepLink(let url):
-                        self?.notificationHandler.receive(deepLink: url)
-                        guard let deepLink = self?.notificationHandler.deepLink.value else { return }
-                        self?.handleDeepLink(deepLink: deepLink)
-                    case .webLink(let url):
-                        self?.handleWebLink(webLink: url)
-                    case .calendar:
-                        self?.showHomeCalendarDetail()
-                    case .poke(let isNewUser):
-                        _ = isNewUser ? self?.runPokeOnboardingFlow() : self?.runPokeFlow()
-                    }
-                }
-            case .soptlog:
-                self?.soptlogCoordinator?.requestCoordinating = { [weak self] destination in
-                    switch destination {
-                    case .dailySoptune:
-                        self?.runDailySoptuneFlow()
-                    case .webLink(let url):
-                        self?.handleWebLink(webLink: url)
-                    }
-                }
-            case .signIn:
-                self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
-                self?.removeDependency(coordinator)
-            }
-        }
-        
-        addDependency(coordinator)
-        coordinator.start()
+//        defer {
+//            bindNotification()
+//        }
+//        
+//        self.childCoordinators = []
+//        
+//        let tabBarBuilder = TabBarBuilder()
+//        let userType = type ?? UserDefaultKeyList.Auth.getUserType()
+//
+//        let homeCoordinator = runHomeFlow(type: userType)
+//        guard let homeVC = homeCoordinator.rootViewController else { return }
+//    
+//        let soptlogCoordinator = runSoptlogFlow(type: userType)
+//        guard let soptlogVC = soptlogCoordinator.rootViewController else { return }
+//                
+//        let (tabbarController, viewModel) = tabBarBuilder.makeTabBar(
+//            with: [homeVC,
+//                   soptlogVC],
+//            userType: userType
+//        )
+//        
+//        let coordinator = LegacyTabBarCoordinator(
+//            router: router,
+//            factory: (tabbarController, viewModel),
+//            items: [
+//                homeVC,
+//                soptlogVC
+//            ]
+//        )
+//        
+//        self.legacyRootController = tabbarController.asNavigationController
+//        self.tabBarController = tabbarController
+//        
+//        self.tabBarController?.selectedIndex = initSelectedTabIndex
+//        
+//        // 각 코디네이터 실행
+//        coordinator.requestCoordinating = { [weak self, weak coordinator] destination in
+//            switch destination {
+//            case .home:
+//                self?.homeCoordinator?.requestCoordinating = { [weak self, weak coordinator] destination in
+//                    switch destination {
+//                    case .attendance:
+//                        self?.runAttendanceFlow()
+//                    case .setting(let userType):
+//                        self?.runMyPageFlow(of: userType)
+//                    case .signIn:
+//                        self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
+//                        self?.removeDependency(coordinator)
+//                    case .notification:
+//                        self?.runNotificationFlow()
+//                    case .soptlog:
+//                        self?.tabBarController?.selectedIndex = 1
+//                    case .deepLink(let url):
+//                        self?.notificationHandler.receive(deepLink: url)
+//                        guard let deepLink = self?.notificationHandler.deepLink.value else { return }
+//                        self?.handleDeepLink(deepLink: deepLink)
+//                    case .webLink(let url):
+//                        self?.handleWebLink(webLink: url)
+//                    case .calendar:
+//                        self?.showHomeCalendarDetail()
+//                    case .poke(let isNewUser):
+//                        _ = isNewUser ? self?.runPokeOnboardingFlow() : self?.runPokeFlow()
+//                    }
+//                }
+//            case .soptlog:
+//                self?.soptlogCoordinator?.requestCoordinating = { [weak self] destination in
+//                    switch destination {
+//                    case .dailySoptune:
+//                        self?.runDailySoptuneFlow()
+//                    case .webLink(let url):
+//                        self?.handleWebLink(webLink: url)
+//                    }
+//                }
+//            case .signIn:
+//                self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
+//                self?.removeDependency(coordinator)
+//            }
+//        }
+//        
+//        addDependency(coordinator)
+//        coordinator.start()
     }
 }
 
@@ -370,20 +370,14 @@ extension ApplicationCoordinator {
         runHomeFlow(type: userType)
         runSoptlogFlow(type: userType)
         
-        let tabBarFactory = tabBarBuilder.makeTabBar(
-            with: [homeNavigationController, soptlogNavigationController],
+        let coordinator = TabBarCoordinator(
+            navigationController: rootNavigationController,
+            factory: tabBarBuilder,
+            views: [homeNavigationController, soptlogNavigationController],
             userType: userType
         )
         
-        let coordinator = TabBarCoordinator(
-            navigationController: rootNavigationController,
-            factory: tabBarFactory
-        )
-        
         coordinator.delegate = self
-        self.rootNavigationController.setViewControllers([tabBarFactory.vc], animated: false)
-        
-        addDependency(coordinator)
         coordinator.start()
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -362,7 +362,6 @@ extension ApplicationCoordinator {
 extension ApplicationCoordinator {
     internal func runTabBarFlow(type: UserType? = nil, initSelectedTabType: TabType = .home) {
         defer { bindNotification() }
-        self.childCoordinators = []
         
         let tabBarBuilder = TabBarBuilder()
         let userType = type ?? UserDefaultKeyList.Auth.getUserType()

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Interface/Sources/TabBarBuildable.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Interface/Sources/TabBarBuildable.swift
@@ -8,7 +8,8 @@
 
 import UIKit
 import Core
+import BaseFeatureDependency
 
 public protocol TabBarBuildable {
-    func makeTabBar(with views: [UIViewController], userType: UserType) -> TabBarPresentable
+    func makeTabBar(with views: [UIViewController], userType: UserType, coordinator: Coordinator) -> TabBarPresentable
 }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarBuilder.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarBuilder.swift
@@ -6,18 +6,20 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import UIKit
+
 import Core
 import Domain
+import BaseFeatureDependency
 @_exported import TabBarFeatureInterface
-import UIKit
 
 public final class TabBarBuilder {
     public init() {}
 }
 
 extension TabBarBuilder: TabBarBuildable {
-    public func makeTabBar(with views: [UIViewController], userType: UserType) -> TabBarPresentable {
-        let viewModel = TabBarViewModel(userType: userType)
+    public func makeTabBar(with views: [UIViewController], userType: UserType, coordinator: Coordinator) -> TabBarPresentable {
+        let viewModel = TabBarViewModel(userType: userType, coordinator: coordinator)
         let tabBarVC = TabBarController(viewModel: viewModel, tabList: views)
         return (tabBarVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -20,11 +20,10 @@ public protocol TabBarCoordinatorDelegate: AnyObject {
     func tabBarCoordinator(_ coordinator: TabBarCoordinator, to destination: TabBarCoordinatorDestination)
 }
 
-public final class TabBarCoordinator: DefaultTabBarCoordinator {
+public final class TabBarCoordinator: BaseCoordinator {
     
     // MARK: - Properties
-    
-    public var finishFlow: (() -> Void)?
+
     public var requestCoordinating: ((TabBarCoordinatorDestination) -> Void)?
     public weak var delegate: TabBarCoordinatorDelegate?
         

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -28,17 +28,23 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
     public var requestCoordinating: ((TabBarCoordinatorDestination) -> Void)?
     public weak var delegate: TabBarCoordinatorDelegate?
         
-    private let factory: TabBarPresentable
+    private let factory: TabBarBuilder
     private var navigationController: UINavigationController
+    private let views: [UIViewController]
+    private let userType: UserType
     
     // MARK: - Init
     
     public init(
         navigationController: UINavigationController,
-        factory: TabBarPresentable
+        factory: TabBarBuilder,
+        views: [UIViewController],
+        userType: UserType
     ) {
         self.navigationController = navigationController
         self.factory = factory
+        self.views = views
+        self.userType = userType
     }
     
     // MARK: - Coordinator Life Cycle
@@ -50,8 +56,8 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
     // MARK: - Navigation
     
     private func showTabBar() {
-        var tabBar = factory
-    
+        var tabBar = factory.makeTabBar(with: views, userType: userType, coordinator: self)
+
         tabBar.vm.onTabBarItemTapped = { [weak self] index in
             // 각 탭의 코디네이터 실행
             guard let self = self,

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -29,7 +29,7 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
     public weak var delegate: TabBarCoordinatorDelegate?
         
     private let factory: TabBarBuilder
-    private var navigationController: UINavigationController
+    private weak var navigationController: UINavigationController?
     private let views: [UIViewController]
     private let userType: UserType
     
@@ -84,7 +84,9 @@ public final class TabBarCoordinator: DefaultTabBarCoordinator {
         tabBar.vm.onFABMenuTapped = { [weak self] url in
             guard let url = URL(string: url) else { return }
             let webView = SOPTWebView(startWith: url)
-            self?.navigationController.pushViewController(webView, animated: true)
+            self?.navigationController?.pushViewController(webView, animated: true)
         }
+        
+        self.navigationController?.setViewControllers([tabBar.vc], animated: false)
     }
 }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -47,10 +47,6 @@ final public class TabBarViewModel: TabBarViewModelType {
         self.userType = userType
         self.coordinator = coordinator
     }
-    
-    deinit {
-        print("tabBarViewModel deinit")
-    }
 }
 
 extension TabBarViewModel {

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import Combine
 
 import Core
+import BaseFeatureDependency
 
 final public class TabBarViewModel: TabBarViewModelType {
     
@@ -17,6 +18,7 @@ final public class TabBarViewModel: TabBarViewModelType {
     
     private let cancelBag = CancelBag()
     private let userType: UserType
+    private let coordinator: AnyCoordinatorObject
     @Published private(set) var isFABTapped: Bool = false
     
     // MARK: - Inputs
@@ -41,8 +43,13 @@ final public class TabBarViewModel: TabBarViewModelType {
     
     // MARK: - initialization
     
-    public init(userType: UserType) {
+    public init(userType: UserType, coordinator: Coordinator) {
         self.userType = userType
+        self.coordinator = coordinator
+    }
+    
+    deinit {
+        print("tabBarViewModel deinit")
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약
- TabBarFlow의 코디네이터 의존성 제거 방식을 변경했습니다.

🌱 작업한 브랜치
- feature/#721

## 🌱 PR Point
### legacyFeature 주석처리에 관하여
tabBarBuilder의 함수 인터페이스가 변경되며 **팩토리 메소드에 TabBarCoordinator를 주입하는 구조로 변경**되었습니다.

이 과정에서 탭 바 컨트롤러를 앱 코디네이터에서 생성하지 않게 되었는데, 
레거시 코드는 여전히 탭 바를 앱 코디네이터에서 사용하여 레거시 빌더가 필요했습니다.

하지만 #717 에서 더 이상 Legacy 피처 플래그를 사용하지 않게 되었기 때문에 주석처리해두었습니다.



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
https://github.com/user-attachments/assets/36b577dc-a062-4ecf-9108-d13814f3c5cc



## 📮 관련 이슈
- Resolved: #721 
