### PR TITLE
[Fix] #787 - 솝트로그 응답값 매핑 수정

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -16,9 +16,9 @@ public struct  SoptlogModel {
     public let todayFortuneText: String
     
     /// 솝탬프 정보
-    public let soptampCount: Int
-    public let viewCount: Int
-    public let myClapCount: Int
+    public let soptampCount: Int?
+    public let viewCount: Int?
+    public let myClapCount: Int?
     
     /// 콕찌르기 정보
     public let totalPokeCount: Int
@@ -30,9 +30,9 @@ public struct  SoptlogModel {
         isActive: Bool,
         isFortuneChecked: Bool,
         todayFortuneText: String,
-        soptampCount: Int,
-        viewCount: Int,
-        myClapCount: Int,
+        soptampCount: Int?,
+        viewCount: Int?,
+        myClapCount: Int?,
         totalPokeCount: Int,
         newFriendsPokeCount: Int,
         bestFriendsPokeCount: Int,

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -27,19 +27,19 @@ extension SoptlogModel {
         let soptampMenus: [SoptlogMenuModel] = [
             SoptlogMenuModel(
                 title: I18N.Soptlog.Menu.completedMission,
-                value: "\(soptampCount)회",
+                value: "\(soptampCount ?? 0)회",
                 hasTooltip: false,
                 hasChevron: true
             ),
             SoptlogMenuModel(
                 title: I18N.Soptlog.Menu.views,
-                value: "\(viewCount)회",
+                value: "\(viewCount ?? 0)회",
                 hasTooltip: true,
                 hasChevron: false
             ),
             SoptlogMenuModel(
                 title: I18N.Soptlog.Menu.receivedClapCount,
-                value: "\(myClapCount)회",
+                value: "\(myClapCount ?? 0)회",
                 hasTooltip: false,
                 hasChevron: false
             )

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -25,7 +25,7 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     private var toolTipTap = PassthroughSubject<CGRect, Never>()
     private var viewWillAppear = PassthroughSubject<Void, Never>()
     private var soptlogInfo: SoptlogPresentationModel?
-    internal var isPokeEmpty: Bool = true
+    internal var isPokeEmpty: Bool = false
     
     private var isActiveUser: Bool {
         UserDefaultKeyList.Auth.isActiveUser ?? false

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -25,7 +25,7 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     private var toolTipTap = PassthroughSubject<CGRect, Never>()
     private var viewWillAppear = PassthroughSubject<Void, Never>()
     private var soptlogInfo: SoptlogPresentationModel?
-    internal var isPokeEmpty: Bool = false
+    internal var isPokeEmpty: Bool = true
     
     private var isActiveUser: Bool {
         UserDefaultKeyList.Auth.isActiveUser ?? false

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -132,6 +132,8 @@ extension SoptlogViewModel {
         } catch let error as MainError {
             switch error {
             case .networkError(_):
+                #warning("AlertVC가 메인스레드에서 보여지지 않는 문제 발생. #789에서 해결 필요")
+                print("🚨 네트워크 에러")
                 onNetworkError?()
             case .authFailed:
                 print("🚨 SoptlogViewModel: 인증에 실패했습니다.")

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -16,9 +16,9 @@ public struct SoptlogResponseEntity: Decodable {
     public let todayFortuneText: String
     
     /// 솝탬프 정보
-    public let soptampCount: Int
-    public let viewCount: Int
-    public let myClapCount: Int
+    public let soptampCount: Int?
+    public let viewCount: Int?
+    public let myClapCount: Int?
     
     /// 콕찌르기 정보
     public let totalPokeCount: Int

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
@@ -302,8 +302,10 @@ extension BaseService {
                         continuation.resume(returning: body)
                     } catch let error {
                         if let error = error as? APIError {
+                            print("🚨 APIError 발생: \(error.localizedDescription)")
                             continuation.resume(throwing: error)
                         }
+                        print("🚨 정의되지 않은 에러 발생: \(error.localizedDescription)")
                         continuation.resume(throwing: MoyaError.jsonMapping(value))
                     }
                 case .failure(let error):


### PR DESCRIPTION
## 🌴 PR 요약
- 솝트로그 API 응답값 타입을 수정했습니다.

🌱 작업한 브랜치
- feature/#787

## 🌱 PR Point
- 솝트로그 응답값 중 옵셔널 타입인 부분을 반영했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|활동 회원|비활동 회원|
|:--:|:--:|
|<img width="375" alt="image" src="https://github.com/user-attachments/assets/7337d569-0b0c-47e7-8020-95bb1031fb7a" />|<img width="375" alt="image" src="https://github.com/user-attachments/assets/6e314d64-47b2-4e5a-bbae-a40d32545575" />|

## 📮 관련 이슈
- Resolved: #787 
