### PR TITLE
[Fix] #766 - 텍스트뷰 폰트 대응

### DIFF
--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
@@ -38,7 +38,7 @@ public class SentenceEditVC: UIViewController, LegacySentenceEditViewControllabl
         let tv = UITextView()
         tv.backgroundColor = DSKitAsset.Colors.black80.color
         tv.textColor = DSKitAsset.Colors.white.color
-        tv.font = DSKitFontFamily.Suit.medium.font(size: 16)
+        tv.font = DSKitFontFamily.Pretendard.medium.font(size: 16)
         tv.layer.cornerRadius = 9.adjustedH
         tv.layer.borderWidth = 1.adjustedH
         tv.isEditable = true

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -699,7 +699,7 @@ extension ListDetailVC {
         self.imagePlaceholderLabel.font = .SoptampFont.subtitle2
         self.imagePlaceholderLabel.text = I18N.ListDetail.imagePlaceHolder
         
-        self.textView.font = DSKitFontFamily.Suit.medium.font(size: 14)
+        self.textView.font = DSKitFontFamily.Pretendard.medium.font(size: 14)
         self.textView.text = I18N.ListDetail.memoPlaceHolder
         self.textView.returnKeyType = .done
         


### PR DESCRIPTION
## 🌴 PR 요약
textview만
SUIT -> Pretendard
로 바꿔줬습니다 ! 

🌱 작업한 브랜치
- fix/#766


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|폰트 대응|![Simulator Screen Recording - iPhone 16 Pro - 2025-12-01 at 18 15 13](https://github.com/user-attachments/assets/33078923-1e04-4111-b0f0-ed26271dffbf)|

## 📮 관련 이슈
- Resolved: #766 
