### PR TITLE
[Feat] #789 - 솝템프 받은 박수 뷰 구현

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -363,6 +363,7 @@ public struct I18N {
             public static let title = "솝탬프 설정"
             public static let editOnelineSentence = "한 마디 편집"
             public static let resetStamp = "스탬프 초기화"
+            public static let clapList = "박수 목록"
         }
         
         public struct EtcSection {

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ClapListModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ClapListModel.swift
@@ -1,0 +1,22 @@
+//
+//  ClapListModel.swift
+//  Domain
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct ClapListModel: Hashable {
+    public let id = UUID()
+    public let name: String
+    public let subtitle: String
+    public let clapCount: Int
+
+    public init(name: String, subtitle: String, clapCount: Int) {
+        self.name = name
+        self.subtitle = subtitle
+        self.clapCount = clapCount
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/ClapListViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/ClapListViewControllable.swift
@@ -1,0 +1,35 @@
+//
+//  ClapListViewControllable.swift
+//  StampFeature
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import BaseFeatureDependency
+import Domain
+
+// MARK: - ViewControllable
+
+public protocol ClapListViewControllable: UIViewController & ClapListRoutingTrigger { }
+
+// MARK: - RoutingTrigger
+
+public protocol ClapListRoutingTrigger {
+    var onNaviBackTap: (() -> Void)? { get set }
+    var onCellTap: ((String?) -> Void)? { get set }
+}
+
+// MARK: - ViewModelType
+
+public typealias ClapListViewModelType = ViewModelType & ClapListRoutingTrigger
+
+// MARK: - Presentable
+
+public typealias ClapListPresentable = (
+    vc: any ClapListViewControllable,
+    vm: any ClapListViewModelType
+)

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
@@ -28,4 +28,5 @@ public protocol StampFeatureBuildable {
     func makeRankingVC(rankingViewType: RankingViewType) -> RankingPresentable
     func makePartRankingVC(rankingViewType: RankingViewType) -> PartRankingPresentable
     func makeStampGuideVC() -> StampGuideViewControllable
+    func makeClapListVC() -> ClapListPresentable
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
@@ -25,18 +25,19 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
     // MARK: - UI Components
 
     private let profileView = UIView().then {
+        //TODO: - 실제 이미지뷰로 변경해주세요.
         $0.backgroundColor = DSKitAsset.Colors.gray700.color
-        $0.layer.cornerRadius = 20
+        $0.layer.cornerRadius = 16
     }
 
     private let nameLabel = UILabel().then {
-        $0.font = .SoptampFont.h3
+        $0.font = .SoptampFont.subtitle1
         $0.textColor = DSKitAsset.Colors.white.color
     }
 
     private let subtitleLabel = UILabel().then {
-        $0.font = .SoptampFont.subtitle2
-        $0.textColor = DSKitAsset.Colors.gray400.color
+        $0.font = .SoptampFont.caption1
+        $0.textColor = DSKitAsset.Colors.gray200.color
         $0.lineBreakMode = .byTruncatingTail
     }
 
@@ -47,6 +48,7 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
     }
 
     private let clapIcon = UIImageView().then {
+        //TODO: - 실제 박수 icon으로 변경해주세요.
         $0.image = UIImage(systemName: "hand.wave.fill")
         $0.tintColor = DSKitAsset.Colors.white.color
         $0.contentMode = .scaleAspectFit
@@ -65,8 +67,7 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
     }
 
     private func setUI() {
-        contentView.backgroundColor = DSKitAsset.Colors.gray900.color
-        contentView.layer.cornerRadius = 12
+        contentView.backgroundColor = .clear
         contentView.clipsToBounds = true
     }
 
@@ -74,14 +75,14 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
         contentView.addSubviews(profileView, nameLabel, subtitleLabel, clapLabel, clapIcon)
 
         profileView.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(16)
+            $0.leading.equalToSuperview().offset(12)
             $0.centerY.equalToSuperview()
-            $0.size.equalTo(40)
+            $0.size.equalTo(32)
         }
 
         nameLabel.snp.makeConstraints {
             $0.leading.equalTo(profileView.snp.trailing).offset(12)
-            $0.top.equalToSuperview().offset(14)
+            $0.top.equalToSuperview().offset(8)
             $0.trailing.lessThanOrEqualTo(clapLabel.snp.leading).offset(-8)
         }
 
@@ -92,15 +93,15 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
             $0.bottom.equalToSuperview().offset(-14)
         }
 
-        clapLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(12)
+        clapIcon.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
         }
 
-        clapIcon.snp.makeConstraints {
-            $0.trailing.equalTo(clapLabel.snp.leading).offset(-4)
-            $0.centerY.equalTo(clapLabel)
-            $0.size.equalTo(18)
+        clapLabel.snp.makeConstraints {
+            $0.trailing.equalTo(clapIcon.snp.leading).offset(-6)
+            $0.centerY.equalToSuperview()
         }
     }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
@@ -20,7 +20,7 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
     // MARK: - Properties
 
     static var isFromNib: Bool = false
-    public var model: ClapListModel?
+    private var model: ClapListModel?
 
     // MARK: - UI Components
 
@@ -66,6 +66,16 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Configure
+
+    func setData(model: ClapListModel) {
+        nameLabel.text = model.name
+        subtitleLabel.text = model.subtitle
+        clapLabel.text = "\(model.clapCount)회"
+    }
+}
+
+extension ClapListCVC {
     private func setUI() {
         contentView.backgroundColor = .clear
         contentView.clipsToBounds = true
@@ -103,13 +113,5 @@ final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
             $0.trailing.equalTo(clapIcon.snp.leading).offset(-6)
             $0.centerY.equalToSuperview()
         }
-    }
-
-    // MARK: - Configure
-
-    func setData(model: ClapListModel) {
-        nameLabel.text = model.name
-        subtitleLabel.text = model.subtitle
-        clapLabel.text = "\(model.clapCount)회"
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/Cell/ClapListCVC.swift
@@ -1,0 +1,114 @@
+//
+//  ClapListCVC.swift
+//  StampFeature
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import Domain
+import DSKit
+
+// MARK: ClapListCVC
+
+final class ClapListCVC: UICollectionViewCell, UICollectionViewRegisterable {
+
+    // MARK: - Properties
+
+    static var isFromNib: Bool = false
+    public var model: ClapListModel?
+
+    // MARK: - UI Components
+
+    private let profileView = UIView().then {
+        $0.backgroundColor = DSKitAsset.Colors.gray700.color
+        $0.layer.cornerRadius = 20
+    }
+
+    private let nameLabel = UILabel().then {
+        $0.font = .SoptampFont.h3
+        $0.textColor = DSKitAsset.Colors.white.color
+    }
+
+    private let subtitleLabel = UILabel().then {
+        $0.font = .SoptampFont.subtitle2
+        $0.textColor = DSKitAsset.Colors.gray400.color
+        $0.lineBreakMode = .byTruncatingTail
+    }
+
+    private let clapLabel = UILabel().then {
+        $0.font = .SoptampFont.h3
+        $0.textColor = DSKitAsset.Colors.white.color
+        $0.textAlignment = .right
+    }
+
+    private let clapIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "hand.wave.fill")
+        $0.tintColor = DSKitAsset.Colors.white.color
+        $0.contentMode = .scaleAspectFit
+    }
+
+    // MARK: - View Life Cycles
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        contentView.backgroundColor = DSKitAsset.Colors.gray900.color
+        contentView.layer.cornerRadius = 12
+        contentView.clipsToBounds = true
+    }
+
+    private func setLayout() {
+        contentView.addSubviews(profileView, nameLabel, subtitleLabel, clapLabel, clapIcon)
+
+        profileView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(16)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(40)
+        }
+
+        nameLabel.snp.makeConstraints {
+            $0.leading.equalTo(profileView.snp.trailing).offset(12)
+            $0.top.equalToSuperview().offset(14)
+            $0.trailing.lessThanOrEqualTo(clapLabel.snp.leading).offset(-8)
+        }
+
+        subtitleLabel.snp.makeConstraints {
+            $0.leading.equalTo(nameLabel)
+            $0.top.equalTo(nameLabel.snp.bottom).offset(4)
+            $0.trailing.lessThanOrEqualTo(clapLabel.snp.leading).offset(-8)
+            $0.bottom.equalToSuperview().offset(-14)
+        }
+
+        clapLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(12)
+            $0.centerY.equalToSuperview()
+        }
+
+        clapIcon.snp.makeConstraints {
+            $0.trailing.equalTo(clapLabel.snp.leading).offset(-4)
+            $0.centerY.equalTo(clapLabel)
+            $0.size.equalTo(18)
+        }
+    }
+
+    // MARK: - Configure
+
+    func setData(model: ClapListModel) {
+        nameLabel.text = model.name
+        subtitleLabel.text = model.subtitle
+        clapLabel.text = "\(model.clapCount)회"
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
@@ -1,0 +1,52 @@
+//
+//  ClapListCompositionalLayout.swift
+//  StampFeature
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+extension ClapListViewController {
+
+    static let standardWidth = UIScreen.main.bounds.width - 40.adjusted
+
+    func createLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            switch ClapListSection.allCases[sectionIndex] {
+            case .main:
+                return self?.createClapListSection()
+            }
+        }
+    }
+
+    private func createClapListSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .estimated(72.adjustedH)
+        )
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(
+            widthDimension: .absolute(ClapListViewController.standardWidth),
+            heightDimension: .estimated(72.adjustedH)
+        )
+        let group = NSCollectionLayoutGroup.vertical(
+            layoutSize: groupSize,
+            subitems: [item]
+        )
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(
+            top: 0,
+            leading: 20.adjusted,
+            bottom: 0,
+            trailing: 20.adjusted
+        )
+        section.interGroupSpacing = 10.adjustedH
+        section.orthogonalScrollingBehavior = .none
+
+        return section
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension ClapListViewController {
+extension ClapListVC {
 
     static let standardWidth = UIScreen.main.bounds.width - 40.adjusted
 
@@ -29,7 +29,7 @@ extension ClapListViewController {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(ClapListViewController.standardWidth),
+            widthDimension: .absolute(ClapListVC.standardWidth),
             heightDimension: .estimated(72.adjustedH)
         )
         let group = NSCollectionLayoutGroup.vertical(

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/CollectionView/ClapListCompositionalLayout.swift
@@ -24,13 +24,13 @@ extension ClapListVC {
     private func createClapListSection() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .estimated(72.adjustedH)
+            heightDimension: .absolute(62.adjustedH)
         )
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
         let groupSize = NSCollectionLayoutSize(
-            widthDimension: .absolute(ClapListVC.standardWidth),
-            heightDimension: .estimated(72.adjustedH)
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .absolute(62.adjustedH)
         )
         let group = NSCollectionLayoutGroup.vertical(
             layoutSize: groupSize,
@@ -40,11 +40,11 @@ extension ClapListVC {
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
             top: 0,
-            leading: 20.adjusted,
+            leading: 0,
             bottom: 0,
-            trailing: 20.adjusted
+            trailing: 0
         )
-        section.interGroupSpacing = 10.adjustedH
+        section.interGroupSpacing = 12.adjustedH
         section.orthogonalScrollingBehavior = .none
 
         return section

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -20,7 +20,8 @@ final class ClapListViewController: UIViewController {
 
     // MARK: - Properties
 
-    private var cancelBag = Set<AnyCancellable>()
+    private var cancelBag = CancelBag()
+    private var viewModel: ClapListViewModel
     lazy var dataSource: UICollectionViewDiffableDataSource<ClapListSection, ClapListModel>! = nil
 
     // MARK: - ClapListCoordinatable
@@ -41,9 +42,10 @@ final class ClapListViewController: UIViewController {
     ).then {
         $0.backgroundColor = DSKitAsset.Colors.gray950.color
         $0.showsVerticalScrollIndicator = true
+        $0.delegate = self
     }
 
-    private let emptyView = UILabel().then {
+    private let clapListEmptyView = UILabel().then {
         $0.text = "아직 받은 박수가 없어요 👏"
         $0.textColor = DSKitAsset.Colors.gray400.color
         $0.font = .SoptampFont.subtitle1
@@ -59,11 +61,14 @@ final class ClapListViewController: UIViewController {
         self.setLayout()
         self.registerCells()
         self.setDataSource()
-        self.applyInitialSnapshot()
+        self.bindViews()
+        self.bindViewModel()
     }
 
-    // TODO: - init(viewModel:) 주입 예정
-    init() {
+    // MARK: - Init
+
+    init(viewModel: ClapListViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -82,7 +87,7 @@ extension ClapListViewController {
     }
 
     private func setLayout() {
-        view.addSubviews(naviBar, clapListCollectionView, emptyView)
+        view.addSubviews(naviBar, clapListCollectionView, clapListEmptyView)
 
         naviBar.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
@@ -93,9 +98,40 @@ extension ClapListViewController {
             $0.leading.trailing.bottom.equalToSuperview()
         }
 
-        emptyView.snp.makeConstraints {
+        clapListEmptyView.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
+    }
+}
+
+// MARK: - Bindings
+
+extension ClapListViewController {
+
+    private func bindViews() {
+        naviBar.leftButtonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onNaviBackTap?()
+            }
+            .store(in: cancelBag)
+    }
+
+    private func bindViewModel() {
+        let input = ClapListViewModel.Input(
+            viewDidLoad: Driver.just(()),
+            viewWillAppear: Driver.just(())
+        )
+
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+
+        output.$clapListModel
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] model in
+                self?.setCollectionView(model: model)
+            }
+            .store(in: cancelBag)
     }
 }
 
@@ -103,13 +139,6 @@ extension ClapListViewController {
 
 extension ClapListViewController {
 
-    // TODO: - bindView(), bindViewModel() 추후 구현
-    private func bindViews() {}
-    private func bindViewModel() {}
-
-}
-
-extension ClapListViewController {
     private func registerCells() {
         ClapListCVC.register(target: clapListCollectionView)
     }
@@ -129,18 +158,34 @@ extension ClapListViewController {
         }
     }
 
-    private func applyInitialSnapshot() {
-        let mock = [
-            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
-            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
-            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
-            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50)
-        ]
+    func setCollectionView(model: [ClapListModel]) {
+        if model.isEmpty {
+            self.clapListCollectionView.isHidden = true
+            self.clapListEmptyView.isHidden = false
+            self.setEmptyView()
+        } else {
+            self.clapListCollectionView.isHidden = false
+            self.clapListEmptyView.isHidden = true
+            self.applySnapshot(model: model)
+        }
+    }
 
+    private func setEmptyView() {
+        clapListEmptyView.snp.removeConstraints()
+        clapListEmptyView.removeFromSuperview()
+        self.view.addSubview(clapListEmptyView)
+        clapListEmptyView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalToSuperview()
+        }
+    }
+
+    private func applySnapshot(model: [ClapListModel]) {
         var snapshot = NSDiffableDataSourceSnapshot<ClapListSection, ClapListModel>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(mock)
+        snapshot.appendItems(model)
         dataSource.apply(snapshot, animatingDifferences: false)
+        self.view.setNeedsLayout()
     }
 }
 
@@ -153,6 +198,8 @@ enum ClapListSection: CaseIterable {
 // MARK: - UICollectionViewDelegate
 
 extension ClapListViewController: UICollectionViewDelegate {
-
-
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let model = dataSource.itemIdentifier(for: indexPath) else { return }
+        onCellTap?(model.name)
+    }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -31,16 +31,28 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
 
     // MARK: - UI Components
 
-    private lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
-        .setTitle("박수 목록")
-        .setTitleTypoStyle(.SoptampFont.h2)
-        .setRightButton(.none)
+    private let backButton = UIButton().then {
+        $0.setImage(DSKitAsset.Assets.chevronLeft.image, for: .normal)
+        $0.tintColor = DSKitAsset.Colors.white.color
+    }
+
+    private let titleLabel = UILabel().then {
+        $0.text = "박수 목록"
+        $0.font = .SoptampFont.h2
+        $0.textColor = DSKitAsset.Colors.white.color
+    }
+
+    private let containerView = UIView().then {
+        $0.backgroundColor = DSKitAsset.Colors.gray900.color
+        $0.layer.cornerRadius = 20
+        $0.clipsToBounds = true
+    }
 
     private lazy var clapListCollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: self.createLayout()
     ).then {
-        $0.backgroundColor = DSKitAsset.Colors.gray950.color
+        $0.backgroundColor = .clear
         $0.showsVerticalScrollIndicator = true
         $0.delegate = self
     }
@@ -82,20 +94,35 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
 extension ClapListVC {
 
     private func setUI() {
-        view.backgroundColor = DSKitAsset.Colors.gray950.color
+        view.backgroundColor = DSKitAsset.Colors.black.color.withAlphaComponent(0.8)
         navigationController?.isNavigationBarHidden = true
     }
 
     private func setLayout() {
-        view.addSubviews(naviBar, clapListCollectionView, clapListEmptyView)
+        view.addSubview(containerView)
+        containerView.addSubviews(backButton, titleLabel, clapListCollectionView, clapListEmptyView)
 
-        naviBar.snp.makeConstraints {
-            $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+        containerView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(164)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(32)
+        }
+
+        backButton.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.leading.equalToSuperview().inset(20)
+            $0.size.equalTo(24)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(backButton)
+            $0.leading.equalTo(backButton.snp.trailing).offset(12)
         }
 
         clapListCollectionView.snp.makeConstraints {
-            $0.top.equalTo(naviBar.snp.bottom).offset(12)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(backButton.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(8)
+            $0.bottom.equalToSuperview().inset(20)
         }
 
         clapListEmptyView.snp.makeConstraints {
@@ -109,12 +136,11 @@ extension ClapListVC {
 extension ClapListVC {
 
     private func bindViews() {
-        naviBar.leftButtonTapped
-            .withUnretained(self)
-            .sink { owner, _ in
-                owner.onNaviBackTap?()
-            }
-            .store(in: cancelBag)
+        backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+    }
+
+    @objc private func backButtonTapped() {
+        onNaviBackTap?()
     }
 
     private func bindViewModel() {
@@ -159,25 +185,7 @@ extension ClapListVC {
     }
 
     func setCollectionView(model: [ClapListModel]) {
-        if model.isEmpty {
-            self.clapListCollectionView.isHidden = true
-            self.clapListEmptyView.isHidden = false
-            self.setEmptyView()
-        } else {
-            self.clapListCollectionView.isHidden = false
-            self.clapListEmptyView.isHidden = true
-            self.applySnapshot(model: model)
-        }
-    }
-
-    private func setEmptyView() {
-        clapListEmptyView.snp.removeConstraints()
-        clapListEmptyView.removeFromSuperview()
-        self.view.addSubview(clapListEmptyView)
-        clapListEmptyView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-            make.width.equalToSuperview()
-        }
+        self.applySnapshot(model: model)
     }
 
     private func applySnapshot(model: [ClapListModel]) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -1,0 +1,158 @@
+//
+//  ClapListVC.swift
+//  StampFeature
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import Domain
+import DSKit
+
+import Combine
+import SnapKit
+import Then
+
+final class ClapListViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private var cancelBag = Set<AnyCancellable>()
+    lazy var dataSource: UICollectionViewDiffableDataSource<ClapListSection, ClapListModel>! = nil
+
+    // MARK: - ClapListCoordinatable
+
+    public var onNaviBackTap: (() -> Void)?
+    public var onCellTap: ((String?) -> Void)?
+
+    // MARK: - UI Components
+
+    private lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
+        .setTitle("박수 목록")
+        .setTitleTypoStyle(.SoptampFont.h2)
+        .setRightButton(.none)
+
+    private lazy var clapListCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: self.createLayout()
+    ).then {
+        $0.backgroundColor = DSKitAsset.Colors.gray950.color
+        $0.showsVerticalScrollIndicator = true
+    }
+
+    private let emptyView = UILabel().then {
+        $0.text = "아직 받은 박수가 없어요 👏"
+        $0.textColor = DSKitAsset.Colors.gray400.color
+        $0.font = .SoptampFont.subtitle1
+        $0.textAlignment = .center
+        $0.isHidden = true
+    }
+
+    // MARK: - Life Cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setUI()
+        self.setLayout()
+        self.registerCells()
+        self.setDataSource()
+        self.applyInitialSnapshot()
+    }
+
+    // TODO: - init(viewModel:) 주입 예정
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - UI & Layouts
+
+extension ClapListViewController {
+
+    private func setUI() {
+        view.backgroundColor = DSKitAsset.Colors.gray950.color
+        navigationController?.isNavigationBarHidden = true
+    }
+
+    private func setLayout() {
+        view.addSubviews(naviBar, clapListCollectionView, emptyView)
+
+        naviBar.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+        }
+
+        clapListCollectionView.snp.makeConstraints {
+            $0.top.equalTo(naviBar.snp.bottom).offset(12)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+
+        emptyView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - CollectionView
+
+extension ClapListViewController {
+
+    // TODO: - bindView(), bindViewModel() 추후 구현
+    private func bindViews() {}
+    private func bindViewModel() {}
+
+}
+
+extension ClapListViewController {
+    private func registerCells() {
+        ClapListCVC.register(target: clapListCollectionView)
+    }
+
+    private func setDataSource() {
+        dataSource = UICollectionViewDiffableDataSource(
+            collectionView: clapListCollectionView
+        ) { collectionView, indexPath, model in
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: ClapListCVC.className,
+                for: indexPath
+            ) as? ClapListCVC else {
+                return UICollectionViewCell()
+            }
+            cell.setData(model: model)
+            return cell
+        }
+    }
+
+    private func applyInitialSnapshot() {
+        let mock = [
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50)
+        ]
+
+        var snapshot = NSDiffableDataSourceSnapshot<ClapListSection, ClapListModel>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(mock)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+// MARK: - Section Enum
+
+enum ClapListSection: CaseIterable {
+    case main
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ClapListViewController: UICollectionViewDelegate {
+
+
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -16,7 +16,7 @@ import Combine
 import SnapKit
 import Then
 
-final class ClapListViewController: UIViewController {
+final class ClapListVC: UIViewController, ClapListViewControllable {
 
     // MARK: - Properties
 
@@ -79,7 +79,7 @@ final class ClapListViewController: UIViewController {
 
 // MARK: - UI & Layouts
 
-extension ClapListViewController {
+extension ClapListVC {
 
     private func setUI() {
         view.backgroundColor = DSKitAsset.Colors.gray950.color
@@ -106,7 +106,7 @@ extension ClapListViewController {
 
 // MARK: - Bindings
 
-extension ClapListViewController {
+extension ClapListVC {
 
     private func bindViews() {
         naviBar.leftButtonTapped
@@ -137,7 +137,7 @@ extension ClapListViewController {
 
 // MARK: - CollectionView
 
-extension ClapListViewController {
+extension ClapListVC {
 
     private func registerCells() {
         ClapListCVC.register(target: clapListCollectionView)
@@ -197,7 +197,7 @@ enum ClapListSection: CaseIterable {
 
 // MARK: - UICollectionViewDelegate
 
-extension ClapListViewController: UICollectionViewDelegate {
+extension ClapListVC: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let model = dataSource.itemIdentifier(for: indexPath) else { return }
         onCellTap?(model.name)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -32,7 +32,7 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
     // MARK: - UI Components
 
     private let backButton = UIButton().then {
-        $0.setImage(DSKitAsset.Assets.chevronLeft.image, for: .normal)
+        $0.setImage(DSKitAsset.Assets.arrowLeft.image, for: .normal)
         $0.tintColor = DSKitAsset.Colors.white.color
     }
 
@@ -55,14 +55,6 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
         $0.backgroundColor = .clear
         $0.showsVerticalScrollIndicator = true
         $0.delegate = self
-    }
-
-    private let clapListEmptyView = UILabel().then {
-        $0.text = "아직 받은 박수가 없어요 👏"
-        $0.textColor = DSKitAsset.Colors.gray400.color
-        $0.font = .SoptampFont.subtitle1
-        $0.textAlignment = .center
-        $0.isHidden = true
     }
 
     // MARK: - Life Cycle
@@ -100,7 +92,7 @@ extension ClapListVC {
 
     private func setLayout() {
         view.addSubview(containerView)
-        containerView.addSubviews(backButton, titleLabel, clapListCollectionView, clapListEmptyView)
+        containerView.addSubviews(backButton, titleLabel, clapListCollectionView)
 
         containerView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(164)
@@ -121,12 +113,8 @@ extension ClapListVC {
 
         clapListCollectionView.snp.makeConstraints {
             $0.top.equalTo(backButton.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(8)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().inset(20)
-        }
-
-        clapListEmptyView.snp.makeConstraints {
-            $0.center.equalToSuperview()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -37,7 +37,7 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
     }
 
     private let titleLabel = UILabel().then {
-        $0.text = "박수 목록"
+        $0.text = I18N.MyPage.SoptampSection.clapList
         $0.font = .SoptampFont.h2
         $0.textColor = DSKitAsset.Colors.white.color
     }
@@ -96,7 +96,7 @@ extension ClapListVC {
 
         containerView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(164)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(16)
             $0.bottom.equalToSuperview().inset(32)
         }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Combine
-import Foundation
 
 import Core
 import Domain
@@ -40,7 +39,6 @@ final class ClapListViewModel: ClapListViewModelType {
 }
 
 extension ClapListViewModel {
-
     func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
@@ -7,3 +7,66 @@
 //
 
 import Foundation
+import Combine
+import Foundation
+
+import Core
+import Domain
+import BaseFeatureDependency
+
+final class ClapListViewModel {
+
+    // MARK: - Triggers
+    var onNaviBackTap: (() -> Void)?
+    var onCellTap: ((String?) -> Void)?
+
+    // MARK: - Properties
+    private var cancelBag = CancelBag()
+
+    // MARK: - Input
+
+    struct Input {
+        let viewDidLoad: Driver<Void>
+        let viewWillAppear: Driver<Void>
+    }
+
+    // MARK: - Output
+    final class Output: NSObject {
+        @Published var clapListModel: [ClapListModel]?
+    }
+
+    // MARK: - Init
+    init() {}
+}
+
+extension ClapListViewModel {
+
+    func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        let output = Output()
+
+        input.viewDidLoad
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.loadDummyData(to: output)
+            }.store(in: cancelBag)
+
+        input.viewWillAppear
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.loadDummyData(to: output)
+            }.store(in: cancelBag)
+
+        return output
+    }
+
+    private func loadDummyData(to output: Output) {
+        let dummyData = [
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50),
+            ClapListModel(name: "서버황혜린", subtitle: "최대글자수최대글자수최대글자수", clapCount: 50)
+        ]
+        output.clapListModel = dummyData
+    }
+}
+

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  ClapListViewModel.swift
+//  StampFeature
+//
+//  Created by 성현주 on 10/22/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/ViewModel/ClapListViewModel.swift
@@ -14,7 +14,7 @@ import Core
 import Domain
 import BaseFeatureDependency
 
-final class ClapListViewModel {
+final class ClapListViewModel: ClapListViewModelType {
 
     // MARK: - Triggers
     var onNaviBackTap: (() -> Void)?

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -18,7 +18,7 @@ final class StampBuilder {
     @Injected public var missionListRepository: MissionListRepositoryInterface
     @Injected public var rankingRepository: RankingRepositoryInterface
     @Injected public var listDetailRepository: ListDetailRepositoryInterface
-    
+
     public init() { }
 }
 
@@ -29,7 +29,7 @@ extension StampBuilder: StampFeatureBuildable {
         let missionListVC = MissionListVC(viewModel: viewModel)
         return (missionListVC, viewModel)
     }
-    
+
     public func makeListDetailVC(
         sceneType: ListDetailSceneType,
         starLevel: StarViewLevel,
@@ -49,7 +49,7 @@ extension StampBuilder: StampFeatureBuildable {
         let listDetailVC = ListDetailVC(viewModel: viewModel)
         return (listDetailVC, viewModel)
     }
-    
+
     public func makeMissionCompletedVC(
         starLevel: StarViewLevel,
         completionHandler: (() -> Void)?
@@ -61,7 +61,7 @@ extension StampBuilder: StampFeatureBuildable {
         missionCompletedVC.modalTransitionStyle = .crossDissolve
         return missionCompletedVC
     }
-    
+
     public func makeRankingVC(rankingViewType: RankingViewType) -> RankingPresentable {
         let useCase = DefaultRankingUseCase(repository: rankingRepository)
         let viewModel = RankingViewModel(
@@ -72,7 +72,7 @@ extension StampBuilder: StampFeatureBuildable {
         rankingVC.viewModel = viewModel
         return (rankingVC, viewModel)
     }
-    
+
     public func makePartRankingVC(rankingViewType: RankingViewType) -> PartRankingPresentable {
         let useCase = DefaultRankingUseCase(repository: rankingRepository)
         let viewModel = PartRankingViewModel(rankingViewType: rankingViewType, useCase: useCase)
@@ -80,9 +80,18 @@ extension StampBuilder: StampFeatureBuildable {
         partRankingVC.viewModel = viewModel
         return (partRankingVC, viewModel)
     }
-    
+
     public func makeStampGuideVC() -> any StampGuideViewControllable {
         let stampGuideVC = StampGuideVC()
         return stampGuideVC
+    }
+
+    public func makeClapListVC() -> ClapListPresentable {
+        let viewModel = ClapListViewModel()
+        let clapListVC = ClapListVC(viewModel: viewModel)
+        return (
+            clapListVC as any ClapListViewControllable,
+            viewModel as any ClapListViewModelType
+        )
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -52,6 +52,7 @@ public final class StampCoordinator: BaseCoordinator {
         
         missionList.vc.onGuideTap = { [weak self] in
             guard let self else { return }
+            //self.showGuide()
             //TODO: - view 연결이후 제거
             self.showClapList()
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -52,7 +52,8 @@ public final class StampCoordinator: BaseCoordinator {
         
         missionList.vc.onGuideTap = { [weak self] in
             guard let self else { return }
-            self.showGuide()
+            //TODO: - view 연결이후 제거
+            self.showClapList()
         }
         
         missionList.vc.onPartRankingButtonTap = { [weak self] rankingViewType in
@@ -199,5 +200,27 @@ extension StampCoordinator {
         }
         
         rootController?.pushViewController(otherMissionList.vc, animated: true)
+    }
+}
+
+// MARK: - ClapListFlow
+
+extension StampCoordinator {
+    public func showClapList() {
+        var clapList = factory.makeClapListVC()
+
+        clapList.vc.onNaviBackTap = { [weak self] in
+            guard let self else { return }
+            self.rootController?.popViewController(animated: true)
+        }
+
+        clapList.vc.onCellTap = { [weak self] username in
+            guard let self else { return }
+            
+            // TODO: - 추후 프로필 상세 화면 연결
+            print("\(username ?? "unknown")의 프로필 탭됨")
+        }
+
+        self.rootController?.pushViewController(clapList.vc, animated: true)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
박수 리스트뷰를 구현했습니다.

🌱 작업한 브랜치
- feature/#789

## 🌱 PR Point
- 기존 코드 컨벤션을 최대한 지키면서 구현할려고 했습니다. 혹시라도 틀린 부분이 있다면 이야기해주세요.
- 컬렉션뷰를 활용해 리스트뷰를 구현했습니다.
- ViewController, ViewModel까지 구현했습니다.
- coordinator관련 로직도 구현완료되어 있습니다. stampCoordinator내에서, showClapList() 이 함수로 호출 가능합니다.
- 셀을 클릭했을때, 해당 인원 프로필로 이동하는 로직이 필요해 닉네임을 전달해주는 콜백을 구현해뒀습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 피그마 폰트와, 프로젝트 타이포가 일치하지 않는 부분이 있어서(pretendard vs suit) 이부분은 디자이너 쌤들과 논의 해보겠습니다
- 솝템프 리스트뷰가 present형식으로 올라와 모달을 호출했을때는 사라지는 이슈가 있습니다. 실제 구현시에는 push된 뷰에서 호출예정이기때문에 자연스레 고쳐질것 같습니다!
### 추후 변경해야되는 부분 (TODO)
- 테스트를 위해 스탬프 가이드로 이동하는 코드에 임의로 claplist가 띄워지게 해뒀습니다. 뷰 연결이후 변경해주세요!
- 뷰모델의 더미함수를 실제 api 통신함수로 변경해야됩니다.
- 박수 아이콘을 실제 아이콘으로 변경해야됩니다. (이전 뷰에서 아이콘을 추가해두신거 같아 중복위험때문에 추가하지 않았습니다)


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|박수리스트|![Simulator Screen Recording - iPhone 17 Pro - 2025-10-22 at 16 43 16](https://github.com/user-attachments/assets/601777e1-017a-4c8f-b35d-93fa6e69e89b)|


## 📮 관련 이슈
- Resolved: #789
(이슈 번호 789라서 키보드에서 이슈번호 엄청 빨리 칠수 있어요 ㅎㅎ)
