### PR TITLE
[Feat] #781 솝탬프, 콕찌르기 네비게이션바 분기 처리

### DIFF
--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -12,7 +12,7 @@ import Domain
 import BaseFeatureDependency
 
 public protocol PokeFeatureBuildable {
-    func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeMainPresentable
+    func makePokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeMainPresentable
     func makePokeMyFriends(coordinator: Coordinator) -> PokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
     func makePokeOnboarding() -> PokeOnboardingPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -26,7 +26,7 @@ extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
         let viewModel = PokeMainViewModel(useCase: useCase,
                                           coordinator: coordinator,
                                           isRouteFromRoot: isRouteFromRoot)
-        let pokeMainVC = PokeMainVC(viewModel: viewModel)
+        let pokeMainVC = PokeMainVC(viewModel: viewModel, isRouteFromTabBar: true)
         return (pokeMainVC, viewModel)
     }
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -34,8 +34,7 @@ extension PokeBuilder: PokeFeatureBuildable {
         let viewModel = PokeMainViewModel(useCase: useCase,
                                           coordinator: coordinator,
                                           isRouteFromRoot: isRouteFromRoot)
-        let pokeMainVC = PokeMainVC(viewModel: viewModel)
-        pokeMainVC.setNavigationBar(isRouteFromTabBar: isRouteFromTabBar)
+        let pokeMainVC = PokeMainVC(viewModel: viewModel, isRouteFromTabBar: isRouteFromTabBar)
         
         return (pokeMainVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -29,12 +29,13 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeFeatureInterface.PokeMainPresentable {
+    public func makePokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeFeatureInterface.PokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
         let viewModel = PokeMainViewModel(useCase: useCase,
                                           coordinator: coordinator,
                                           isRouteFromRoot: isRouteFromRoot)
         let pokeMainVC = PokeMainVC(viewModel: viewModel)
+        pokeMainVC.setNavigationBar(isRouteFromTabBar: isRouteFromTabBar)
         
         return (pokeMainVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -36,7 +36,7 @@ public final class PokeCoordinator: BaseCoordinator {
     // MARK: - Coordinator Life Cycle
 
     public func start(isRouteFromTabBar: Bool = false) {
-        showPokeMain(isRouteFromRoot: isRouteFromTabBar, isRouteFromTabBar: isRouteFromTabBar)
+        showPokeMain(isRouteFromRoot: false, isRouteFromTabBar: isRouteFromTabBar)
     }
     public override func start() {
         start(isRouteFromTabBar: false)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -36,7 +36,7 @@ public final class PokeCoordinator: BaseCoordinator {
     // MARK: - Coordinator Life Cycle
 
     public func start(isRouteFromTabBar: Bool = false) {
-        showPokeMain(isRouteFromRoot: false, isRouteFromTabBar: isRouteFromTabBar)
+        showPokeMain(isRouteFromRoot: isRouteFromTabBar, isRouteFromTabBar: isRouteFromTabBar)
     }
     public override func start() {
         start(isRouteFromTabBar: false)
@@ -45,15 +45,11 @@ public final class PokeCoordinator: BaseCoordinator {
     // MARK: - Navigation
 
     public func showPokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool) {
-        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot, coordinator: self)
+        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot, isRouteFromTabBar: isRouteFromTabBar,  coordinator: self)
 
         if isRouteFromTabBar {
             self.rootController = self.navigationController
-            pokeMain.vm.onNaviBackTap = { [weak self] in
-                self?.rootController?.popViewController(animated: true)
-            }
             self.navigationController?.setViewControllers([pokeMain.vc], animated: false)
-
         } else {
             let newNav = UINavigationController(rootViewController: pokeMain.vc)
             newNav.modalPresentationStyle = .overFullScreen

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -17,296 +17,297 @@ import BaseFeatureDependency
 import PokeFeatureInterface
 
 public final class PokeMainVC: UIViewController, PokeMainViewControllable {
-
-  // MARK: - Properties
-
-  public var viewModel: PokeMainViewModel
-  private var cancelBag = CancelBag()
-
-  // MARK: - UI Components
-
-  private let backButton = UIButton().then {
-    $0.setImage(DSKitAsset.Assets.xMark.image.withTintColor(DSKitAsset.Colors.gray30.color), for: .normal)
-  }
-
-  private let serviceTitleLabel = UILabel().then {
-    $0.font = UIFont.MDS.heading6.font
-    $0.textColor = DSKitAsset.Colors.gray30.color
-    $0.text = I18N.Poke.poke
-  }
-
-  private lazy var navigationView = UIStackView(
-    arrangedSubviews: [backButton, serviceTitleLabel]
-  ).then {
-    $0.axis = .horizontal
-    $0.spacing = 2
-    $0.alignment = .center
-  }
-
-  private lazy var scrollView = UIScrollView().then {
-    $0.refreshControl = self.refreshControl
-    $0.showsVerticalScrollIndicator = false
-    $0.showsHorizontalScrollIndicator = false
-  }
-
-  private let contentStackView = UIStackView().then {
-    $0.axis = .vertical
-    $0.spacing = 12
-  }
-
-  // 누가 나를 찔렀어요 부분
-  private let pokedSectionHeaderView = PokeMainSectionHeaderView(title: I18N.Poke.someonePokedMe)
-  private let pokedUserContentView = PokeNotificationListContentView(frame: .zero)
-  private lazy var pokedSectionGroupView = self.makeSectionGroupView(header: pokedSectionHeaderView, content: pokedUserContentView).then {
-    $0.isHidden = true
-  }
-
-  // 내 친구를 찔러보세요 부분
-  private let friendSectionHeaderView = PokeMainSectionHeaderView(title: I18N.Poke.pokeMyFriends)
-  private let friendSectionContentView = PokeProfileListView(viewType: .main)
-  private lazy var friendSectionGroupView = self.makeSectionGroupView(header: friendSectionHeaderView, content: friendSectionContentView)
-
-  // 내 친구의 친구를 찔러보세요 부분
-  private let recommendPokeLabel = UILabel().then {
-    $0.text = I18N.Poke.pokeNearbyFriends
-    $0.textColor = DSKitAsset.Colors.gray30.color
-    $0.font = UIFont.MDS.title5.font
-  }
-
-  private let firstProfileCardGroupView = ProfileCardGroupView(frame: .zero)
-  private let secondProfileCardGroupView = ProfileCardGroupView(frame: .zero)
-  private let thirdProfileCardGroupView = ProfileCardGroupView(frame: .zero)
-
-  // 리프레시
-  private let refreshGuideLabel = UILabel().then {
-    $0.font = UIFont.MDS.title7.font
-    $0.textColor = DSKitAsset.Colors.gray200.color
-    $0.text = I18N.Poke.refreshGuide
-    $0.textAlignment = .center
-    $0.numberOfLines = 2
-  }
-
-  private let refreshControl = UIRefreshControl()
-
-  // MARK: - initialization
-
-  public init(viewModel: PokeMainViewModel) {
-    self.viewModel = viewModel
-    super.init(nibName: nil, bundle: nil)
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  // MARK: - View Life Cycle
-
-  public override func viewDidLoad() {
-    super.viewDidLoad()
-    setUI()
-    setDelegate()
-    setStackView()
-    setLayout()
-    bindViewModel()
-  }
+    
+    // MARK: - Properties
+    
+    public var viewModel: PokeMainViewModel
+    private var isRouteFromTabBar: Bool
+    private var cancelBag = CancelBag()
+    
+    // MARK: - UI Components
+    
+    private let backButton = UIButton().then {
+        $0.setImage(DSKitAsset.Assets.xMark.image.withTintColor(DSKitAsset.Colors.gray30.color), for: .normal)
+    }
+    
+    private let serviceTitleLabel = UILabel().then {
+        $0.font = UIFont.MDS.heading6.font
+        $0.textColor = DSKitAsset.Colors.gray30.color
+        $0.text = I18N.Poke.poke
+    }
+    
+    private lazy var navigationView = UIStackView(
+        arrangedSubviews: [backButton, serviceTitleLabel]
+    ).then {
+        $0.axis = .horizontal
+        $0.spacing = 2
+        $0.alignment = .center
+    }
+    
+    private lazy var scrollView = UIScrollView().then {
+        $0.refreshControl = self.refreshControl
+        $0.showsVerticalScrollIndicator = false
+        $0.showsHorizontalScrollIndicator = false
+    }
+    
+    private let contentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 12
+    }
+    
+    // 누가 나를 찔렀어요 부분
+    private let pokedSectionHeaderView = PokeMainSectionHeaderView(title: I18N.Poke.someonePokedMe)
+    private let pokedUserContentView = PokeNotificationListContentView(frame: .zero)
+    private lazy var pokedSectionGroupView = self.makeSectionGroupView(header: pokedSectionHeaderView, content: pokedUserContentView).then {
+        $0.isHidden = true
+    }
+    
+    // 내 친구를 찔러보세요 부분
+    private let friendSectionHeaderView = PokeMainSectionHeaderView(title: I18N.Poke.pokeMyFriends)
+    private let friendSectionContentView = PokeProfileListView(viewType: .main)
+    private lazy var friendSectionGroupView = self.makeSectionGroupView(header: friendSectionHeaderView, content: friendSectionContentView)
+    
+    // 내 친구의 친구를 찔러보세요 부분
+    private let recommendPokeLabel = UILabel().then {
+        $0.text = I18N.Poke.pokeNearbyFriends
+        $0.textColor = DSKitAsset.Colors.gray30.color
+        $0.font = UIFont.MDS.title5.font
+    }
+    
+    private let firstProfileCardGroupView = ProfileCardGroupView(frame: .zero)
+    private let secondProfileCardGroupView = ProfileCardGroupView(frame: .zero)
+    private let thirdProfileCardGroupView = ProfileCardGroupView(frame: .zero)
+    
+    // 리프레시
+    private let refreshGuideLabel = UILabel().then {
+        $0.font = UIFont.MDS.title7.font
+        $0.textColor = DSKitAsset.Colors.gray200.color
+        $0.text = I18N.Poke.refreshGuide
+        $0.textAlignment = .center
+        $0.numberOfLines = 2
+    }
+    
+    private let refreshControl = UIRefreshControl()
+    
+    // MARK: - initialization
+    
+    public init(
+        viewModel: PokeMainViewModel,
+        isRouteFromTabBar: Bool
+    ) {
+        self.viewModel = viewModel
+        self.isRouteFromTabBar = isRouteFromTabBar
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setDelegate()
+        setStackView()
+        setLayout()
+        bindViewModel()
+    }
 }
 
 // MARK: - UI & Layout
 
 extension PokeMainVC {
-  private func setUI() {
-    self.navigationController?.isNavigationBarHidden = true
-    view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
-  }
-
-  private func setDelegate() {
-    self.navigationController?.interactivePopGestureRecognizer?.delegate = self
-  }
-
-  private func setStackView() {
-    self.contentStackView.addArrangedSubviews(pokedSectionGroupView,
-                                              friendSectionGroupView,
-                                              recommendPokeLabel,
-                                              firstProfileCardGroupView,
-                                              secondProfileCardGroupView,
-                                              thirdProfileCardGroupView,
-                                              refreshGuideLabel)
-
-    contentStackView.setCustomSpacing(28, after: friendSectionGroupView)
-    contentStackView.setCustomSpacing(12, after: thirdProfileCardGroupView)
-  }
-
-  private func makeSectionGroupView(header: PokeMainSectionHeaderView, content: UIView) -> UIView {
-    let view = UIView()
-    view.backgroundColor = DSKitAsset.Colors.gray900.color
-    view.addSubviews(header, content)
-    view.layer.cornerRadius = 12
-
-    header.snp.makeConstraints { make in
-      make.top.leading.trailing.equalToSuperview()
+    private func setUI() {
+        self.navigationController?.isNavigationBarHidden = true
+        view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
+        
+        backButton.isHidden = isRouteFromTabBar
     }
-
-    content.snp.makeConstraints { make in
-      make.top.equalTo(header.snp.bottom).offset(8)
-      make.leading.trailing.equalToSuperview().inset(12)
-      make.bottom.equalToSuperview().inset(8)
+    
+    private func setDelegate() {
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
-
-    return view
-  }
-
-  private func setLayout() {
-    self.view.addSubviews(navigationView, scrollView)
-
-    backButton.snp.makeConstraints { make in
-      make.width.equalTo(40)
-      make.height.equalTo(40)
+    
+    private func setStackView() {
+        self.contentStackView.addArrangedSubviews(pokedSectionGroupView,
+                                                  friendSectionGroupView,
+                                                  recommendPokeLabel,
+                                                  firstProfileCardGroupView,
+                                                  secondProfileCardGroupView,
+                                                  thirdProfileCardGroupView,
+                                                  refreshGuideLabel)
+        
+        contentStackView.setCustomSpacing(28, after: friendSectionGroupView)
+        contentStackView.setCustomSpacing(12, after: thirdProfileCardGroupView)
     }
-
-    navigationView.snp.makeConstraints { make in
-      make.top.equalTo(view.safeAreaLayoutGuide)
-      make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(8)
-      make.height.equalTo(44)
+    
+    private func makeSectionGroupView(header: PokeMainSectionHeaderView, content: UIView) -> UIView {
+        let view = UIView()
+        view.backgroundColor = DSKitAsset.Colors.gray900.color
+        view.addSubviews(header, content)
+        view.layer.cornerRadius = 12
+        
+        header.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+        }
+        
+        content.snp.makeConstraints { make in
+            make.top.equalTo(header.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(12)
+            make.bottom.equalToSuperview().inset(8)
+        }
+        
+        return view
     }
-
-    setScrollViewLayout()
-  }
-
-  private func setScrollViewLayout() {
-    self.scrollView.addSubviews(contentStackView)
-
-    scrollView.snp.makeConstraints { make in
-      make.top.equalTo(navigationView.snp.bottom)
-      make.leading.trailing.bottom.equalToSuperview()
+    
+    private func setLayout() {
+        self.view.addSubviews(navigationView, scrollView)
+        
+        backButton.snp.makeConstraints { make in
+            make.width.equalTo(40)
+            make.height.equalTo(40)
+        }
+        
+        navigationView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(8)
+            make.height.equalTo(44)
+        }
+        
+        setScrollViewLayout()
     }
-
-    contentStackView.snp.makeConstraints { make in
-      make.width.equalTo(self.view.frame.width - 20 * 2)
-      make.top.equalToSuperview().inset(8)
-      make.leading.trailing.equalToSuperview().inset(20)
-      make.bottom.equalToSuperview().inset(20)
+    
+    private func setScrollViewLayout() {
+        self.scrollView.addSubviews(contentStackView)
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(navigationView.snp.bottom)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        contentStackView.snp.makeConstraints { make in
+            make.width.equalTo(self.view.frame.width - 20 * 2)
+            make.top.equalToSuperview().inset(8)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(20)
+        }
     }
-  }
-
-  private func setFriendRandomUsers(with randomUsers: PokeFriendRandomUserModel) {
-    let profileCardGroupViews = [firstProfileCardGroupView, secondProfileCardGroupView, thirdProfileCardGroupView]
-    recommendPokeLabel.isHidden = randomUsers.randomInfoList.isEmpty
-    for (i, profileCardGroupView) in profileCardGroupViews.enumerated() {
-      let randomUser = randomUsers.randomInfoList[safe: i]
-      profileCardGroupView.isHidden = (randomUser == nil)
-      if let randomUser {
-        profileCardGroupView.setData(with: randomUser)
-      }
+    
+    private func setFriendRandomUsers(with randomUsers: PokeFriendRandomUserModel) {
+        let profileCardGroupViews = [firstProfileCardGroupView, secondProfileCardGroupView, thirdProfileCardGroupView]
+        recommendPokeLabel.isHidden = randomUsers.randomInfoList.isEmpty
+        for (i, profileCardGroupView) in profileCardGroupViews.enumerated() {
+            let randomUser = randomUsers.randomInfoList[safe: i]
+            profileCardGroupView.isHidden = (randomUser == nil)
+            if let randomUser {
+                profileCardGroupView.setData(with: randomUser)
+            }
+        }
     }
-  }
 }
 
 extension PokeMainVC: UIGestureRecognizerDelegate {
-  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-    guard let viewControllers = self.navigationController?.viewControllers else { return false }
-    return viewControllers.count > 1
-  }
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let viewControllers = self.navigationController?.viewControllers else { return false }
+        return viewControllers.count > 1
+    }
 }
 
 // MARK: - Methods
 
 extension PokeMainVC {
-  private func bindViewModel() {
-    let profileImageTap = Publishers.Merge5(
-      pokedUserContentView.profileImageTap
-        .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainAlarm) },
-      friendSectionContentView.profileImageTap
-        .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainFriend) },
-      firstProfileCardGroupView.profileImageTap
-        .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) },
-      secondProfileCardGroupView.profileImageTap
-        .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) },
-      thirdProfileCardGroupView.profileImageTap
-        .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) })
-      .asDriver()
-
-    let input = PokeMainViewModel
-      .Input(
-        viewDidLoad: Just(()).asDriver(),
-        naviBackButtonTap: self.backButton
-          .publisher(for: .touchUpInside)
-          .mapVoid().asDriver(),
-        pokedSectionHeaderButtonTap: pokedSectionHeaderView
-          .rightButtonTap,
-        friendSectionHeaderButtonTap: friendSectionHeaderView
-          .rightButtonTap,
-        pokedSectionKokButtonTap: pokedUserContentView
-          .kokButtonTap,
-        friendSectionKokButtonTap: friendSectionContentView
-          .kokButtonTap,
-        nearbyFriendsSectionKokButtonTap: firstProfileCardGroupView
-          .kokButtonTap
-          .merge(with: secondProfileCardGroupView.kokButtonTap)
-          .merge(with: thirdProfileCardGroupView.kokButtonTap)
-          .asDriver(),
-        refreshRequest: refreshControl.publisher(for: .valueChanged).mapVoid().asDriver(),
-        profileImageTap: profileImageTap
-      )
-
-    let output = viewModel.transform(from: input, cancelBag: cancelBag)
-
-    output.pokedToMeUser
-      .withUnretained(self)
-      .sink { owner, model in
-        owner.pokedUserContentView.configure(with: model)
-      }.store(in: cancelBag)
-
-    output.pokedUserSectionWillBeHidden
-      .assign(to: \.isHidden, onWeak: pokedSectionGroupView)
-      .store(in: cancelBag)
-
-    output.myFriend
-      .withUnretained(self)
-      .sink { owner, model in
-        owner.friendSectionContentView.setData(with: model)
-      }.store(in: cancelBag)
-
-    output.friendsSectionWillBeHidden
-      .assign(to: \.isHidden, onWeak: friendSectionGroupView)
-      .store(in: cancelBag)
-
-    output.friendRandomUsers
-      .withUnretained(self)
-      .sink { owner, randomUsers in
-        owner.setFriendRandomUsers(with: randomUsers)
-      }.store(in: cancelBag)
-
-    output.endRefreshLoading
-      .withUnretained(self)
-      .sink { owner, _ in
-        owner.refreshControl.endRefreshing()
-      }.store(in: cancelBag)
-
-    output.pokeResponse
-      .withUnretained(self)
-      .sink { owner, updatedUser in
-        let pokeUserViews = [owner.pokedUserContentView,
-                             owner.friendSectionContentView,
-                             owner.firstProfileCardGroupView,
-                             owner.secondProfileCardGroupView,
-                             owner.thirdProfileCardGroupView]
-          .compactMap { $0 as? PokeCompatible }
-
-        pokeUserViews.forEach { pokeUserView in
-          pokeUserView.changeUIAfterPoke(newUserModel: updatedUser)
-        }
-      }.store(in: cancelBag)
-
-    output.isLoading
-      .withUnretained(self)
-      .sink { owner, isLoading in
-        isLoading ? owner.showLoading() : owner.stopLoading()
-      }.store(in: cancelBag)
-  }
-}
-
-extension PokeMainVC {
-    func setNavigationBar(isRouteFromTabBar: Bool) {
-        backButton.isHidden = isRouteFromTabBar
+    private func bindViewModel() {
+        let profileImageTap = Publishers.Merge5(
+            pokedUserContentView.profileImageTap
+                .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainAlarm) },
+            friendSectionContentView.profileImageTap
+                .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainFriend) },
+            firstProfileCardGroupView.profileImageTap
+                .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) },
+            secondProfileCardGroupView.profileImageTap
+                .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) },
+            thirdProfileCardGroupView.profileImageTap
+                .map { ($0, PokeAmplitudeEventPropertyValue.pokeMainRecommendNotMyFriend) })
+            .asDriver()
+        
+        let input = PokeMainViewModel
+            .Input(
+                viewDidLoad: Just(()).asDriver(),
+                naviBackButtonTap: self.backButton
+                    .publisher(for: .touchUpInside)
+                    .mapVoid().asDriver(),
+                pokedSectionHeaderButtonTap: pokedSectionHeaderView
+                    .rightButtonTap,
+                friendSectionHeaderButtonTap: friendSectionHeaderView
+                    .rightButtonTap,
+                pokedSectionKokButtonTap: pokedUserContentView
+                    .kokButtonTap,
+                friendSectionKokButtonTap: friendSectionContentView
+                    .kokButtonTap,
+                nearbyFriendsSectionKokButtonTap: firstProfileCardGroupView
+                    .kokButtonTap
+                    .merge(with: secondProfileCardGroupView.kokButtonTap)
+                    .merge(with: thirdProfileCardGroupView.kokButtonTap)
+                    .asDriver(),
+                refreshRequest: refreshControl.publisher(for: .valueChanged).mapVoid().asDriver(),
+                profileImageTap: profileImageTap
+            )
+        
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+        
+        output.pokedToMeUser
+            .withUnretained(self)
+            .sink { owner, model in
+                owner.pokedUserContentView.configure(with: model)
+            }.store(in: cancelBag)
+        
+        output.pokedUserSectionWillBeHidden
+            .assign(to: \.isHidden, onWeak: pokedSectionGroupView)
+            .store(in: cancelBag)
+        
+        output.myFriend
+            .withUnretained(self)
+            .sink { owner, model in
+                owner.friendSectionContentView.setData(with: model)
+            }.store(in: cancelBag)
+        
+        output.friendsSectionWillBeHidden
+            .assign(to: \.isHidden, onWeak: friendSectionGroupView)
+            .store(in: cancelBag)
+        
+        output.friendRandomUsers
+            .withUnretained(self)
+            .sink { owner, randomUsers in
+                owner.setFriendRandomUsers(with: randomUsers)
+            }.store(in: cancelBag)
+        
+        output.endRefreshLoading
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.refreshControl.endRefreshing()
+            }.store(in: cancelBag)
+        
+        output.pokeResponse
+            .withUnretained(self)
+            .sink { owner, updatedUser in
+                let pokeUserViews = [owner.pokedUserContentView,
+                                     owner.friendSectionContentView,
+                                     owner.firstProfileCardGroupView,
+                                     owner.secondProfileCardGroupView,
+                                     owner.thirdProfileCardGroupView]
+                    .compactMap { $0 as? PokeCompatible }
+                
+                pokeUserViews.forEach { pokeUserView in
+                    pokeUserView.changeUIAfterPoke(newUserModel: updatedUser)
+                }
+            }.store(in: cancelBag)
+        
+        output.isLoading
+            .withUnretained(self)
+            .sink { owner, isLoading in
+                isLoading ? owner.showLoading() : owner.stopLoading()
+            }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -304,3 +304,9 @@ extension PokeMainVC {
       }.store(in: cancelBag)
   }
 }
+
+extension PokeMainVC {
+    func setNavigationBar(isRouteFromTabBar: Bool) {
+        backButton.isHidden = isRouteFromTabBar
+    }
+}

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -588,7 +588,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runPokeFlow() -> BaseCoordinator {
+    internal func runPokeFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
         var coordinator: BaseCoordinator
         
         switch Config.coordinatorFlag {
@@ -604,17 +604,17 @@ extension ApplicationCoordinator {
             }
             coordinator = legacyPokeCoordinator
             addDependency(coordinator)
+            
+            coordinator.start()
         case .new:
             let newCoordinator = PokeCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: PokeBuilder()
             )
-            
+            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
             coordinator = newCoordinator
         }
-        
-        coordinator.start()
-        
+    
         return coordinator
     }
     

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -577,7 +577,7 @@ extension ApplicationCoordinator {
                 factory: StampBuilder(),
                 mypageFactory: MyPageBuilder()
             )
-            newCoordinator.start(isRouteFromTabBar: false)
+            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
             coordinator = newCoordinator
         }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -552,7 +552,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runStampFlow() -> BaseCoordinator {
+    internal func runStampFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
         var coordinator: BaseCoordinator
         
         switch Config.coordinatorFlag {
@@ -568,18 +568,19 @@ extension ApplicationCoordinator {
                 self?.removeDependency(legacyStampCoordinator)
             }
             addDependency(legacyStampCoordinator)
-            
             coordinator = legacyStampCoordinator
+            coordinator.start()
+            
         case .new:
-            coordinator = StampCoordinator(
+            let newCoordinator = StampCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: StampBuilder(),
                 mypageFactory: MyPageBuilder()
             )
+            newCoordinator.start(isRouteFromTabBar: false)
+            coordinator = newCoordinator
         }
 
-        coordinator.start()
-        
         return coordinator
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/PokeDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/PokeDeepLink.swift
@@ -23,6 +23,6 @@ public struct PokeDeepLink: DeepLinkExecutable {
             return coordinator
         }
         
-        return coordinator.runPokeFlow()
+        return coordinator.runPokeFlow(isRouteFromTabBar: false)
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/SoptampDeepLink.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/DeepLinks/SoptampDeepLink.swift
@@ -23,6 +23,6 @@ public struct SoptampDeepLink: DeepLinkExecutable {
             return coordinator
         }
         
-        return coordinator.runStampFlow()
+        return coordinator.runStampFlow(isRouteFromTabBar: false)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
@@ -13,7 +13,7 @@ import Domain
 import BaseFeatureDependency
 
 public protocol StampFeatureBuildable {
-    func makeMissionListVC(sceneType: MissionListSceneType, coordinator: Coordinator) -> MissionListPresentable
+    func makeMissionListVC(sceneType: MissionListSceneType, isRouteFromTabBar: Bool, coordinator: Coordinator) -> MissionListPresentable
     func makeListDetailVC(
         sceneType: ListDetailSceneType,
         starLevel: StarViewLevel,

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/LegacyStampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/LegacyStampBuilder.swift
@@ -24,7 +24,7 @@ extension LegacyStampBuilder: LegacyStampFeatureViewBuildable {
     public func makeMissionListVC(sceneType: MissionListSceneType, coordinator: Coordinator) -> LegacyMissionListViewControllable {
         let useCase = DefaultMissionListUseCase(repository: missionListRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType, coordinator: coordinator)
-        let missionListVC = MissionListVC(viewModel: viewModel)
+        let missionListVC = MissionListVC(viewModel: viewModel, isRouteFromTabBar: false)
         missionListVC.viewModel = viewModel
         return missionListVC
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -23,7 +23,7 @@ final class StampBuilder {
 }
 
 extension StampBuilder: StampFeatureBuildable {
-    public func makeMissionListVC(sceneType: MissionListSceneType, isRouteFromTabBar: Bool = true, coordinator: Coordinator) -> MissionListPresentable {
+    public func makeMissionListVC(sceneType: MissionListSceneType, isRouteFromTabBar: Bool, coordinator: Coordinator) -> MissionListPresentable {
         let useCase = DefaultMissionListUseCase(repository: missionListRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType, coordinator: coordinator)
         let missionListVC = MissionListVC(viewModel: viewModel, isRouteFromTabBar: isRouteFromTabBar)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -23,10 +23,11 @@ final class StampBuilder {
 }
 
 extension StampBuilder: StampFeatureBuildable {
-    public func makeMissionListVC(sceneType: MissionListSceneType, coordinator: Coordinator) -> MissionListPresentable {
+    public func makeMissionListVC(sceneType: MissionListSceneType, isRouteFromTabBar: Bool = true, coordinator: Coordinator) -> MissionListPresentable {
         let useCase = DefaultMissionListUseCase(repository: missionListRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType, coordinator: coordinator)
-        let missionListVC = MissionListVC(viewModel: viewModel)
+        let missionListVC = MissionListVC(viewModel: viewModel, isRouteFromTabBar: isRouteFromTabBar)
+   
         return (missionListVC, viewModel)
     }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -50,13 +50,10 @@ public final class StampCoordinator: BaseCoordinator {
     // MARK: - Navigation
 
     private func showMissionList(sceneType: MissionListSceneType, isRouteFromTabBar: Bool) {
-        var missionList = factory.makeMissionListVC(sceneType: sceneType, coordinator: self)
+        var missionList = factory.makeMissionListVC(sceneType: sceneType, isRouteFromTabBar: isRouteFromTabBar, coordinator: self)
 
         if isRouteFromTabBar {
             self.rootController = self.navigationController
-            missionList.vc.onNaviBackTap = { [weak self] in
-                self?.navigationController.popViewController(animated: true)
-            }
             self.navigationController.setViewControllers([missionList.vc], animated: false)
         } else {
             let navController = UINavigationController(rootViewController: missionList.vc)
@@ -204,6 +201,7 @@ extension StampCoordinator {
     private func showOtherMissionList(_ username: String, _ sentence: String) {
         var otherMissionList = factory.makeMissionListVC(
             sceneType: .ranking(userName: username, sentence: sentence),
+            isRouteFromTabBar: false,
             coordinator: self
         )
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -27,6 +27,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     public var sceneType: MissionListSceneType {
         return self.viewModel.missionListsceneType
     }
+    private var isRouteFromTabBar: Bool = true
     private var cancelBag = CancelBag()
     
     private var missionTypeMenuSelected = CurrentValueSubject<MissionListFetchType, Never>(.all)
@@ -165,8 +166,12 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
-    init(viewModel: MissionListViewModel) {
+    init(
+        viewModel: MissionListViewModel,
+        isRouteFromTabBar: Bool
+    ) {
         self.viewModel = viewModel
+        self.isRouteFromTabBar = isRouteFromTabBar
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -200,6 +205,7 @@ extension MissionListVC {
         naviBar.snp.makeConstraints { make in
             make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
         }
+        naviBar.setLeftButtonHidden(isRouteFromTabBar)
         
         missionListCollectionView.snp.makeConstraints { make in
             make.top.equalTo(naviBar.snp.bottom).offset(20.adjustedH)

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
@@ -96,6 +96,23 @@ extension STNavigationBar {
 //        self.leftButton.addTarget(self, action: #selector(popToPreviousVC), for: .touchUpInside)
     }
     
+    private func leftButtonLayoutForMenu() {
+        self.addSubview(leftButton)
+        
+        leftButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview().offset(1)
+            make.leading.equalToSuperview().inset(20)
+            make.width.height.equalTo(32)
+        }
+        
+        titleButton.snp.remakeConstraints { make in
+            make.centerY.equalToSuperview().offset(1)
+            make.leading.equalTo(leftButton.snp.trailing).offset(12)
+        }
+    }
+}
+
+extension STNavigationBar {
     @discardableResult
     public func setTitle(_ title: String) -> Self {
         switch self.naviType {
@@ -179,19 +196,27 @@ extension STNavigationBar {
         return self
     }
     
-    private func leftButtonLayoutForMenu() {
-        self.addSubview(leftButton)
+    @discardableResult
+    public func setLeftButtonHidden(_ isHidden: Bool) -> Self {
+        guard naviType == .title else { return self }
         
-        leftButton.snp.makeConstraints { make in
-            make.centerY.equalToSuperview().offset(1)
-            make.leading.equalToSuperview().inset(20)
-            make.width.height.equalTo(32)
+        if !isHidden {
+            addSubview(leftButton)
+        } else {
+            leftButton.removeFromSuperview()
         }
-        
-        titleButton.snp.remakeConstraints { make in
-            make.centerY.equalToSuperview().offset(1)
-            make.leading.equalTo(leftButton.snp.trailing).offset(12)
+    
+        titleButton.snp.remakeConstraints {
+            $0.centerY.equalToSuperview().offset(1)
+            
+            if isHidden {
+                $0.leading.equalToSuperview().offset(20)
+            } else {
+                $0.leading.equalTo(leftButton.snp.trailing).offset(12)
+            }
         }
+    
+        return self
     }
 }
 

--- a/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
+++ b/SOPT-iOS/Projects/Modules/DSKit/Sources/Components/SoptampComponents/STNavigationBar.swift
@@ -206,13 +206,13 @@ extension STNavigationBar {
             leftButton.removeFromSuperview()
         }
     
-        titleButton.snp.remakeConstraints {
-            $0.centerY.equalToSuperview().offset(1)
+        titleButton.snp.remakeConstraints { make in
+            make.centerY.equalToSuperview().offset(1)
             
             if isHidden {
-                $0.leading.equalToSuperview().offset(20)
+                make.leading.equalToSuperview().offset(20)
             } else {
-                $0.leading.equalTo(leftButton.snp.trailing).offset(12)
+                make.leading.equalTo(leftButton.snp.trailing).offset(12)
             }
         }
     


### PR DESCRIPTION
## 🌴 PR 요약
솝탬프, 콕찌르기 네비게이션바 분기 처리 했습니다.

🌱 작업한 브랜치
- feature/#781

## 🌱 PR Point
탭 전환 시에는 isRouteFromTabBar를 true로 두고 x 버튼을 hidden 시켰고,
알림을 통해 이동할 때에는 현상유지했습니다!

VC의 configure와 같은 함수를 통해 isRouteFromTabBar에 따른 처리를 하려고 했으나
솝탬프의 경우, STNavigationBar를 따로 사용하고 있었기 때문에 
**VC를 생성할 때 내부 네비게이션바가 hierarchy에 올라가지 않은 상태에서 UI를 건들게 되**는 이슈가 있어서
**생성자**를 통해 처리해줬습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| |![Simulator Screen Recording - iPhone 16 Pro - 2025-12-11 at 18 20 31](https://github.com/user-attachments/assets/4a05e491-35ba-41bb-9c53-0c7320e41b8a)|

## 📮 관련 이슈
- Resolved: #781 
