### PR TITLE
[Fix] #756 - clap 실패했을 때 로직 처리 정상화

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -72,11 +72,13 @@ extension ListDetailRepository: ListDetailRepositoryInterface {
             .asDriver()
     }
 
-    public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountModel, Error> {
+    public func clap(stampId: Int, clapCount: Int) -> AnyPublisher<Result<ClapCountModel, Error>, Never> {
         return stampService.clap(stampId: stampId, clapCount: clapCount)
-            .map{ $0.toDomain() }
+            .map{ .success($0.toDomain()) }
+            .catch{ Just(.failure($0)) }
             .eraseToAnyPublisher()
     }
+    
     public func getClapList(stampId: Int, nickname: String) -> AnyPublisher<[ClapperModel], Error> {
         return stampService.getClapList(stampId: stampId, nickname: nickname)
             .map { $0.map { $0.toDomain() } }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
@@ -18,6 +18,6 @@ public protocol ListDetailRepositoryInterface {
     func postStamp(stampData: ListDetailRequestModel) -> AnyPublisher<ListDetailModel, Error>
     func putStamp(stampData: ListDetailRequestModel) -> Driver<Int>
     func deleteStamp(stampId: Int) -> Driver<Bool>
-    func clap(stampId: Int, clapCount: Int) -> AnyPublisher<ClapCountModel, Error>
+    func clap(stampId: Int, clapCount: Int) -> AnyPublisher<Result<ClapCountModel, Error>, Never>
     func getClapList(stampId: Int, nickname: String) -> AnyPublisher<[ClapperModel], Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -26,7 +26,7 @@ public protocol ListDetailUseCase {
     var presignedURL: PassthroughSubject<PresignedUrlModel, Error> { get set }
     var editSuccess: PassthroughSubject<Bool, Error> { get set }
     var deleteSuccess: PassthroughSubject<Bool, Error> { get set }
-    var clapSuccess: PassthroughSubject<ClapCountModel, Error> { get set }
+    var clapResult: PassthroughSubject<Result<ClapCountModel, Error>, Never> { get set }
     var clapListModel: PassthroughSubject<[ClapperModel], Error> { get set }
 }
 
@@ -40,7 +40,7 @@ public class DefaultListDetailUseCase {
     public var mediaUploadCompleted = PassthroughSubject<Void, Error>()
     public var editSuccess = PassthroughSubject<Bool, Error>()
     public var deleteSuccess = PassthroughSubject<Bool, Error>()
-    public var clapSuccess = PassthroughSubject<ClapCountModel, Error>()
+    public var clapResult = PassthroughSubject<Result<ClapCountModel, Error>, Never>()
     public var clapListModel = PassthroughSubject<[ClapperModel], Error>()
 
     public init(repository: ListDetailRepositoryInterface) {
@@ -125,19 +125,16 @@ extension DefaultListDetailUseCase: ListDetailUseCase {
 
     public func clap(stampId: Int, clapCount: Int) {
         repository.clap(stampId: stampId, clapCount: clapCount)
-            .replaceError(
-                with: ClapCountModel(
-                    stampId: 0,
-                    appliedCount: 0,
-                    totalClapCount: 0
-                )
-            )
             .withUnretained(self)
-            .sink { event in
-                print("completion: \(event)")
-            } receiveValue: { owner, model in
-                owner.clapSuccess.send(model)
+            .sink { owner, result in
+                switch result {
+                case .success(let model):
+                    owner.clapResult.send(.success(model))
+                case .failure(let error):
+                    owner.clapResult.send(.failure(error))
+                }
             }.store(in: self.cancelBag)
+            
     }
 
     public func getClapList(stampId: Int, nickname: String) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -273,7 +273,7 @@ extension ListDetailVC {
                 isLoading ? owner.showLoading() : owner.stopLoading()
             }.store(in: cancelBag)
         
-        output.clapSuccessed
+        output.clapResult
             .withUnretained(self)
             .sink { owner, result in
                 switch result {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -65,7 +65,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
         var deleteSuccessed = PassthroughSubject<Bool, Never>()
         var bottomButtonEnabled = PassthroughSubject<Bool, Never>()
         let isLoading = PassthroughSubject<Bool, Never>()
-        var clapSuccessed = PassthroughSubject<Result<ClapCountModel, Error>, Never>()
+        var clapResult = PassthroughSubject<Result<ClapCountModel, Error>, Never>()
     }
     
     // MARK: - init
@@ -255,6 +255,7 @@ extension ListDetailViewModel {
         let listDetailModel = useCase.listDetailModel
         let editSuccess = useCase.editSuccess
         let deleteSuccess = useCase.deleteSuccess
+        let clapResult = useCase.clapResult
         
         listDetailModel.asDriver()
             .withUnretained(self)
@@ -282,6 +283,12 @@ extension ListDetailViewModel {
             .withUnretained(self)
             .sink { owner, success in
                 output.deleteSuccessed.send(success)
+            }.store(in: self.cancelBag)
+        
+        clapResult.asDriver()
+            .withUnretained(self)
+            .sink { owner, result in
+                output.clapResult.send(result)
             }.store(in: self.cancelBag)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
 
기존에 실패했을 때 failure case가 호출되지 않는 버그를 해결했습니다.

🌱 작업한 브랜치
- fix/#756

## 🌱 PR Point

기존에 `PassthroughSubject<ClapCountModel, Never>()`는 한 번 실패하면 이벤트 스트림이 완전 종료되는 문제가 있어서 
`PassthroughSubject<Result<ClapCountModel, Error>, Never>()` Result 타입으로 감싸줘서 스트림이 종료되는 문제를 해결했습니다. 

## 📮 관련 이슈
- Resolved: #756 
