### PR TITLE
[Fix] #788 - 탭 바 전환 로직 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -41,4 +41,19 @@ public extension TabBarItemType {
             }
         }
     }
+    
+    /// 실제 탭바 인덱스 -> TabBarItemType
+    static func from(index: Int, userType: UserType) -> TabBarItemType? {
+        switch userType {
+        case .active:
+            return TabBarItemType(rawValue: index)
+        case .visitor, .inactive:
+            switch index {
+            case 0: return .home
+            case 1: return .poke
+            case 2: return .soptlog
+            default: return nil
+            }
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -10,8 +10,8 @@ import Foundation
 
 public enum TabBarItemType: Int, CaseIterable {
     case home
-    case poke
     case soptamp
+    case poke
     case soptlog
 }
 
@@ -25,27 +25,19 @@ public extension TabBarItemType {
         }
     }
     
+    /// 유저타입 별 탭 바 인덱스 매핑
     func getTabIndex(userType: UserType) -> Int {
         switch userType {
         case .active:
-            switch self {
-            case .home:
-                0
-            case .soptamp:
-                1
-            case .poke:
-                2
-            case .soptlog:
-                3
-            }
+            return self.rawValue
         case .visitor, .inactive:
             switch self {
             case .home, .soptamp:
-                0
+                return 0
             case .poke:
-                1
+                return 1
             case .soptlog:
-                2
+                return 2
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -48,7 +48,7 @@ extension ApplicationCoordinator: TabBarCoordinatorDelegate {
     }
 
     private func selectedTab(_ tab: TabBarItemType) {
-        self.tabBarController?.selectedIndex = tab.rawValue
+        self.tabBarController?.selectedIndex = tab.getTabIndex(userType: UserDefaultKeyList.Auth.getUserType())
     }
 }
 

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Interface/Sources/TabBarPresentable.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Interface/Sources/TabBarPresentable.swift
@@ -13,7 +13,7 @@ import BaseFeatureDependency
 import Core
 
 public protocol TabBarCoordinatable {
-    var onTabBarItemTapped: ((Int) -> Void)? { get set }
+    var onTabBarItemTapped: ((TabBarItemType) -> Void)? { get set }
     var showTabBarAlert: (() -> Void)? { get set }
 }
 public typealias TabBarViewModelType = ViewModelType & TabBarCoordinatable

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/LegacyTabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/LegacyTabBarCoordinator.swift
@@ -38,12 +38,12 @@ public final class LegacyTabBarCoordinator: DefaultTabBarCoordinator {
     private func showTabBar() {
         var tabBar = factory
                 
-        tabBar.vm.onTabBarItemTapped = { [weak self] index in
+        tabBar.vm.onTabBarItemTapped = { [weak self] tabType in
             // 각 탭의 코디네이터 실행
-            switch index {
-            case 0:
+            switch tabType {
+            case .home:
                 self?.requestCoordinating?(.home)
-            case 1:
+            case .soptlog:
                 self?.requestCoordinating?(.soptlog)
             default:
                 return

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -67,17 +67,17 @@ public final class TabBarCoordinator: BaseCoordinator {
     private func showTabBar() {
         var tabBar = factory.makeTabBar(with: views, userType: userType, coordinator: self)
 
-        tabBar.vm.onTabBarItemTapped = { [weak self] index in
+        tabBar.vm.onTabBarItemTapped = { [weak self] tabType in
             // 각 탭의 코디네이터 실행
-            guard let self = self,
-                  let tabType = TabBarItemType(rawValue: index) else { return }
+            guard let self = self else { return }
+            
             switch tabType {
             case .home:
                 self.delegate?.tabBarCoordinator(self, to: .home)
-            case .poke:
-                self.delegate?.tabBarCoordinator(self, to: .poke)
             case .soptamp:
                 self.delegate?.tabBarCoordinator(self, to: .soptamp)
+            case .poke:
+                self.delegate?.tabBarCoordinator(self, to: .poke)
             case .soptlog:
                 self.delegate?.tabBarCoordinator(self, to: .soptlog)
             }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -17,10 +17,11 @@ final public class TabBarViewModel: TabBarViewModelType {
     
     // MARK: - Properties
     
-    private let cancelBag = CancelBag()
-    private let userType: UserType
     private let coordinator: AnyCoordinatorObject
+    private let cancelBag = CancelBag()
     private let homeUseCase: HomeUseCase
+    
+    private let userType: UserType
     @Published public private(set) var tabBarBadges: [TabBarItemType: String] = [:]
     
     // MARK: - Inputs
@@ -38,7 +39,7 @@ final public class TabBarViewModel: TabBarViewModelType {
     
     // MARK: - TabBarCoordinating
     
-    public var onTabBarItemTapped: ((Int) -> Void)?
+    public var onTabBarItemTapped: ((TabBarItemType) -> Void)?
     public var showTabBarAlert: (() -> Void)?
     
     // MARK: - initialization
@@ -63,8 +64,9 @@ extension TabBarViewModel {
         input.isTabSelectedIndex
             .withUnretained(self)
             .sink { owner, index in
-                owner.onTabBarItemTapped?(index)
-                owner.trackAmplitude(itemIndex: index)
+                guard let tabBar = TabBarItemType.from(index: index, userType: owner.userType) else { return }
+                owner.onTabBarItemTapped?(tabBar)
+                owner.trackAmplitude(itemType: tabBar)
             }.store(in: cancelBag)
         
         return output
@@ -74,10 +76,8 @@ extension TabBarViewModel {
 // MARK: - Methods
 
 extension TabBarViewModel {
-    private func trackAmplitude(itemIndex: Int) {
-        if let item = TabBarItemType(rawValue: itemIndex) {
-            AmplitudeInstance.shared.trackWithUserType(event: item.toAmplitudeEventType)
-        }
+    private func trackAmplitude(itemType: TabBarItemType) {
+        AmplitudeInstance.shared.trackWithUserType(event: itemType.toAmplitudeEventType)
     }
     
     private func fetchAppServiceBadges() {


### PR DESCRIPTION
## 🌴 PR 요약
- 탭 바 전환 로직을 수정했습니다.

🌱 작업한 브랜치
- feature/#788

## 🌱 PR Point
유저의 활동 여부에 따라 화면전환을 분기처리하는 로직에서 문제가 발생하는 부분을 해결했습니다.

### 문제 원인
<img width="2198" height="158" alt="image" src="https://github.com/user-attachments/assets/efe5f786-5fb1-4067-a943-1e31c41f3c8c" />

1. `TabBarController`에서 선택된 탭의 Index를 전달
2. `TabBarViewModel`에서 인덱스를 `TabBarCoordinator`로 전달
3. `TabBarCoordinator`에서 **index를 가지고 분기처리**
    - 이때 rawValue를 가지고 탭 바 아이템을 찾기 때문에 유저의 활동/비활동 상태가 반영되지 않음
    - ex) 비활동 상태의 경우 콕찌르기가 1의 인덱스를 갖지만, rawValue 1은 `.soptamp`이기 때문
    - ex) 활동 상태의 경우 콕찌르기가 2의 인덱스를 가져 rawValue 2인 `.poke`를 잘 찾을 수 있음

인덱스로 관리하게 되면 추후 **탭이 변경되었을 때 수정 범위를 찾기 어렵다고 판단**했습니다.
해당 이슈의 원인도 **활동 상태에 따라 인덱스가 나타내는 탭이 무엇인지 직관적으로 알 수 없기 때문**이라고 생각했습니다. 따라서 인덱스가 아닌 **case를 기준으로 탭을 전환하도록 수정**했습니다.

### 수정 이후
<img width="2255" height="189" alt="image" src="https://github.com/user-attachments/assets/95fe02a1-2630-4e46-953f-4a9fecd42ecb" />

- 각 타입에서 탭바 전환 정보는 열거형 정보로 전달합니다.
- 탭바의 값을 직접 수정해야하는 Controller와 ApplicationCoordinator에서는 인덱스를 사용합니다.
- `인덱스 -> 탭바 아이템`의 동작을 하는 from 메소드를 추가했습니다.
- `getTabIndex`는 `AppCoordinator`에서 인덱스를 할당할 때 사용되므로 유지하였습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `인덱스 -> 열거형 케이스 -> 인덱스`처럼 변환 후 다시 역변환하기 때문에 불필요한 계산이 들어갔다고 느껴질 것 같습니다. 하지만 객체 간 인덱스로 정보를 주고받는 것보다 변환을 두 번 하는 것이 유지보수에 더 큰 장점이라고 생각되어 해당 방법을 선택했습니다.

## 📸 스크린샷
- 솝탬프 메뉴 클릭 시 화면전환  

|기능|스크린샷|
|:--:|:--:|
|수정 전|![Simulator Screen Recording - iPhone 16 - 2025-12-13 at 02 00 19](https://github.com/user-attachments/assets/65b4ce0e-b8ea-4342-9123-6479975e09e9)|
|수정 후|![Simulator Screen Recording - iPhone 16 Pro - 2025-12-13 at 02 01 24](https://github.com/user-attachments/assets/d61c2743-9aee-48a7-8c1a-36e142c5b272)|

## 📮 관련 이슈
- Resolved: #788 
