### PR TITLE
[Fix] #728 - homeFeature 출석 버튼 탭 시 화면 중첩 네비게이션 버그 해결

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -86,7 +86,8 @@ final class CalendarCardCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        resetSubscription()
+        self.cancelBag.cancel()
+        self.cancelBag = CancelBag()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Cells/Calendar/CalendarCardCVC.swift
@@ -86,8 +86,7 @@ final class CalendarCardCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        self.cancelBag.cancel()
-        self.cancelBag = CancelBag()
+        resetSubscription()
     }
 }
 
@@ -143,5 +142,10 @@ extension CalendarCardCVC {
                                                  backgroundColor: tagType.backgroundColor)
         }
         self.attendanceButton.isHidden = (userType == .visitor || userType == .inactive)
+    }
+    
+    func resetSubscription() {
+        self.cancelBag.cancel()
+        self.cancelBag = CancelBag()
     }
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Registration/HomeForMemberItemProvider.swift
@@ -22,8 +22,10 @@ extension HomeForMemberVC {
     func createCalendarCellRegistration() -> CalendarCellRegistration {
         collectionView.createCellRegistration { [weak self] cell, _, item in
             guard let self else { return }
-            cell.configureCell(model: item, userType: self.viewModel.userType)
             
+            cell.cancelBag.cancel()
+            
+            cell.configureCell(model: item, userType: self.viewModel.userType)
             cell.attendanceButtonTap
                 .withUnretained(self)
                 .sink { owner, _ in

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -88,6 +88,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         stopLatestPostAnimationLoop()
         cancelTasks()
         stopPopularPostsAnimationLoop()
+        cancelCellSubscription()
     }
 }
 
@@ -381,6 +382,12 @@ extension HomeForMemberVC {
                 updateUI(with: data)
             }
         }
+    }
+    
+    private func cancelCellSubscription() {
+        collectionView.visibleCells
+            .compactMap { $0 as? CalendarCardCVC }
+            .forEach { $0.cancelBag.cancel() }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -88,7 +88,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         stopLatestPostAnimationLoop()
         cancelTasks()
         stopPopularPostsAnimationLoop()
-        resetCellSubscription()
+        cancelCellSubscription()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -88,7 +88,6 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         stopLatestPostAnimationLoop()
         cancelTasks()
         stopPopularPostsAnimationLoop()
-        cancelCellSubscription()
     }
 }
 
@@ -382,12 +381,6 @@ extension HomeForMemberVC {
                 updateUI(with: data)
             }
         }
-    }
-    
-    private func resetCellSubscription() {
-        collectionView.visibleCells
-            .compactMap { $0 as? CalendarCardCVC }
-            .forEach { $0.resetSubscription() }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -384,10 +384,10 @@ extension HomeForMemberVC {
         }
     }
     
-    private func cancelCellSubscription() {
+    private func resetCellSubscription() {
         collectionView.visibleCells
             .compactMap { $0 as? CalendarCardCVC }
-            .forEach { $0.cancelBag.cancel() }
+            .forEach { $0.resetSubscription() }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -88,7 +88,7 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
         stopLatestPostAnimationLoop()
         cancelTasks()
         stopPopularPostsAnimationLoop()
-        cancelCellSubscription()
+        resetCellSubscription()
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- fix/#728

## 🌱 PR Point
문제상황 -> 출석하고 뒤로가기를 했을 때 **cell이 다시 그려지지 않아서 구독 취소가 되지 않음** (prepareForeReuse가 호출되는 시점은 cell이 다시 그려질 때라서 !!)

해결 -> **viewDidDisappear에서 구독을 reset하는 로직 추가**

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략
## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #728 
