### PR TITLE
[Feat] #741 - clap API 연결

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -39,7 +39,12 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
       return Fail(error: NSError()).eraseToAnyPublisher()
     }
     return stampService.fetchStampListDetail(missionId: missionId, username: username)
-      .map { $0.toDomain() }
+          .map {
+              let result = $0.toDomain()
+              print("stamp result: \(result.viewCount)")
+              
+              return result
+          }
       .eraseToAnyPublisher()
   }
   

--- a/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -39,12 +39,7 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
       return Fail(error: NSError()).eraseToAnyPublisher()
     }
     return stampService.fetchStampListDetail(missionId: missionId, username: username)
-          .map {
-              let result = $0.toDomain()
-              print("stamp result: \(result.viewCount)")
-              
-              return result
-          }
+          .map { $0.toDomain() }
       .eraseToAnyPublisher()
   }
   

--- a/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -71,4 +71,10 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
       .map { $0 == 200 }
       .asDriver()
   }
+    
+  public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountModel, Error> {
+      return stampService.clap(stampId: stampId, clapCount: clapCount)
+          .map{ $0.toDomain() }
+          .eraseToAnyPublisher()
+  }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/ClapTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/ClapTransform.swift
@@ -1,0 +1,21 @@
+//
+//  ClapTransform.swift
+//  Data
+//
+//  Created by 최주리 on 10/23/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Networks
+import Domain
+
+public extension ClapCountEntity {
+    func toDomain() -> ClapCountModel {
+        return .init(
+            stapmId: stapmId,
+            appliedCount: appliedCount,
+            totalClapCount: totalClapCount
+        )
+  }
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/ClapTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/ClapTransform.swift
@@ -13,7 +13,7 @@ import Domain
 public extension ClapCountEntity {
     func toDomain() -> ClapCountModel {
         return .init(
-            stapmId: stapmId,
+            stampId: stampId,
             appliedCount: appliedCount,
             totalClapCount: totalClapCount
         )

--- a/SOPT-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
@@ -18,7 +18,10 @@ extension ListDetailEntity {
       content: self.contents,
       date: self.updatedAt ?? self.createdAt,
       stampId: self.id,
-      activityDate: self.activityDate
+      activityDate: self.activityDate,
+      clapCount: self.clapCount,
+      myClapCount: self.myClapCount,
+      viewCount: self.viewCount
     )
   }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/ListDetailTransform.swift
@@ -21,7 +21,8 @@ extension ListDetailEntity {
       activityDate: self.activityDate,
       clapCount: self.clapCount,
       myClapCount: self.myClapCount,
-      viewCount: self.viewCount
+      viewCount: self.viewCount,
+      isMine: self.mine
     )
   }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ClapCountModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ClapCountModel.swift
@@ -1,0 +1,21 @@
+//
+//  ClapCountModel.swift
+//  Domain
+//
+//  Created by 최주리 on 10/23/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct ClapCountModel {
+    public let stapmId: Int
+    public let appliedCount: Int
+    public let totalClapCount: Int
+    
+    public init(stapmId: Int, appliedCount: Int, totalClapCount: Int) {
+        self.stapmId = stapmId
+        self.appliedCount = appliedCount
+        self.totalClapCount = totalClapCount
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ClapCountModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ClapCountModel.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 public struct ClapCountModel {
-    public let stapmId: Int
+    public let stampId: Int
     public let appliedCount: Int
     public let totalClapCount: Int
     
-    public init(stapmId: Int, appliedCount: Int, totalClapCount: Int) {
-        self.stapmId = stapmId
+    public init(stampId: Int, appliedCount: Int, totalClapCount: Int) {
+        self.stampId = stampId
         self.appliedCount = appliedCount
         self.totalClapCount = totalClapCount
     }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
@@ -17,6 +17,7 @@ public struct ListDetailModel {
   public let clapCount: Int
   public let myClapCount: Int?
   public let viewCount: Int
+  public let isMine: Bool?
   
   public init(
     image: String,
@@ -26,7 +27,8 @@ public struct ListDetailModel {
     activityDate: String,
     clapCount: Int,
     myClapCount: Int?,
-    viewCount: Int
+    viewCount: Int,
+    isMine: Bool?
   ) {
     self.image = image
     self.content = content
@@ -36,5 +38,6 @@ public struct ListDetailModel {
     self.clapCount = clapCount
     self.myClapCount = myClapCount
     self.viewCount = viewCount
+    self.isMine = isMine
   }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
@@ -14,18 +14,27 @@ public struct ListDetailModel {
   public let date: String
   public let stampId: Int
   public let activityDate: String
+  public let clapCount: Int
+  public let myClapCount: Int
+  public let viewCount: Int
   
   public init(
     image: String,
     content: String,
     date: String,
     stampId: Int,
-    activityDate: String
+    activityDate: String,
+    clapCount: Int,
+    myClapCount: Int,
+    viewCount: Int
   ) {
     self.image = image
     self.content = content
     self.date = date
     self.stampId = stampId
     self.activityDate = activityDate
+    self.clapCount = clapCount
+    self.myClapCount = myClapCount
+    self.viewCount = viewCount
   }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
@@ -15,7 +15,7 @@ public struct ListDetailModel {
   public let stampId: Int
   public let activityDate: String
   public let clapCount: Int
-  public let myClapCount: Int
+  public let myClapCount: Int?
   public let viewCount: Int
   
   public init(
@@ -25,7 +25,7 @@ public struct ListDetailModel {
     stampId: Int,
     activityDate: String,
     clapCount: Int,
-    myClapCount: Int,
+    myClapCount: Int?,
     viewCount: Int
   ) {
     self.image = image

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
@@ -12,10 +12,11 @@ import Combine
 import Foundation
 
 public protocol ListDetailRepositoryInterface {
-  func fetchListDetail(missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error>
-  func getPresignedURL() -> AnyPublisher<PresignedUrlModel, Error>
-  func uploadMedia(imageData: Data, presignedUrl: String) -> AnyPublisher<Void, Error>
-  func postStamp(stampData: ListDetailRequestModel) -> AnyPublisher<ListDetailModel, Error>
-  func putStamp(stampData: ListDetailRequestModel) -> Driver<Int>
-  func deleteStamp(stampId: Int) -> Driver<Bool>
+    func fetchListDetail(missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error>
+    func getPresignedURL() -> AnyPublisher<PresignedUrlModel, Error>
+    func uploadMedia(imageData: Data, presignedUrl: String) -> AnyPublisher<Void, Error>
+    func postStamp(stampData: ListDetailRequestModel) -> AnyPublisher<ListDetailModel, Error>
+    func putStamp(stampData: ListDetailRequestModel) -> Driver<Int>
+    func deleteStamp(stampId: Int) -> Driver<Bool>
+    func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountModel, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -90,7 +90,8 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
                     activityDate: "",
                     clapCount: 0,
                     myClapCount: 0,
-                    viewCount: 0
+                    viewCount: 0,
+                    isMine: false
                 )
             )
             .withUnretained(self)

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -124,7 +124,7 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
         repository.clap(stampId: stampId, clapCount: clapCount)
             .replaceError(
                 with: ClapCountModel(
-                    stapmId: 0,
+                    stampId: 0,
                     appliedCount: 0,
                     totalClapCount: 0
                 )

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -12,104 +12,124 @@ import Combine
 import Foundation
 
 public protocol ListDetailUseCase {
-  func fetchListDetail(missionId: Int, username: String?)
-  func postStamp(stampData: ListDetailRequestModel)
-  func putStamp(stampData: ListDetailRequestModel)
-  func getPresignedURL()
-  func uploadMedia(imageData: Data, presignedUrl: String)
-  func deleteStamp(stampId: Int)
-  
-  var listDetailModel: PassthroughSubject<ListDetailModel, Error> { get set }
-  var mediaUploadCompleted: PassthroughSubject<Void, Error> { get set }
-  var presignedURL: PassthroughSubject<PresignedUrlModel, Error> { get set }
-  var editSuccess: PassthroughSubject<Bool, Error> { get set }
-  var deleteSuccess: PassthroughSubject<Bool, Error> { get set }
+    func fetchListDetail(missionId: Int, username: String?)
+    func postStamp(stampData: ListDetailRequestModel)
+    func putStamp(stampData: ListDetailRequestModel)
+    func getPresignedURL()
+    func uploadMedia(imageData: Data, presignedUrl: String)
+    func deleteStamp(stampId: Int)
+    func clap(stampId: Int, clapCount: Int)
+    
+    var listDetailModel: PassthroughSubject<ListDetailModel, Error> { get set }
+    var mediaUploadCompleted: PassthroughSubject<Void, Error> { get set }
+    var presignedURL: PassthroughSubject<PresignedUrlModel, Error> { get set }
+    var editSuccess: PassthroughSubject<Bool, Error> { get set }
+    var deleteSuccess: PassthroughSubject<Bool, Error> { get set }
+    var clapSuccess: PassthroughSubject<ClapCountModel, Error> { get set }
 }
 
 public class DefaultListDetailUseCase {
-  
-  private let repository: ListDetailRepositoryInterface
-  private var cancelBag = CancelBag()
-  
-  public var listDetailModel = PassthroughSubject<ListDetailModel, Error>()
-  public var presignedURL = PassthroughSubject<PresignedUrlModel, Error>()
-  public var mediaUploadCompleted = PassthroughSubject<Void, Error>()
-  public var editSuccess = PassthroughSubject<Bool, Error>()
-  public var deleteSuccess = PassthroughSubject<Bool, Error>()
-  
-  public init(repository: ListDetailRepositoryInterface) {
-    self.repository = repository
-  }
+    
+    private let repository: ListDetailRepositoryInterface
+    private var cancelBag = CancelBag()
+    
+    public var listDetailModel = PassthroughSubject<ListDetailModel, Error>()
+    public var presignedURL = PassthroughSubject<PresignedUrlModel, Error>()
+    public var mediaUploadCompleted = PassthroughSubject<Void, Error>()
+    public var editSuccess = PassthroughSubject<Bool, Error>()
+    public var deleteSuccess = PassthroughSubject<Bool, Error>()
+    public var clapSuccess = PassthroughSubject<ClapCountModel, Error>()
+    
+    public init(repository: ListDetailRepositoryInterface) {
+        self.repository = repository
+    }
 }
 
 extension DefaultListDetailUseCase: ListDetailUseCase {
-  public func fetchListDetail(missionId: Int, username: String?) {
-    repository.fetchListDetail(missionId: missionId, username: username)
-      .withUnretained(self)
-      .sink(receiveCompletion: { event in
-        print("completion: \(event)")
-      }, receiveValue: { owner, model in
-          owner.listDetailModel.send(model)
-      })
-      .store(in: self.cancelBag)
-  }
-  
-  public func getPresignedURL() {
-    self.repository.getPresignedURL()
-      .withUnretained(self)
-      .sink(receiveCompletion: {
-        print("completion: \($0)")
-      }, receiveValue: { owner, presignedModel in
-        owner.presignedURL.send(presignedModel)
-      }).store(in: self.cancelBag)
-  }
-
-  public func uploadMedia(imageData: Data, presignedUrl: String) {
-    self.repository
-      .uploadMedia(imageData: imageData, presignedUrl: presignedUrl)
-      .withUnretained(self)
-      .sink(receiveCompletion: {
-        print("completion: \($0)")
-      }, receiveValue: { owner, _ in
-        owner.mediaUploadCompleted.send(())
-          print("receivedValue: \(owner)")
-      }).store(in: self.cancelBag)
-  }
-  
-  public func postStamp(stampData: ListDetailRequestModel) {
-    repository.postStamp(stampData: stampData)
-      .replaceError(
-        with: ListDetailModel(
-          image: "",
-          content: "",
-          date: "",
-          stampId: 0,
-          activityDate: ""
-        )
-      )
-      .withUnretained(self)
-      .sink { event in
-        print("completion: \(event)")
-      } receiveValue: { owner, model in
-          owner.listDetailModel.send(model)
-      }.store(in: self.cancelBag)
-  }
-  
-  public func putStamp(stampData: ListDetailRequestModel) {
-    repository.putStamp(stampData: stampData)
-      .replaceError(with: -1)
-      .withUnretained(self)
-      .sink { owner, result in
-        owner.editSuccess.send(result == -1 ? false: true)
-      }.store(in: self.cancelBag)
-  }
-  
-  public func deleteStamp(stampId: Int) {
-    repository.deleteStamp(stampId: stampId)
-      .replaceError(with: false)
-      .withUnretained(self)
-      .sink { owner, success in
-        owner.deleteSuccess.send(success)
-      }.store(in: self.cancelBag)
-  }
+    public func fetchListDetail(missionId: Int, username: String?) {
+        repository.fetchListDetail(missionId: missionId, username: username)
+            .withUnretained(self)
+            .sink(receiveCompletion: { event in
+                print("completion: \(event)")
+            }, receiveValue: { owner, model in
+                owner.listDetailModel.send(model)
+            })
+            .store(in: self.cancelBag)
+    }
+    
+    public func getPresignedURL() {
+        self.repository.getPresignedURL()
+            .withUnretained(self)
+            .sink(receiveCompletion: {
+                print("completion: \($0)")
+            }, receiveValue: { owner, presignedModel in
+                owner.presignedURL.send(presignedModel)
+            }).store(in: self.cancelBag)
+    }
+    
+    public func uploadMedia(imageData: Data, presignedUrl: String) {
+        self.repository
+            .uploadMedia(imageData: imageData, presignedUrl: presignedUrl)
+            .withUnretained(self)
+            .sink(receiveCompletion: {
+                print("completion: \($0)")
+            }, receiveValue: { owner, _ in
+                owner.mediaUploadCompleted.send(())
+                print("receivedValue: \(owner)")
+            }).store(in: self.cancelBag)
+    }
+    
+    public func postStamp(stampData: ListDetailRequestModel) {
+        repository.postStamp(stampData: stampData)
+            .replaceError(
+                with: ListDetailModel(
+                    image: "",
+                    content: "",
+                    date: "",
+                    stampId: 0,
+                    activityDate: ""
+                )
+            )
+            .withUnretained(self)
+            .sink { event in
+                print("completion: \(event)")
+            } receiveValue: { owner, model in
+                owner.listDetailModel.send(model)
+            }.store(in: self.cancelBag)
+    }
+    
+    public func putStamp(stampData: ListDetailRequestModel) {
+        repository.putStamp(stampData: stampData)
+            .replaceError(with: -1)
+            .withUnretained(self)
+            .sink { owner, result in
+                owner.editSuccess.send(result == -1 ? false: true)
+            }.store(in: self.cancelBag)
+    }
+    
+    public func deleteStamp(stampId: Int) {
+        repository.deleteStamp(stampId: stampId)
+            .replaceError(with: false)
+            .withUnretained(self)
+            .sink { owner, success in
+                owner.deleteSuccess.send(success)
+            }.store(in: self.cancelBag)
+    }
+    
+    public func clap(stampId: Int, clapCount: Int) {
+        repository.clap(stampId: stampId, clapCount: clapCount)
+            .replaceError(
+                with: ClapCountModel(
+                    stapmId: 0,
+                    appliedCount: 0,
+                    totalClapCount: 0
+                )
+            )
+            .withUnretained(self)
+            .sink { event in
+                print("completion: \(event)")
+            } receiveValue: { owner, model in
+                owner.clapSuccess.send(model)
+            }.store(in: self.cancelBag)
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -87,7 +87,10 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
                     content: "",
                     date: "",
                     stampId: 0,
-                    activityDate: ""
+                    activityDate: "",
+                    clapCount: 0,
+                    myClapCount: 0,
+                    viewCount: 0
                 )
             )
             .withUnretained(self)

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/ListDetailPresentable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/ListDetailPresentable.swift
@@ -19,6 +19,7 @@ public protocol ListDetailViewControllable: UIViewController & ListDetailRouting
 public protocol ListDetailRoutingTrigger {
   var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)? { get set }
   var onNaviBackTap: (() -> Void)? { get set }
+  var onViewClapTap: (() -> Void)? { get set }
 }
 public typealias ListDetailViewModelType = ViewModelType & ListDetailRoutingTrigger
 public typealias ListDetailPresentable = (vc: ListDetailViewControllable, vm: any ListDetailViewModelType)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -52,9 +52,7 @@ public final class StampCoordinator: BaseCoordinator {
         
         missionList.vc.onGuideTap = { [weak self] in
             guard let self else { return }
-            //self.showGuide()
-            //TODO: - view 연결이후 제거
-            self.showClapList()
+            self.showGuide()
         }
         
         missionList.vc.onPartRankingButtonTap = { [weak self] rankingViewType in
@@ -120,6 +118,11 @@ extension StampCoordinator {
         missionDetail.vc.onNaviBackTap = { [weak self] in
             guard let self else { return }
             self.rootController?.popViewController(animated: true)
+        }
+        
+        missionDetail.vc.onViewClapTap = { [weak self] in
+            guard let self else { return }
+            self.showClapList()
         }
         
         rootController?.pushViewController(missionDetail.vc, animated: true)
@@ -212,7 +215,7 @@ extension StampCoordinator {
 
         clapList.vc.onNaviBackTap = { [weak self] in
             guard let self else { return }
-            self.rootController?.popViewController(animated: true)
+            self.rootController?.dismiss(animated: true )
         }
 
         clapList.vc.onCellTap = { [weak self] username in
@@ -222,6 +225,6 @@ extension StampCoordinator {
             print("\(username ?? "unknown")의 프로필 탭됨")
         }
 
-        self.rootController?.pushViewController(clapList.vc, animated: true)
+        self.rootController?.topViewController?.present(clapList.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -425,12 +425,10 @@ extension ListDetailVC {
         
         setClapCount(total: totalClapCount + 1, mine: myClapCount + 1)
         
-        // TODO: 이미 올라와있으면 안내려가게
-        
         let transformY = self.clapBadge.transform.ty
         let isVisible = self.clapBadge.alpha > 0.9
         
-        // 올라가고 잇는 상태
+        // 올라가고 있는 상태
         if transformY < 0 && isVisible && isAnimating {
             return
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -66,6 +66,7 @@ public class ListDetailVC: UIViewController, LegacyListDetailViewControllable, L
     
     public var onNaviBackTap: (() -> Void)?
     public var onComplete: ((StarViewLevel, (() -> Void)?) -> Void)?
+    public var onViewClapTap: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -146,6 +147,13 @@ extension ListDetailVC {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onNaviBackTap?()
+            }.store(in: cancelBag)
+        
+        viewClapButton
+            .publisher(for: .touchUpInside)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.onViewClapTap?()
             }.store(in: cancelBag)
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -50,8 +50,10 @@ public class ListDetailVC: UIViewController, LegacyListDetailViewControllable, L
     }
     private var originImage: UIImage = UIImage()
     private var originText: String = ""
-    private let deleteButtonTapped = PassthroughSubject<Bool, Never>()
+    private var totalClapCount: Int = 0
+    private var myClapCount: Int = 0
     
+    private let deleteButtonTapped = PassthroughSubject<Bool, Never>()
     private let imageSelected = PassthroughSubject<Data, Never>()
     private let dateSelected = PassthroughSubject<String, Never>()
     private let textEdited = PassthroughSubject<String, Never>()
@@ -144,14 +146,6 @@ extension ListDetailVC {
             .sink { owner, _ in
                 owner.onNaviBackTap?()
             }.store(in: cancelBag)
-        
-        // TODO: debounce 적용
-        clapButton
-            .publisher(for: .touchUpInside)
-            .withUnretained(self)
-            .sink { owner, _ in
-                owner.clap()
-            }.store(in: cancelBag)
     }
     
     private func bindViewModels() {
@@ -174,6 +168,17 @@ extension ListDetailVC {
             .mapVoid()
             .asDriver()
         
+        let clapButtonTapped = clapButton
+            .publisher(for: .touchUpInside)
+            .withUnretained(self)
+            .map { owner, _ in
+                owner.clap()
+                return 1
+            }
+            .scan(0) { count, new in count + new }
+            .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .asDriver()
+        
         let input = ListDetailViewModel.Input(
             viewDidLoad: Driver.just(()),
             imageSelected: self.imageSelected.eraseToAnyPublisher(),
@@ -181,7 +186,9 @@ extension ListDetailVC {
             textEdited: textEdited.asDriver(),
             bottomButtonTapped: bottomButtonTapped,
             rightButtonTapped: rightButtonTapped,
-            deleteButtonTapped: deleteButtonTapped.asDriver())
+            deleteButtonTapped: deleteButtonTapped.asDriver(),
+            clapButtonTapped: clapButtonTapped
+        )
         
         let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
@@ -251,6 +258,17 @@ extension ListDetailVC {
             .sink { owner, isLoading in
                 isLoading ? owner.showLoading() : owner.stopLoading()
             }.store(in: cancelBag)
+        
+        output.clapSuccessed
+            .withUnretained(self)
+            .sink { owner, result in
+                switch result {
+                case .success(let model):
+                    owner.setClapCount(total: model.totalClapCount, mine: model.appliedCount)
+                case .failure:
+                    owner.setClapCount(total: owner.viewModel.totalClapCount, mine: owner.viewModel.myClapCount)
+                }
+            }.store(in: cancelBag)
     }
     
     private func setData(_ model: ListDetailModel) {
@@ -264,6 +282,7 @@ extension ListDetailVC {
 
         self.missionDateTextField.setTextFieldView(.inactive)
         self.textView.text = model.content
+        self.missionInfoView.setFullText(date: model.activityDate, clapCount: model.clapCount, viewCount: model.viewCount)
     }
     
     private func reloadData(_ scenetype: ListDetailSceneType) {
@@ -381,8 +400,11 @@ extension ListDetailVC {
             self.backgroundDimmerView.alpha = 1
         }
     }
-
+    
     private func clap() {
+        setClapCount(total: totalClapCount + 1, mine: myClapCount + 1)
+        
+        // TODO: 이미 올라와있으면 안내려가게
         UIView.animate(withDuration: 0.4, animations: {
             self.clapBadge.transform = CGAffineTransform(translationX: 0, y: -38)
         }) { _ in
@@ -393,6 +415,15 @@ extension ListDetailVC {
                 self.clapBadge.alpha = 1
             }
         }
+    }
+    
+    private func setClapCount(total: Int, mine: Int) {
+        totalClapCount = total
+        myClapCount = mine
+        
+        clapButton.setCount(totalClapCount)
+        clapBadge.setCount(myClapCount)
+        missionInfoView.setClapText(clapCount: totalClapCount)
     }
     
     // MARK: - @objc
@@ -549,14 +580,10 @@ extension ListDetailVC {
             self.originImage = self.missionImageView.image ?? UIImage()
             self.bottomButton.changeTitle(attributedString: I18N.ListDetail.editComplete)
                 .setEnabled(false)
-            self.missionDateTextField.isHidden = false
-            self.viewClapButton.isHidden = true
         } else {
             self.naviBar.resetLeftButtonAction()
             self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
             self.bottomButton.changeTitle(attributedString: I18N.ListDetail.missionComplete)
-            self.missionDateTextField.isHidden = true
-            self.viewClapButton.isHidden = false
         }
         
         switch type {
@@ -567,6 +594,8 @@ extension ListDetailVC {
             self.bottomButton.isHidden = false
             self.missionInfoView.isHidden = true
             self.zoomInView.isHidden = true
+            self.viewClapButton.isHidden = true
+            self.missionDateTextField.isHidden = false
         case .completed:
             self.scrollView.setContentOffset(.zero, animated: true)
             self.naviBar.setRightButton(.addRecord)
@@ -577,13 +606,21 @@ extension ListDetailVC {
             self.missionDateTextField.setTextFieldView(.completed)
             self.missionInfoView.isHidden = false
             self.zoomInView.isHidden = false
+            self.viewClapButton.isHidden = false
+            self.missionDateTextField.isHidden = true
         }
         
         if viewModel.isOtherUser {
             self.naviBar.hideRightButton()
             self.naviBar.setTitle(viewModel.otherUserName)
+            
+            setOtherUserLayout()
+            clapButton.setCount(self.totalClapCount)
         } else {
             self.naviBar.setTitle(I18N.ListDetail.myMission)
+            
+            setMineLayout()
+            clapBadge.setCount(self.myClapCount)
         }
     }
     
@@ -627,6 +664,9 @@ extension ListDetailVC {
         self.zoomImageView.layer.cornerRadius = 10
         self.zoomImageView.clipsToBounds = true
         self.zoomImageView.contentMode = .scaleAspectFit
+        
+        self.clapButton.setCount(self.totalClapCount)
+        self.clapBadge.setCount(self.myClapCount)
     }
     
     private func setTextView(_ state: TextViewState) {
@@ -738,15 +778,12 @@ extension ListDetailVC {
         contentStackView.snp.makeConstraints { make in
             make.leading.top.trailing.equalToSuperview()
         }
-
-        if viewModel.isOtherUser {
-            setOtherUserLayout()
-        } else {
-            setMineLayout()
-        }
     }
     
     private func setOtherUserLayout() {
+        bottomButton.removeFromSuperview()
+        viewClapButton.removeFromSuperview()
+        
         contentView.addSubviews(clapBadge, clapButton)
         clapButton.snp.makeConstraints {
             $0.top.equalTo(contentStackView.snp.bottom).offset(12)
@@ -762,6 +799,9 @@ extension ListDetailVC {
     }
     
     private func setMineLayout() {
+        clapButton.removeFromSuperview()
+        clapBadge.removeFromSuperview()
+        
         contentView.addSubviews(bottomButton, viewClapButton)
         bottomButton.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -181,6 +181,7 @@ extension ListDetailVC {
             .publisher(for: .touchUpInside)
             .withUnretained(self)
             .map { owner, _ in
+                guard owner.myClapCount < 50 else { return 0 }
                 owner.clap()
                 return 1
             }
@@ -274,9 +275,12 @@ extension ListDetailVC {
                 switch result {
                 case .success(let model):
                     owner.totalClapCount = model.totalClapCount
+                    owner.myClapCount = owner.viewModel.myClapCount
                     owner.setClapCount(total: owner.totalClapCount, mine: owner.myClapCount)
                 case .failure:
-                    owner.setClapCount(total: owner.viewModel.totalClapCount, mine: owner.viewModel.myClapCount)
+                    owner.totalClapCount = owner.viewModel.totalClapCount
+                    owner.myClapCount = owner.viewModel.myClapCount
+                    owner.setClapCount(total: owner.totalClapCount, mine: owner.myClapCount)
                 }
             }.store(in: cancelBag)
     }
@@ -418,10 +422,6 @@ extension ListDetailVC {
     }
     
     private func clap() {
-        if myClapCount >= 50 {
-            return
-        }
-        
         setClapCount(total: totalClapCount + 1, mine: myClapCount + 1)
         
         let transformY = self.clapBadge.transform.ty

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -274,7 +274,6 @@ extension ListDetailVC {
                 switch result {
                 case .success(let model):
                     owner.totalClapCount = model.totalClapCount
-                    owner.myClapCount = model.appliedCount
                     owner.setClapCount(total: owner.totalClapCount, mine: owner.myClapCount)
                 case .failure:
                     owner.setClapCount(total: owner.viewModel.totalClapCount, mine: owner.viewModel.myClapCount)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -264,7 +264,9 @@ extension ListDetailVC {
             .sink { owner, result in
                 switch result {
                 case .success(let model):
-                    owner.setClapCount(total: model.totalClapCount, mine: model.appliedCount)
+                    owner.totalClapCount = model.totalClapCount
+                    owner.myClapCount = model.appliedCount
+                    owner.setClapCount(total: owner.totalClapCount, mine: owner.myClapCount)
                 case .failure:
                     owner.setClapCount(total: owner.viewModel.totalClapCount, mine: owner.viewModel.myClapCount)
                 }
@@ -283,6 +285,12 @@ extension ListDetailVC {
         self.missionDateTextField.setTextFieldView(.inactive)
         self.textView.text = model.content
         self.missionInfoView.setFullText(date: model.activityDate, clapCount: model.clapCount, viewCount: model.viewCount)
+        
+        self.totalClapCount = model.clapCount
+        self.myClapCount = model.myClapCount ?? 0
+        
+        self.clapButton.setCount(self.totalClapCount)
+        self.clapBadge.setCount(self.myClapCount)
     }
     
     private func reloadData(_ scenetype: ListDetailSceneType) {
@@ -402,6 +410,10 @@ extension ListDetailVC {
     }
     
     private func clap() {
+        if myClapCount >= 50 {
+            return
+        }
+        
         setClapCount(total: totalClapCount + 1, mine: myClapCount + 1)
         
         // TODO: 이미 올라와있으면 안내려가게
@@ -615,12 +627,10 @@ extension ListDetailVC {
             self.naviBar.setTitle(viewModel.otherUserName)
             
             setOtherUserLayout()
-            clapButton.setCount(self.totalClapCount)
         } else {
             self.naviBar.setTitle(I18N.ListDetail.myMission)
             
             setMineLayout()
-            clapBadge.setCount(self.myClapCount)
         }
     }
     
@@ -664,9 +674,6 @@ extension ListDetailVC {
         self.zoomImageView.layer.cornerRadius = 10
         self.zoomImageView.clipsToBounds = true
         self.zoomImageView.contentMode = .scaleAspectFit
-        
-        self.clapButton.setCount(self.totalClapCount)
-        self.clapBadge.setCount(self.myClapCount)
     }
     
     private func setTextView(_ state: TextViewState) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -52,6 +52,7 @@ public class ListDetailVC: UIViewController, LegacyListDetailViewControllable, L
     private var originText: String = ""
     private var totalClapCount: Int = 0
     private var myClapCount: Int = 0
+    private var isAnimating: Bool = false
     
     private let deleteButtonTapped = PassthroughSubject<Bool, Never>()
     private let imageSelected = PassthroughSubject<Data, Never>()
@@ -417,6 +418,24 @@ extension ListDetailVC {
         setClapCount(total: totalClapCount + 1, mine: myClapCount + 1)
         
         // TODO: 이미 올라와있으면 안내려가게
+        
+        let transformY = self.clapBadge.transform.ty
+        let isVisible = self.clapBadge.alpha > 0.9
+        
+        // 올라가고 잇는 상태
+        if transformY < 0 && isVisible && isAnimating {
+            return
+        }
+        
+        // 사라지는 중
+        if !isVisible {
+            self.clapBadge.layer.removeAllAnimations()
+            self.clapBadge.alpha = 1
+            self.clapBadge.transform = CGAffineTransform(translationX: 0, y: -38)
+        }
+        
+        isAnimating = true
+        
         UIView.animate(withDuration: 0.4, animations: {
             self.clapBadge.transform = CGAffineTransform(translationX: 0, y: -38)
         }) { _ in
@@ -425,8 +444,10 @@ extension ListDetailVC {
             }) { _ in
                 self.clapBadge.transform = .identity
                 self.clapBadge.alpha = 1
+                self.isAnimating = false
             }
         }
+        
     }
     
     private func setClapCount(total: Int, mine: Int) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
@@ -24,18 +24,16 @@ final class ClapButton: UIButton {
 }
 
 extension ClapButton {
-    func setEnabled(_ isEnabled: Bool) {
-        self.isEnabled = isEnabled
-    }
-    
     func setCount(_ count: Int) {
-        self.setAttributedTitle(
-            NSAttributedString(
-                string: String(count),
-                attributes: [.font: DSKitFontFamily.Suit.bold.font(size: 20), .foregroundColor: UIColor.white]
-            ),
-            for: .normal
+        let attributedString = NSAttributedString(
+            string: String(count),
+            attributes: [
+                .font: DSKitFontFamily.Suit.bold.font(size: 20),
+                .foregroundColor: UIColor.white
+            ]
         )
+        
+        self.setAttributedTitle(attributedString, for: .normal)
     }
 }
 
@@ -44,9 +42,10 @@ extension ClapButton {
 extension ClapButton {
     private func setUI() {
         let attributedString = NSAttributedString(
-            string: "999",
+            string: "0",
             attributes: [.font: DSKitFontFamily.Suit.bold.font(size: 20), .foregroundColor: UIColor.white]
         )
+        self.setAttributedTitle(attributedString, for: .normal)
         
         var config = UIButton.Configuration.bordered()
         config.image = DSKitAsset.Assets.icClap.image.withRenderingMode(.alwaysTemplate)
@@ -63,19 +62,18 @@ extension ClapButton {
         config.background.strokeWidth = 1
         config.background.strokeColor = DSKitAsset.Colors.gray700.color
         config.background.backgroundColor = DSKitAsset.Colors.gray900.color
-        config.attributedTitle = AttributedString(attributedString)
         config.cornerStyle = .capsule
         
         self.configuration = config
-        self.configurationUpdateHandler = { [weak self] button in
-            guard let self else { return }
-            
-            if self.isSelected {
-                config.background.backgroundColor = DSKitAsset.Colors.gray800.color
-            } else {
-                config.background.backgroundColor = DSKitAsset.Colors.gray900.color
-            }
-            self.configuration = config
-        }
+        //        self.configurationUpdateHandler = { button in
+        //            var updateConfig = button.configuration
+        //
+        //            if button.isSelected {
+        //                updateConfig?.background.backgroundColor = DSKitAsset.Colors.gray800.color
+        //            } else {
+        //                updateConfig?.background.backgroundColor = DSKitAsset.Colors.gray900.color
+        //            }
+        //            button.configuration = config
+        //        }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
@@ -46,34 +46,33 @@ extension ClapButton {
             attributes: [.font: DSKitFontFamily.Suit.bold.font(size: 20), .foregroundColor: UIColor.white]
         )
         self.setAttributedTitle(attributedString, for: .normal)
-        
-        var config = UIButton.Configuration.bordered()
-        config.image = DSKitAsset.Assets.icClap.image.withRenderingMode(.alwaysTemplate)
-        config.imageColorTransformer = UIConfigurationColorTransformer { _ in
-            if self.isEnabled {
-                DSKitAsset.Colors.white.color
-            } else {
-                DSKitAsset.Colors.gray400.color
+
+        self.configuration = UIButton.Configuration.bordered()
+        self.configurationUpdateHandler = { button in
+            guard var configuration = button.configuration else { return }
+            
+            configuration.image = DSKitAsset.Assets.icClap.image.withRenderingMode(.alwaysTemplate)
+            configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in
+                if self.isEnabled {
+                    DSKitAsset.Colors.white.color
+                } else {
+                    DSKitAsset.Colors.gray400.color
+                }
             }
+            configuration.imagePadding = 8
+            configuration.cornerStyle = .capsule
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 18, bottom: 12, trailing: 18)
+            
+            configuration.background.cornerRadius = 20
+            configuration.background.strokeWidth = 1
+            configuration.background.strokeColor = DSKitAsset.Colors.gray700.color
+            if button.isHighlighted {
+                configuration.baseBackgroundColor = DSKitAsset.Colors.gray800.color
+            } else {
+                configuration.baseBackgroundColor = DSKitAsset.Colors.gray900.color
+            }
+
+            button.configuration = configuration
         }
-        config.imagePadding = 8
-        config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 18, bottom: 12, trailing: 18)
-        config.background.cornerRadius = 20
-        config.background.strokeWidth = 1
-        config.background.strokeColor = DSKitAsset.Colors.gray700.color
-        config.background.backgroundColor = DSKitAsset.Colors.gray900.color
-        config.cornerStyle = .capsule
-        
-        self.configuration = config
-        //        self.configurationUpdateHandler = { button in
-        //            var updateConfig = button.configuration
-        //
-        //            if button.isSelected {
-        //                updateConfig?.background.backgroundColor = DSKitAsset.Colors.gray800.color
-        //            } else {
-        //                updateConfig?.background.backgroundColor = DSKitAsset.Colors.gray900.color
-        //            }
-        //            button.configuration = config
-        //        }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapButton.swift
@@ -53,7 +53,7 @@ extension ClapButton {
             
             configuration.image = DSKitAsset.Assets.icClap.image.withRenderingMode(.alwaysTemplate)
             configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in
-                if self.isEnabled {
+                if button.isEnabled {
                     DSKitAsset.Colors.white.color
                 } else {
                     DSKitAsset.Colors.gray400.color

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapCountBadge.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ClapCountBadge.swift
@@ -30,6 +30,12 @@ final class ClapCountBadge: UIView {
     }
 }
 
+extension ClapCountBadge {
+    func setCount(_ count: Int) {
+        countLabel.text = "+\(count)"
+    }
+}
+
 // MARK: - UI & Layout
 
 extension ClapCountBadge {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/MissionInfoView.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/MissionInfoView.swift
@@ -27,18 +27,9 @@ final class MissionInfoView: UIView {
         $0.image = DSKitAsset.Assets.icCommunicationEye.image
     }
 
-    // TODO: text 삭제
-    private let dateLabel = UILabel().then {
-        $0.text = "2025.12.12"
-    }
-    
-    private let clapCountLabel = UILabel().then {
-        $0.text = "999"
-    }
-    
-    private let viewCountLabel = UILabel().then {
-        $0.text = "212"
-    }
+    private let dateLabel = UILabel()
+    private let clapCountLabel = UILabel()
+    private let viewCountLabel = UILabel()
     
     // MARK: - Private Variables
     private var cancelBag = CancelBag()

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -233,7 +233,6 @@ extension ListDetailViewModel {
         let listDetailModel = useCase.listDetailModel
         let editSuccess = useCase.editSuccess
         let deleteSuccess = useCase.deleteSuccess
-        let clapSuccess = useCase.clapSuccess
         
         listDetailModel.asDriver()
             .withUnretained(self)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -32,9 +32,9 @@ public class ListDetailViewModel: ListDetailViewModelType {
     public var isOtherUser: Bool
     public var otherUserName: String!
     
-    // TODO: 스탬프 조회 API 변경 후 init에 넣기
     var totalClapCount: Int = 0
-    var myClapCount: Int?
+    var myClapCount: Int = 0
+    var viewcount: Int = 0
     
     private var uploadedUrl: String?
     
@@ -212,6 +212,7 @@ extension ListDetailViewModel {
                     let isImageSelected = owner.isImageSelected(currentImage)
                     let isDateChanged = owner.isDateChanged(output.listDetailModel?.activityDate, currentDate)
                     let isTextChanged = owner.isTextChanged(output.listDetailModel?.content, currentText)
+                    print("isImageSelected: \(isImageSelected)\nisDateChanged: \(isDateChanged)\nisTextChanged\(isTextChanged)")
                     return isImageSelected || isDateChanged || isTextChanged
                 default:
                     let isImageSelected = !currentImage.isEmpty
@@ -239,6 +240,9 @@ extension ListDetailViewModel {
             .compactMap { owner, model in
                 owner.stampId = model.stampId
                 owner.uploadedUrl = model.image
+                owner.totalClapCount = model.clapCount
+                owner.myClapCount = model.myClapCount
+                owner.viewcount = model.viewCount
                 return model
             }
             .assign(to: \.self.listDetailModel, on: output)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -23,6 +23,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
     
     private let useCase: ListDetailUseCase
     private var cancelBag = CancelBag()
+    
     public var sceneType: ListDetailSceneType!
     public var starLevel: StarViewLevel!
     public var missionId: Int!
@@ -30,6 +31,10 @@ public class ListDetailViewModel: ListDetailViewModelType {
     public var stampId: Int!
     public var isOtherUser: Bool
     public var otherUserName: String!
+    
+    // TODO: 스탬프 조회 API 변경 후 init에 넣기
+    var totalClapCount: Int = 0
+    var myClapCount: Int?
     
     private var uploadedUrl: String?
     
@@ -47,6 +52,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
         let bottomButtonTapped: Driver<Void>
         let rightButtonTapped: Driver<ListDetailSceneType>
         let deleteButtonTapped: Driver<Bool>
+        let clapButtonTapped: Driver<Int>
     }
     
     // MARK: - Outputs
@@ -58,6 +64,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
         var deleteSuccessed = PassthroughSubject<Bool, Never>()
         var bottomButtonEnabled = PassthroughSubject<Bool, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
+        var clapSuccessed = PassthroughSubject<Result<ClapCountModel, Error>, Never>()
     }
     
     // MARK: - init
@@ -184,6 +191,12 @@ extension ListDetailViewModel {
             .sink { owner, date in
                 owner.currentDate.send(date)
             }.store(in: cancelBag)
+        
+        input.clapButtonTapped
+            .withUnretained(self)
+            .sink { owner, count in
+                owner.useCase.clap(stampId: owner.stampId, clapCount: count)
+            }.store(in: cancelBag)
 
         // 버튼 활성화 로직
         Publishers.CombineLatest3(currentImage, currentDate, currentText)
@@ -219,6 +232,7 @@ extension ListDetailViewModel {
         let listDetailModel = useCase.listDetailModel
         let editSuccess = useCase.editSuccess
         let deleteSuccess = useCase.deleteSuccess
+        let clapSuccess = useCase.clapSuccess
         
         listDetailModel.asDriver()
             .withUnretained(self)
@@ -241,6 +255,13 @@ extension ListDetailViewModel {
             .sink { owner, success in
                 output.deleteSuccessed.send(success)
             }.store(in: self.cancelBag)
+        
+        clapSuccess.asDriver()
+            .withUnretained(self)
+            .sink { owner, model in
+                output.clapSuccessed.send(.success(model))
+            }.store(in: cancelBag)
+            
     }
 }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -261,13 +261,6 @@ extension ListDetailViewModel {
             .sink { owner, success in
                 output.deleteSuccessed.send(success)
             }.store(in: self.cancelBag)
-        
-        clapSuccess.asDriver()
-            .withUnretained(self)
-            .sink { owner, model in
-                output.clapSuccessed.send(.success(model))
-            }.store(in: cancelBag)
-            
     }
 }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -18,6 +18,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
     // TODO: coordinating vc -> vm
     public var onComplete: ((Core.StarViewLevel, (() -> Void)?) -> Void)?
     public var onNaviBackTap: (() -> Void)?
+    public var onViewClapTap: (() -> Void)?
     
     // MARK: - Properties
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -242,7 +242,9 @@ extension ListDetailViewModel {
                 owner.totalClapCount = model.clapCount
                 owner.myClapCount = model.myClapCount ?? 0
                 owner.viewcount = model.viewCount
-                print("viewCount: \(owner.viewcount)")
+                if let mine = model.isMine {
+                    owner.isOtherUser = !mine
+                }
                 return model
             }
             .assign(to: \.self.listDetailModel, on: output)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -212,7 +212,6 @@ extension ListDetailViewModel {
                     let isImageSelected = owner.isImageSelected(currentImage)
                     let isDateChanged = owner.isDateChanged(output.listDetailModel?.activityDate, currentDate)
                     let isTextChanged = owner.isTextChanged(output.listDetailModel?.content, currentText)
-                    print("isImageSelected: \(isImageSelected)\nisDateChanged: \(isDateChanged)\nisTextChanged\(isTextChanged)")
                     return isImageSelected || isDateChanged || isTextChanged
                 default:
                     let isImageSelected = !currentImage.isEmpty
@@ -241,8 +240,9 @@ extension ListDetailViewModel {
                 owner.stampId = model.stampId
                 owner.uploadedUrl = model.image
                 owner.totalClapCount = model.clapCount
-                owner.myClapCount = model.myClapCount
+                owner.myClapCount = model.myClapCount ?? 0
                 owner.viewcount = model.viewCount
+                print("viewCount: \(owner.viewcount)")
                 return model
             }
             .assign(to: \.self.listDetailModel, on: output)

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/StampAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/StampAPI.swift
@@ -19,6 +19,7 @@ public enum StampAPI {
   case deleteStamp(stampId: Int)
   case resetStamp
   case getReportUrl
+  case clap(stampId: Int, clapCount: Int)
 }
 
 extension StampAPI: BaseAPI {
@@ -38,13 +39,15 @@ extension StampAPI: BaseAPI {
       return "/all"
     case .getReportUrl:
       return "/report"
+    case .clap(let stampId, _):
+      return "/\(stampId)/clap"
     }
   }
   
   // MARK: - Method
   public var method: Moya.Method {
     switch self {
-    case .postStamp:
+    case .postStamp, .clap:
       return .post
     case .putStamp:
       return .put
@@ -66,6 +69,8 @@ extension StampAPI: BaseAPI {
       params["image"] = requestModel.imgURL
       params["contents"] = requestModel.content
       params["activityDate"] = requestModel.activityDate
+    case .clap(_, let clapCount):
+        params["clapCount"] = clapCount
     default: break
     }
     return params

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/StampAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/StampAPI.swift
@@ -87,7 +87,7 @@ extension StampAPI: BaseAPI {
   
   public var task: Task {
     switch self {
-    case .fetchStampListDetail, .postStamp, .putStamp:
+    case .fetchStampListDetail, .postStamp, .putStamp, .clap:
       return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
     default:
       return .requestPlain

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ClapCountEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ClapCountEntity.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct ClapCountEntity: Decodable {
-    public let stapmId: Int
+    public let stampId: Int
     public let appliedCount: Int
     public let totalClapCount: Int
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ClapCountEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ClapCountEntity.swift
@@ -1,0 +1,15 @@
+//
+//  ClapCountEntity.swift
+//  Networks
+//
+//  Created by 최주리 on 10/23/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct ClapCountEntity: Decodable {
+    public let stapmId: Int
+    public let appliedCount: Int
+    public let totalClapCount: Int
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ListDetailEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ListDetailEntity.swift
@@ -17,9 +17,9 @@ public struct ListDetailEntity: Codable {
   public let missionID: Int
   public let activityDate: String
   public let clapCount: Int
-  public let myClapCount: Int
+  public let myClapCount: Int?
   public let viewCount: Int
-  public let mine: Bool
+  public let mine: Bool?
   
   enum CodingKeys: String, CodingKey {
     case createdAt, updatedAt, id, contents, images, activityDate, clapCount, myClapCount, viewCount, mine, missionID = "missionId"
@@ -34,9 +34,9 @@ public struct ListDetailEntity: Codable {
     missionID: Int,
     activityDate: String,
     clapCount: Int,
-    myClapCount: Int,
+    myClapCount: Int?,
     viewCount: Int,
-    mine: Bool
+    mine: Bool?
   ) {
     self.createdAt = createdAt
     self.updatedAt = updatedAt

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ListDetailEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ListDetailEntity.swift
@@ -16,9 +16,13 @@ public struct ListDetailEntity: Codable {
   public let images: [String]
   public let missionID: Int
   public let activityDate: String
+  public let clapCount: Int
+  public let myClapCount: Int
+  public let viewCount: Int
+  public let mine: Bool
   
   enum CodingKeys: String, CodingKey {
-    case createdAt, updatedAt, id, contents, images, activityDate, missionID = "missionId"
+    case createdAt, updatedAt, id, contents, images, activityDate, clapCount, myClapCount, viewCount, mine, missionID = "missionId"
   }
   
   public init(
@@ -28,7 +32,11 @@ public struct ListDetailEntity: Codable {
     contents: String,
     images: [String],
     missionID: Int,
-    activityDate: String
+    activityDate: String,
+    clapCount: Int,
+    myClapCount: Int,
+    viewCount: Int,
+    mine: Bool
   ) {
     self.createdAt = createdAt
     self.updatedAt = updatedAt
@@ -37,6 +45,10 @@ public struct ListDetailEntity: Codable {
     self.images = images
     self.missionID = missionID
     self.activityDate = activityDate
+    self.clapCount = clapCount
+    self.myClapCount = myClapCount
+    self.viewCount = viewCount
+    self.mine = mine
   }
 }
 

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/StampService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/StampService.swift
@@ -55,7 +55,7 @@ extension DefaultStampService: StampService {
         try await requestObjectAsync(.getReportUrl)
     }
     
-    public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountEntity, any Error> {
+    public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountEntity, Error> {
         return requestObjectInCombine(.clap(stampId: stampId, clapCount: clapCount))
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/StampService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/StampService.swift
@@ -21,6 +21,7 @@ public protocol StampService {
     func deleteStamp(stampId: Int) -> AnyPublisher<Int, Error>
     func resetStamp() -> AnyPublisher<Int, Error>
     func getReportUrl() -> AnyPublisher<SoptampReportUrlEntity, Error>
+    func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountEntity, Error>
     
     func getReportURLAsync() async throws -> SoptampReportUrlEntity
 }
@@ -52,5 +53,9 @@ extension DefaultStampService: StampService {
     
     public func getReportURLAsync() async throws -> SoptampReportUrlEntity {
         try await requestObjectAsync(.getReportUrl)
+    }
+    
+    public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountEntity, any Error> {
+        return requestObjectInCombine(.clap(stampId: stampId, clapCount: clapCount))
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- 박수치기 API 연결했습니다
- 박수 관련 변동된 API 수정했습니다 (스탬프 조회, 등록)
- 현주가 만들어준 박수친 사람 목록 네비게이션 연결했습니다.

🌱 작업한 브랜치
- feature/#741

## 🌱 PR Point
`ListDtailVC`
- VC에서 debounce처리를 통해 연속으로 탭했을 경우, 마지막 탭으로부터 1초 후에 VM의 네트워크 통신을 거치도록 했고, View에서 박수 숫자는 실시간으로 늘어나야하기 때문에 view에서 clap()을 통해 실시간 반영했습니다.
- output을 통해 박수치기 네트워크 통신이 성공했는지 여부를 받아서 성공했을 경우 서버에서 받아온 값으로 교체하고, 실패한 경우 롤백하도록 하여 네트워크로 인한 UI 딜레이를 줄였습니다.
```swift
let clapButtonTapped = clapButton
            .publisher(for: .touchUpInside)
            .withUnretained(self)
            .map { owner, _ in
                owner.clap()
                return 1
            }
            .scan(0) { count, new in count + new }
            .debounce(for: .seconds(1), scheduler: RunLoop.main)
            .asDriver()

output.clapSuccessed
            .withUnretained(self)
            .sink { owner, result in
                switch result {
                case .success(let model):
                    owner.totalClapCount = model.totalClapCount
                    owner.myClapCount = model.appliedCount
                    owner.setClapCount(total: owner.totalClapCount, mine: owner.myClapCount)
                case .failure:
                    owner.setClapCount(total: owner.viewModel.totalClapCount, mine: owner.viewModel.myClapCount)
                }
            }.store(in: cancelBag)
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|![Simulator Screen Recording - iPhone 16 Pro - 2025-10-25 at 15 59 54](https://github.com/user-attachments/assets/8e05242b-335e-4071-909c-28952ffe5ea2)|

## 📮 관련 이슈
- Resolved: #741 
