### PR TITLE
[Fix] #754 - SOPTWKView 쿠키 도메인 값 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Extension/Foundation+/URL+.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Extension/Foundation+/URL+.swift
@@ -10,4 +10,12 @@ public extension URL {
             return URL(string: encodedString)
         }
     }
+    
+    var rootDomain: String? {
+        guard let host = self.host() else { return nil }
+        let components = host.components(separatedBy: ".")
+        
+        guard components.count >= 2 else { return nil }
+        return components.suffix(2).joined(separator: ".")
+    }
 }

--- a/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
+++ b/SOPT-iOS/Projects/Features/WebFeature/Sources/SOPTWebView.swift
@@ -48,7 +48,7 @@ public final class SOPTWebView: UIViewController, SOPTWebViewControllable {
             if !self.barrier,
                let refreshToken = UserDefaultKeyList.CoreAuth.refreshToken,
                let cookie = HTTPCookie(properties: [
-                HTTPCookiePropertyKey.domain: url.host() ?? "",
+                HTTPCookiePropertyKey.domain: "." + (url.rootDomain ?? "sopt.org"),
                 HTTPCookiePropertyKey.name: "Refresh-Token",
                 HTTPCookiePropertyKey.path: "/",
                 HTTPCookiePropertyKey.value: refreshToken,


### PR DESCRIPTION
## 🌴 PR 요약
SOPTWKView의 쿠키 도메인 값을 수정했습니다.

🌱 작업한 브랜치
- feature/#754

## 🌱 PR Point
플랫폼 BE에서 사용하는 쿠키 도메인 값과 iOS의 도메인 값이 일치하지 않아 해당 부분 수정했습니다.

**AS-IS**
- `http://서브도메인.루트도메인/path/query` 에서 url.host()로 도메인 값을 넘겨줌

**TO-BE**
- 서브도메인은 dev와 prod 환경에 따라 다르기 때문에 rootDomain을 추출하는 계산 프로퍼티 추가

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- rootDomain 앞에 .은 플랫폼 BE 형식을 따랐습니다.

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #754
