### PR TITLE
[Fix] #734 - SOPTWebView의 쿠키 설정에서 refreshToken key 명칭 변경

### DIFF
--- a/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
@@ -49,7 +49,7 @@ public final class SOPTWebView: UIViewController, SOPTWebViewControllable {
                let refreshToken = UserDefaultKeyList.CoreAuth.refreshToken,
                let cookie = HTTPCookie(properties: [
                 HTTPCookiePropertyKey.domain: url.host() ?? "",
-                HTTPCookiePropertyKey.name: "refresh-token",
+                HTTPCookiePropertyKey.name: "Refresh-Token",
                 HTTPCookiePropertyKey.path: "/",
                 HTTPCookiePropertyKey.value: refreshToken,
                 HTTPCookiePropertyKey.secure: "TRUE",


### PR DESCRIPTION
## 🌴 PR 요약
- SOPTWebView의 쿠키 설정에서 refreshToken의 키 명칭을 변경했습니다.

🌱 작업한 브랜치
- feature/#734

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
[관련 슬랙 스레드](https://sopt-makers.slack.com/archives/C041WU3BMD4/p1760887489606689)

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #734
