### PR TITLE
[Feat] #736 - SOPTWKView header에 user-agent 설정 추가

### DIFF
--- a/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
@@ -61,6 +61,7 @@ public final class SOPTWebView: UIViewController, SOPTWebViewControllable {
         
         self.webView = WKWebView(frame: .zero, configuration: configuration).then {
             $0.allowsBackForwardNavigationGestures = config.allowsBackForwardNavigationGestures
+            $0.customUserAgent = "SOPT-iOS"
         }
         self.downloadManager = downloadManager
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
## 🌴 PR 요약
웹뷰 헤더에 user-agent를 추가했습니다.

🌱 작업한 브랜치
- feature/#736

## 🌱 PR Point
생략

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
웹뷰 진입 시 특정 뷰에서 내비게이션이 중복되는 이슈가 있었는데요, 플그 웹에서 iOS만 따로 분기처리를 해주신다고 합니다.
iOS 유저인지 판별하기 위해 User-Agent를 추가했어요. ([관련 스레드](https://sopt-makers.slack.com/archives/C041WU3BMD4/p1760964719281979))

<img width="360" height="445" alt="image" src="https://github.com/user-attachments/assets/47b7df78-6bd4-4b77-81d2-2b81eb8f8c8f" />


## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #736
