### PR TITLE
[Fix] #713 - 출석 코드 입력 후 dismiss되지 않는 이슈 해결

### DIFF
--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
@@ -62,6 +62,6 @@ public final class AttendanceCoordinator: DefaultCoordinator {
         
         attendance.vc.modalPresentationStyle = .overFullScreen
         attendance.vc.modalTransitionStyle = .crossDissolve
-        navigationController?.present(attendance.vc, animated: true)
+        navigationController?.present(attendance.vc, animated: true, completion: nil)
     }
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/Coordinator/AttendanceCoordinator.swift
@@ -62,6 +62,6 @@ public final class AttendanceCoordinator: DefaultCoordinator {
         
         attendance.vc.modalPresentationStyle = .overFullScreen
         attendance.vc.modalTransitionStyle = .crossDissolve
-        navigationController?.present(attendance.vc, animated: true, completion: nil)
+        navigationController?.present(attendance.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AttendanceResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AttendanceResponseEntity.swift
@@ -1,0 +1,17 @@
+//
+//  AttendanceResponseEntity.swift
+//  Networks
+//
+//  Created by Jae Hyun Lee on 10/10/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct AttendanceResponseEntity: Codable {
+    public let subLectureId: Int
+    
+    public init(subLectureId: Int) {
+        self.subLectureId = subLectureId
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/AttendanceService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/AttendanceService.swift
@@ -18,7 +18,7 @@ public protocol AttendanceService {
     func fetchAttendanceSchedule() -> AnyPublisher<BaseEntity<AttendanceScheduleEntity>, Error>
     func fetchAttendanceScore() -> AnyPublisher<BaseEntity<AttendanceScoreEntity>, Error>
     func fetchAttendanceRound(lectureId: Int) -> AnyPublisher<BaseEntity<AttendanceRoundEntity>, Error>
-    func postAttendance(lectureRoundId: Int, code: String) -> AnyPublisher<BaseEntity<String>, Error>
+    func postAttendance(lectureRoundId: Int, code: String) -> AnyPublisher<BaseEntity<AttendanceResponseEntity>, Error>
 }
 
 extension DefaultAttendanceService: AttendanceService {
@@ -35,7 +35,7 @@ extension DefaultAttendanceService: AttendanceService {
         opRequestObjectInCombine(AttendanceAPI.lectureRound(lectureId: lectureId))
     }
     
-    public func postAttendance(lectureRoundId: Int, code: String) -> AnyPublisher<BaseEntity<String>, Error> {
+    public func postAttendance(lectureRoundId: Int, code: String) -> AnyPublisher<BaseEntity<AttendanceResponseEntity>, Error> {
         opRequestObjectInCombine(AttendanceAPI.attend(lectureRoundId: lectureRoundId, code: code))
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

출석 코드 입력 후 모달이 dismiss되지 않는 이슈를 해결했어요.

🌱 작업한 브랜치
- #713 

## 🌱 PR Point

- 출석 모달은 attendances/attend 요청의 response가 정상적으로 돌아왔는지의 여부에 따라 dismiss되고 있었습니다.
- 서버에서 내려오는 response와 기존 entity 형식이 일치하지 않아 usecase에서 해당 결과가 false로 캐치되었고, 모달이 정상적으로 dismiss되지 못하고 있었습니다.

```
Response Body: {"success":true,"message":"출석 성공","data":{"subLectureId":638}}
```

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- sample data들의 형식을 미루어봤을 때, 서버 명세가 변경되거나 하진 않은 것 같은데요...
- 그동안 잘 동작되었던 이유와, 이번 기수 들어 갑작스레 문제가 생긴 이유 또한 명확히 파악하진 못했습니다. 
- 해당 내용은 추후 원인 파악을 더 세부적으로 해보겠습니다.
- 다만 내일이 세미나 시작일이므로, 해당 부분 반영해 심사 올리도록 하겠습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|출석 모달|<video src = "https://github.com/user-attachments/assets/7908e7b5-c395-436f-bdbb-2968b20dc069" width = 300>|



## 📮 관련 이슈
- Resolved: #713 
