### PR TITLE
[Hotfix] #774 - 누락된 의존성 추가

### DIFF
--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Project.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Project.swift
@@ -13,7 +13,6 @@ let project = Project.makeModule(
     name: "SoptlogFeature",
     targets: [.unitTest, .staticFramework, .demo, .interface],
     interfaceDependencies: [
-        .Features.Web.Feature,
         .Features.Poke.Interface
     ]
 )

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Project.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Project.swift
@@ -13,6 +13,7 @@ let project = Project.makeModule(
     name: "SoptlogFeature",
     targets: [.unitTest, .staticFramework, .demo, .interface],
     interfaceDependencies: [
-        .Features.Web.Feature
+        .Features.Web.Feature,
+        .Features.Poke.Interface
     ]
 )


### PR DESCRIPTION
## 🌴 PR 요약

누락된 의존성을 추가했어요.

🌱 작업한 브랜치
- #774 

## 🌱 PR Point

- Project 파일에 의존성을 추가해주지 않으면 아래 캡처본과 같이 의존성 관련 에러가 나요.
- 현재 코드 상 SoptlogFeatureInterface 내에서 PokeInterface에 의존성을 가지고 있기 때문에, 이를 잘 추가해주어야 해요!

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
<img width="400" alt="image" src="https://github.com/user-attachments/assets/084e343a-9e57-403d-90e0-7bba62eaa911" />

## 📮 관련 이슈
- Resolved: #774 
