### PR TITLE
[Feature] #802 토글버튼, 플로팅 버튼 추가

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/MissionListFetchType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/MissionListFetchType.swift
@@ -12,6 +12,7 @@ public enum MissionListFetchType: String {
     case all
     case complete
     case incomplete
+    case appjam
     
     public var path: String {
         return self.rawValue

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -136,7 +136,8 @@ public struct I18N {
     
     public struct RankingList {
         public static let noSentenceText = "설정된 한 마디가 없습니다."
-        public static let rankingForPartTitle = "파트별 랭킹"
+        public static let partRankingTitle = "파트별 랭킹"
+        public static let personalRankingTitle = "개인별 랭킹"
         public static let myRanking = "내 랭킹 보기"
     }
     

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -138,6 +138,7 @@ public struct I18N {
         public static let noSentenceText = "설정된 한 마디가 없습니다."
         public static let partRankingTitle = "파트별 랭킹"
         public static let personalRankingTitle = "개인별 랭킹"
+        public static let appjamRankingTitle = "앱잼팀 랭킹"
         public static let myRanking = "내 랭킹 보기"
     }
     

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -128,6 +128,10 @@ public struct I18N {
         public static let noMission = "아직 완료한 미션이 없습니다!"
         public static let multipleTen = "x 10"
         public static let specialMission = "특별미션"
+        public static let allMission = "전체 미션"
+        public static let completeMission = "완료 미션"
+        public static let uncompleteMission = "미완료 미션"
+        public static let appjamMission = "앱잼 미션"
     }
     
     public struct RankingList {

--- a/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/MissionListRepository.swift
@@ -70,6 +70,11 @@ extension MissionListRepository {
       return missionService.fetchIncompleteMissionList()
         .map { $0.toDomain() }
         .eraseToAnyPublisher()
+    // TODO: - API 연결 시 수정
+    default:
+        return missionService.fetchAllMissionList()
+          .map { $0.toDomain() }
+          .eraseToAnyPublisher()
     }
   }
   

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STBadgeView.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STBadgeView.swift
@@ -1,0 +1,72 @@
+//
+//  STBadgeView.swift
+//  StampFeature
+//
+//  Created by 최주리 on 12/17/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import DSKit
+
+final class STBadgeView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
+        $0.textColor = DSKitAsset.Colors.black.color
+        $0.textAlignment = .center
+    }
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setCornerRadius()
+    }
+}
+
+
+// MARK: - UI & Layout
+
+extension STBadgeView {
+    private func setUI() {
+        self.backgroundColor = DSKitAsset.Colors.secondary.color
+    }
+    
+    private func setLayout() {
+        self.addSubviews(titleLabel)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(6)
+            make.top.bottom.equalToSuperview().inset(3)
+            make.width.greaterThanOrEqualTo(8)
+        }
+    }
+    
+    private func setCornerRadius() {
+        self.layer.cornerRadius = self.frame.height / 2
+    }
+}
+
+
+// MARK: - Methods
+
+extension STBadgeView {
+    func setData(with text: String) {
+        self.titleLabel.text = text
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import Combine
 
 import Core
 import DSKit

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
@@ -22,57 +22,31 @@ final class STDoubleFloatingButton: UIView {
     
     private lazy var stackView = UIStackView().then {
         $0.axis = .horizontal
-        $0.spacing = 0.f
     }
     
-    private lazy var personalRankButton: UIButton = {
-        let bt = UIButton()
-        var config = UIButton.Configuration.plain()
+    private lazy var personalRankButton = UIButton().then {
+        let config = setButtonConfiguration(
+            text: I18N.RankingList.personalRankingTitle,
+            textColor: DSKitColors.Color.black
+        )
         
-        config.background.backgroundColor = .clear
-        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: -15, bottom: 0, trailing: 0)
-        config.imagePadding = 10
-        config.baseForegroundColor = DSKitAsset.Colors.black.color
-        config.image = DSKitAsset.Assets.icTrophy.image
-        
-        var attributedStr = AttributedString(I18N.RankingList.personalRankingTitle)
-        attributedStr.font = .SoptampFont.h2
-        attributedStr.foregroundColor = DSKitColors.Color.black
-        attributedStr.kern = 0
-        config.attributedTitle = attributedStr
-        
-        bt.configuration = config
-        bt.layer.backgroundColor = DSKitAsset.Colors.white.color.cgColor
-        bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-        bt.layer.cornerRadius = 27
-        
-        return bt
-    }()
+        $0.configuration = config
+        $0.layer.backgroundColor = DSKitAsset.Colors.white.color.cgColor
+        $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+        $0.layer.cornerRadius = 27
+    }
     
-    private lazy var partRankButton: UIButton = {
-        let bt = UIButton()
-        var config = UIButton.Configuration.plain()
+    private lazy var partRankButton = UIButton().then {
+        let config = setButtonConfiguration(
+            text: I18N.RankingList.partRankingTitle,
+            textColor: DSKitColors.Color.white
+        )
         
-        config.background.backgroundColor = .clear
-        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: -15, bottom: 0, trailing: 0)
-        config.imagePadding = 10
-        config.baseForegroundColor = DSKitAsset.Colors.black.color
-        config.image = DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate)
-        config.baseForegroundColor = DSKitColors.Color.white
-        
-        var attributedStr = AttributedString(I18N.RankingList.partRankingTitle)
-        attributedStr.font = .SoptampFont.h2
-        attributedStr.foregroundColor = DSKitColors.Color.white
-        attributedStr.kern = 0
-        config.attributedTitle = attributedStr
-        
-        bt.configuration = config
-        bt.layer.backgroundColor = DSKitAsset.Colors.black.color.cgColor
-        bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-        bt.layer.cornerRadius = 27
-        
-        return bt
-    }()
+        $0.configuration = config
+        $0.layer.backgroundColor = DSKitAsset.Colors.black.color.cgColor
+        $0.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+        $0.layer.cornerRadius = 27
+    }
     
     // MARK: - Initialization
     
@@ -107,5 +81,22 @@ extension STDoubleFloatingButton {
             make.width.equalTo(143.adjusted)
             make.height.equalTo(54.adjustedH)
         }
+    }
+    
+    private func setButtonConfiguration(text: String, textColor: UIColor) -> UIButton.Configuration {
+        var config = UIButton.Configuration.plain()
+        
+        config.background.backgroundColor = .clear
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: -15, bottom: 0, trailing: 0)
+        config.imagePadding = 10
+        config.image = DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate)
+        config.baseForegroundColor = textColor
+        
+        var attributedStr = AttributedString(text)
+        attributedStr.font = .SoptampFont.h2
+        attributedStr.foregroundColor = textColor
+        config.attributedTitle = attributedStr
+        
+        return config
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
@@ -1,0 +1,101 @@
+//
+//  STDoubleFloatingButton.swift
+//  StampFeature
+//
+//  Created by 최주리 on 12/17/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import DSKit
+
+final class STDoubleFloatingButton: UIView {
+
+    // MARK: - Properties
+    
+    public lazy var personalButtonTapped = personalRankButton.gesture().mapVoid().asDriver()
+    public lazy var partButtonTapped = partRankButton.gesture().mapVoid().asDriver()
+    
+    // MARK: - UI Components
+    
+    private lazy var stackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 0.f
+    }
+    
+    private lazy var personalRankButton: UIButton = {
+        let bt = UIButton()
+        bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+        bt.layer.cornerRadius = 27.adjustedH
+        bt.setBackgroundColor(DSKitAsset.Colors.white.color, for: .normal)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .normal)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .highlighted)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .selected)
+        bt.tintColor = DSKitAsset.Colors.black.color
+        bt.titleLabel?.font = .SoptampFont.h2
+        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.personalRankingTitle)
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitColors.Color.black, range: NSMakeRange(0, attributedStr.length))
+        bt.setAttributedTitle(attributedStr, for: .normal)
+        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
+        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        return bt
+    }()
+    
+    private lazy var partRankButton: UIButton = {
+        let bt = UIButton()
+        bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
+        bt.layer.cornerRadius = 27.adjustedH
+        bt.setBackgroundColor(DSKitAsset.Colors.black.color, for: .normal)
+        bt.setBackgroundColor(DSKitAsset.Colors.black.color.withAlphaComponent(0.8), for: .selected)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
+        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .highlighted)
+        bt.tintColor = .white
+        bt.titleLabel?.font = .SoptampFont.h2
+        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.partRankingTitle)
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
+        bt.setAttributedTitle(attributedStr, for: .normal)
+        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
+        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        return bt
+    }()
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: UI & Layout
+
+extension STDoubleFloatingButton {
+    private func setLayout() {
+        self.addSubview(stackView)
+        stackView.addArrangedSubviews(personalRankButton, partRankButton)
+        
+        stackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        personalRankButton.snp.makeConstraints { make in
+            make.width.equalTo(143.adjusted)
+            make.height.equalTo(54.adjustedH)
+        }
+        
+        partRankButton.snp.makeConstraints { make in
+            make.width.equalTo(143.adjusted)
+            make.height.equalTo(54.adjustedH)
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STDoubleFloatingButton.swift
@@ -27,39 +27,50 @@ final class STDoubleFloatingButton: UIView {
     
     private lazy var personalRankButton: UIButton = {
         let bt = UIButton()
+        var config = UIButton.Configuration.plain()
+        
+        config.background.backgroundColor = .clear
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: -15, bottom: 0, trailing: 0)
+        config.imagePadding = 10
+        config.baseForegroundColor = DSKitAsset.Colors.black.color
+        config.image = DSKitAsset.Assets.icTrophy.image
+        
+        var attributedStr = AttributedString(I18N.RankingList.personalRankingTitle)
+        attributedStr.font = .SoptampFont.h2
+        attributedStr.foregroundColor = DSKitColors.Color.black
+        attributedStr.kern = 0
+        config.attributedTitle = attributedStr
+        
+        bt.configuration = config
+        bt.layer.backgroundColor = DSKitAsset.Colors.white.color.cgColor
         bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.setBackgroundColor(DSKitAsset.Colors.white.color, for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .highlighted)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .selected)
-        bt.tintColor = DSKitAsset.Colors.black.color
-        bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.personalRankingTitle)
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitColors.Color.black, range: NSMakeRange(0, attributedStr.length))
-        bt.setAttributedTitle(attributedStr, for: .normal)
-        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        bt.layer.cornerRadius = 27
+        
         return bt
     }()
     
     private lazy var partRankButton: UIButton = {
         let bt = UIButton()
+        var config = UIButton.Configuration.plain()
+        
+        config.background.backgroundColor = .clear
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: -15, bottom: 0, trailing: 0)
+        config.imagePadding = 10
+        config.baseForegroundColor = DSKitAsset.Colors.black.color
+        config.image = DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate)
+        config.baseForegroundColor = DSKitColors.Color.white
+        
+        var attributedStr = AttributedString(I18N.RankingList.partRankingTitle)
+        attributedStr.font = .SoptampFont.h2
+        attributedStr.foregroundColor = DSKitColors.Color.white
+        attributedStr.kern = 0
+        config.attributedTitle = attributedStr
+        
+        bt.configuration = config
+        bt.layer.backgroundColor = DSKitAsset.Colors.black.color.cgColor
         bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.setBackgroundColor(DSKitAsset.Colors.black.color, for: .normal)
-        bt.setBackgroundColor(DSKitAsset.Colors.black.color.withAlphaComponent(0.8), for: .selected)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .highlighted)
-        bt.tintColor = .white
-        bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.partRankingTitle)
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
-        bt.setAttributedTitle(attributedStr, for: .normal)
-        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        bt.layer.cornerRadius = 27
+        
         return bt
     }()
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
@@ -19,14 +19,11 @@ final class STSingleFloatingButton: UIView {
     
     // MARK: - UI Components
     
-    private let floatingButton: UIButton = {
-        let bt = UIButton()
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.backgroundColor = DSKitAsset.Colors.white.color
-        bt.titleLabel?.font = .SoptampFont.h2
-        
-        return bt
-    }()
+    private let floatingButton = UIButton().then {
+        $0.layer.cornerRadius = 27.adjustedH
+        $0.backgroundColor = DSKitAsset.Colors.white.color
+        $0.titleLabel?.font = .SoptampFont.h2
+    }
     
     private let badgeView = STBadgeView().then {
         $0.isHidden = true
@@ -38,16 +35,7 @@ final class STSingleFloatingButton: UIView {
         super.init(frame: frame)
         
         setLayout()
-        setTitle(title)
-        
-        if showBadge {
-            badgeView.isHidden = false
-            badgeView.setData(with: "New")
-        }
-        
-        if withImage {
-            floatingButton.setImage(DSKitAsset.Assets.icTrophy.image, for: .normal)
-        }
+        setData(title: title, withImage: withImage, showBadge: showBadge)
     }
     
     required init?(coder: NSCoder) {
@@ -72,11 +60,20 @@ extension STSingleFloatingButton {
             make.trailing.equalTo(floatingButton.snp.trailing).offset(-16)
         }
     }
-    
-    private func setTitle(_ title: String) {
+
+    private func setData(title: String, withImage: Bool, showBadge: Bool) {
         let attributedStr = NSMutableAttributedString(string: title)
         attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
         attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitAsset.Colors.black.color, range: NSMakeRange(0, attributedStr.length))
         floatingButton.setAttributedTitle(attributedStr, for: .normal)
+        
+        if showBadge {
+            badgeView.isHidden = false
+            badgeView.setData(with: "New")
+        }
+        
+        if withImage {
+            floatingButton.setImage(DSKitAsset.Assets.icTrophy.image, for: .normal)
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
@@ -1,0 +1,64 @@
+//
+//  STFloatingButton.swift
+//  StampFeature
+//
+//  Created by 최주리 on 12/17/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+import Combine
+
+import Core
+import DSKit
+
+final class STSingleFloatingButton: UIView {
+
+    // MARK: - Properties
+    
+    public lazy var buttonTapped = floatingButton.gesture().mapVoid().asDriver()
+    
+    // MARK: - UI Components
+    
+    private let floatingButton: UIButton = {
+        let bt = UIButton()
+        bt.layer.cornerRadius = 27.adjustedH
+        bt.backgroundColor = DSKitAsset.Colors.white.color
+        bt.titleLabel?.font = .SoptampFont.h2
+        return bt
+    }()
+    
+    // MARK: - Initialization
+    
+    init(frame: CGRect, title: String) {
+        super.init(frame: frame)
+        
+        setLayout()
+        setTitle(title)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: UI & Layout
+
+extension STSingleFloatingButton {
+    private func setLayout() {
+        addSubview(floatingButton)
+        
+        floatingButton.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalTo(143.adjusted)
+            make.height.equalTo(54.adjustedH)
+        }
+    }
+    
+    private func setTitle(_ title: String) {
+        let attributedStr = NSMutableAttributedString(string: title)
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
+        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitAsset.Colors.black.color, range: NSMakeRange(0, attributedStr.length))
+        floatingButton.setAttributedTitle(attributedStr, for: .normal)
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
@@ -20,7 +20,7 @@ final class STSingleFloatingButton: UIView {
     // MARK: - UI Components
     
     private let floatingButton = UIButton().then {
-        $0.layer.cornerRadius = 27.adjustedH
+        $0.layer.cornerRadius = 27
         $0.backgroundColor = DSKitAsset.Colors.white.color
         $0.titleLabel?.font = .SoptampFont.h2
     }
@@ -51,8 +51,8 @@ extension STSingleFloatingButton {
         
         floatingButton.snp.makeConstraints { make in
             make.edges.equalToSuperview()
-            make.width.equalTo(143.adjusted)
-            make.height.equalTo(54.adjustedH)
+            make.width.equalTo(143)
+            make.height.equalTo(54)
         }
         
         badgeView.snp.makeConstraints { make in

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STSingleFloatingButton.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import Combine
 
 import Core
 import DSKit
@@ -25,16 +24,30 @@ final class STSingleFloatingButton: UIView {
         bt.layer.cornerRadius = 27.adjustedH
         bt.backgroundColor = DSKitAsset.Colors.white.color
         bt.titleLabel?.font = .SoptampFont.h2
+        
         return bt
     }()
     
+    private let badgeView = STBadgeView().then {
+        $0.isHidden = true
+    }
+    
     // MARK: - Initialization
     
-    init(frame: CGRect, title: String) {
+    init(frame: CGRect, title: String, withImage: Bool = false, showBadge: Bool = false) {
         super.init(frame: frame)
         
         setLayout()
         setTitle(title)
+        
+        if showBadge {
+            badgeView.isHidden = false
+            badgeView.setData(with: "New")
+        }
+        
+        if withImage {
+            floatingButton.setImage(DSKitAsset.Assets.icTrophy.image, for: .normal)
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -46,12 +59,17 @@ final class STSingleFloatingButton: UIView {
 
 extension STSingleFloatingButton {
     private func setLayout() {
-        addSubview(floatingButton)
+        addSubviews(floatingButton, badgeView)
         
         floatingButton.snp.makeConstraints { make in
             make.edges.equalToSuperview()
             make.width.equalTo(143.adjusted)
             make.height.equalTo(54.adjustedH)
+        }
+        
+        badgeView.snp.makeConstraints { make in
+            make.top.equalTo(floatingButton.snp.top).offset(-10)
+            make.trailing.equalTo(floatingButton.snp.trailing).offset(-16)
         }
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -110,45 +110,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     
     private let missionListEmptyView = MissionListEmptyView()
     
-    private lazy var floatingButtonStackView = UIStackView(frame: self.view.frame).then {
-        $0.axis = .horizontal
-        $0.spacing = 0.f
-    }
-    
-    private lazy var currentGenerationRankFloatingButton: UIButton = {
-        let bt = UIButton()
-        bt.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.setBackgroundColor(DSKitAsset.Colors.white.color, for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.white.color), for: .highlighted)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .selected)
-        bt.tintColor = DSKitAsset.Colors.black.color
-        bt.titleLabel?.font = .SoptampFont.h2
-        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-        return bt
-    }()
-    
-    private lazy var partRankingFloatingButton: UIButton = {
-        let bt = UIButton()
-        bt.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.setBackgroundColor(DSKitAsset.Colors.black.color, for: .normal)
-        bt.setBackgroundColor(DSKitAsset.Colors.black.color.withAlphaComponent(0.8), for: .selected)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate), for: .normal)
-        bt.setImage(DSKitAsset.Assets.icTrophy.image.withRenderingMode(.alwaysTemplate).withTintColor(DSKitAsset.Colors.gray200.color), for: .highlighted)
-        bt.tintColor = .white
-        bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.rankingForPartTitle)
-        let style = NSMutableParagraphStyle()
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.white, range: NSMakeRange(0, attributedStr.length))
-        bt.setAttributedTitle(attributedStr, for: .normal)
-        bt.contentEdgeInsets = UIEdgeInsets(top: 0, left: -15, bottom: 0, right: 0)
-        bt.titleEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-        return bt
-    }()
+    private let doubleFloatingButton = STDoubleFloatingButton()
     
     // MARK: - View Life Cycle
     
@@ -219,21 +181,11 @@ extension MissionListVC {
         
         switch sceneType {
         case .default:
-            self.view.addSubview(self.floatingButtonStackView)
+            self.view.addSubview(self.doubleFloatingButton)
             
-            self.floatingButtonStackView.snp.makeConstraints { make in
+            self.doubleFloatingButton.snp.makeConstraints { make in
                 make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
                 make.centerX.equalToSuperview()
-            }
-            
-            self.partRankingFloatingButton.snp.makeConstraints {
-                $0.width.equalTo(143.adjusted)
-                $0.height.equalTo(54.adjustedH)
-            }
-            
-            self.currentGenerationRankFloatingButton.snp.makeConstraints {
-                $0.width.equalTo(143.adjusted)
-                $0.height.equalTo(54.adjustedH)
             }
             
         case .ranking:
@@ -272,13 +224,13 @@ extension MissionListVC {
                 owner.onNaviBackTap?()
             }.store(in: self.cancelBag)
         
-        partRankingFloatingButton.publisher(for: .touchUpInside)
+        doubleFloatingButton.partButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onPartRankingButtonTap?(.partRanking)
             }.store(in: self.cancelBag)
         
-        currentGenerationRankFloatingButton.publisher(for: .touchUpInside)
+        doubleFloatingButton.personalButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
                 guard let usersActiveGenerationStatus = owner.usersActiveGenerationStatus else { return }
@@ -321,8 +273,6 @@ extension MissionListVC {
                 guard generationStatus.status == .ACTIVE else { return }
                 
                 self?.usersActiveGenerationStatus = generationStatus
-                self?.remakeButtonConstraint()
-                self?.configurePersonalRankingButton()
             }.store(in: self.cancelBag)
         
         output.needNetworkAlert
@@ -413,8 +363,8 @@ extension MissionListVC {
     
     private func bringRankingFloatingButtonToFront() {
         self.view.subviews.forEach { view in
-            if view == self.partRankingFloatingButton {
-                self.view.bringSubviewToFront(partRankingFloatingButton)
+            if view == self.doubleFloatingButton {
+                self.view.bringSubviewToFront(doubleFloatingButton)
             }
         }
     }
@@ -425,17 +375,6 @@ extension MissionListVC {
         snapshot.appendItems(model, toSection: .missionList)
         dataSource.apply(snapshot, animatingDifferences: false)
         self.view.setNeedsLayout()
-    }
-    
-    private func remakeButtonConstraint() {
-        self.floatingButtonStackView.addArrangedSubviews(self.currentGenerationRankFloatingButton, self.partRankingFloatingButton)
-    }
-    
-    private func configurePersonalRankingButton() {
-        let attributedStr = NSMutableAttributedString(string: "개인별 랭킹")
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitColors.Color.black, range: NSMakeRange(0, attributedStr.length))
-        self.currentGenerationRankFloatingButton.setAttributedTitle(attributedStr, for: .normal)
     }
     
     private func showNetworkAlert() {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -54,7 +54,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         switch sceneType {
         case .default:
             return STNavigationBar(type: .title)
-                .setTitle("전체 미션")
+                .setTitle(I18N.MissionList.allMission)
                 .setTitleTypoStyle(.SoptampFont.h2)
                 .setTitleButtonMenu(menuItems: self.menuItems)
                 .addLeftButtonToTitleMenu()
@@ -68,9 +68,9 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     
     private lazy var menuItems: [UIAction] = {
         var menuItems: [UIAction] = []
-        [("전체 미션", MissionListFetchType.all),
-         ("완료 미션", MissionListFetchType.complete),
-         ("미완료 미션", MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
+        [(I18N.MissionList.allMission, MissionListFetchType.all),
+         (I18N.MissionList.completeMission, MissionListFetchType.complete),
+         (I18N.MissionList.uncompleteMission, MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
             menuItems.append(UIAction(title: menuTitle,
                                       handler: { [weak self] _ in
                 self?.missionTypeMenuSelected.send(fetchType)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -94,7 +94,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         lb.numberOfLines = 2
         lb.textAlignment = .center
         lb.backgroundColor = DSKitAsset.Colors.soptampPurple100.color
-        lb.layer.cornerRadius = 9.adjustedH
+        lb.layer.cornerRadius = 9
         lb.clipsToBounds = true
         lb.setCharacterSpacing(0)
         return lb
@@ -181,7 +181,7 @@ extension MissionListVC {
         naviBar.setLeftButtonHidden(isRouteFromTabBar)
         
         missionListCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom).offset(20.adjustedH)
+            make.top.equalTo(naviBar.snp.bottom).offset(20)
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
         }
@@ -192,14 +192,14 @@ extension MissionListVC {
                 self.view.addSubview(self.singleFloatingButton)
                 
                 self.singleFloatingButton.snp.makeConstraints { make in
-                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
                     make.centerX.equalToSuperview()
                 }
             } else {
                 self.view.addSubview(self.doubleFloatingButton)
                 
                 self.doubleFloatingButton.snp.makeConstraints { make in
-                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
                     make.centerX.equalToSuperview()
                 }
             }
@@ -208,13 +208,13 @@ extension MissionListVC {
             self.view.addSubview(sentenceLabel)
             
             sentenceLabel.snp.makeConstraints { make in
-                make.top.equalTo(naviBar.snp.bottom).offset(10.adjustedH)
-                make.leading.trailing.equalToSuperview().inset(20.adjusted)
-                make.height.equalTo(64.adjustedH)
+                make.top.equalTo(naviBar.snp.bottom).offset(10)
+                make.leading.trailing.equalToSuperview().inset(20)
+                make.height.equalTo(64)
             }
             
             missionListCollectionView.snp.remakeConstraints { make in
-                make.top.equalTo(sentenceLabel.snp.bottom).offset(16.adjustedH)
+                make.top.equalTo(sentenceLabel.snp.bottom).offset(16)
                 make.leading.trailing.equalToSuperview()
                 make.bottom.equalToSuperview()
             }
@@ -375,7 +375,7 @@ extension MissionListVC {
         missionListEmptyView.removeFromSuperview()
         self.view.addSubviews(missionListEmptyView)
         missionListEmptyView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom).offset(145.adjustedH)
+            make.top.equalTo(naviBar.snp.bottom).offset(145)
             make.centerX.equalToSuperview()
             make.width.equalToSuperview()
             make.bottom.equalToSuperview().priority(.low)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -112,6 +112,13 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     
     private let doubleFloatingButton = STDoubleFloatingButton()
     
+    private let singleFloatingButton = STSingleFloatingButton(
+        frame: .zero,
+        title: I18N.RankingList.appjamRankingTitle,
+        withImage: true,
+        showBadge: true
+    )
+    
     // MARK: - View Life Cycle
     
     public override func viewDidLoad() {
@@ -181,11 +188,20 @@ extension MissionListVC {
         
         switch sceneType {
         case .default:
-            self.view.addSubview(self.doubleFloatingButton)
-            
-            self.doubleFloatingButton.snp.makeConstraints { make in
-                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
-                make.centerX.equalToSuperview()
+            if isAppJam {
+                self.view.addSubview(self.singleFloatingButton)
+                
+                self.singleFloatingButton.snp.makeConstraints { make in
+                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+                    make.centerX.equalToSuperview()
+                }
+            } else {
+                self.view.addSubview(self.doubleFloatingButton)
+                
+                self.doubleFloatingButton.snp.makeConstraints { make in
+                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
+                    make.centerX.equalToSuperview()
+                }
             }
             
         case .ranking:
@@ -236,6 +252,12 @@ extension MissionListVC {
                 guard let usersActiveGenerationStatus = owner.usersActiveGenerationStatus else { return }
                 
                 owner.onCurrentGenerationRankingButtonTap?(.currentGeneration(info: usersActiveGenerationStatus))
+            }.store(in: self.cancelBag)
+        
+        singleFloatingButton.buttonTapped
+            .withUnretained(self)
+            .sink { owner, _ in
+                // TODO: - 화면 전환 연결
             }.store(in: self.cancelBag)
         
         swipeHandler

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -21,6 +21,9 @@ import BaseFeatureDependency
 
 public class MissionListVC: UIViewController, MissionListViewControllable, LegacyMissionListViewControllable {
     
+    // TODO: - 화면 전환 시에 수정
+    private var isAppJam: Bool = true
+    
     // MARK: - Properties
     
     public var viewModel: MissionListViewModel
@@ -54,7 +57,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         switch sceneType {
         case .default:
             return STNavigationBar(type: .title)
-                .setTitle(I18N.MissionList.allMission)
+                .setTitle(isAppJam ? I18N.MissionList.appjamMission : I18N.MissionList.allMission)
                 .setTitleTypoStyle(.SoptampFont.h2)
                 .setTitleButtonMenu(menuItems: self.menuItems)
                 .addLeftButtonToTitleMenu()
@@ -70,7 +73,8 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         var menuItems: [UIAction] = []
         [(I18N.MissionList.allMission, MissionListFetchType.all),
          (I18N.MissionList.completeMission, MissionListFetchType.complete),
-         (I18N.MissionList.uncompleteMission, MissionListFetchType.incomplete)].forEach { [weak self] menuTitle, fetchType in
+         (I18N.MissionList.uncompleteMission, MissionListFetchType.incomplete),
+         (I18N.MissionList.appjamMission, MissionListFetchType.appjam)].forEach { [weak self] menuTitle, fetchType in
             menuItems.append(UIAction(title: menuTitle,
                                       handler: { [weak self] _ in
                 self?.missionTypeMenuSelected.send(fetchType)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -388,6 +388,10 @@ extension MissionListVC {
             if view == self.doubleFloatingButton {
                 self.view.bringSubviewToFront(doubleFloatingButton)
             }
+            
+            if view == self.singleFloatingButton {
+                self.view.bringSubviewToFront(singleFloatingButton)
+            }
         }
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
@@ -37,7 +37,7 @@ public class PartRankingVC: UIViewController, LegacyPartRankingViewControllable,
     
     lazy var naviBar = STNavigationBar(type: .titleWithLeftButton)
         .setTitleTypoStyle(.SoptampFont.h2)
-        .setTitle(I18N.RankingList.rankingForPartTitle)
+        .setTitle(I18N.RankingList.partRankingTitle)
         .setRightButton(.none)
     
     private lazy var rankingCollectionView: UICollectionView = {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -53,19 +53,12 @@ public class RankingVC: UIViewController, LegacyRankingViewControllable, Ranking
         return rf
     }()
     
-    private lazy var showMyRankingFloatingButton: UIButton = {
-        let bt = UIButton()
-        bt.layer.cornerRadius = 27.adjustedH
-        bt.backgroundColor = DSKitAsset.Colors.white.color
-        bt.titleLabel?.font = .SoptampFont.h2
-        let attributedStr = NSMutableAttributedString(string: I18N.RankingList.myRanking)
-        let style = NSMutableParagraphStyle()
-        attributedStr.addAttribute(NSAttributedString.Key.kern, value: 0, range: NSMakeRange(0, attributedStr.length))
-        attributedStr.addAttribute(NSAttributedString.Key.foregroundColor, value: DSKitAsset.Colors.black.color, range: NSMakeRange(0, attributedStr.length))
-        bt.setAttributedTitle(attributedStr, for: .normal)
-        bt.isHidden = true
-        return bt
-    }()
+    private let showMyRankingFloatingButton = STSingleFloatingButton(
+        frame: .zero,
+        title: I18N.RankingList.myRanking
+    ).then {
+        $0.isHidden = true
+    }
     
     // MARK: - View Life Cycle
     private let rankingViewType: RankingViewType
@@ -125,8 +118,6 @@ extension RankingVC {
         }
         
         showMyRankingFloatingButton.snp.makeConstraints { make in
-            make.width.equalTo(143.adjusted)
-            make.height.equalTo(54.adjustedH)
             make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18.adjustedH)
             make.centerX.equalToSuperview()
         }
@@ -150,8 +141,7 @@ extension RankingVC {
             .mapVoid()
             .asDriver()
         
-        let showRankingButtonTapped = self.showMyRankingFloatingButton
-            .publisher(for: .touchUpInside)
+        let showRankingButtonTapped = self.showMyRankingFloatingButton.buttonTapped
             .withUnretained(self)
             .filter { owner, _ in owner.rankingCollectionView.indexPathsForVisibleItems.count > 5 }
             .mapVoid()


### PR DESCRIPTION
## 🌴 PR 요약

앱잼 솝탬프 관련 토글버튼, 플로팅 버튼 추가

🌱 작업한 브랜치
- feature/#802

## 🌱 PR Point
솝탬프 내에서 사용되고 있는 플로팅 버튼을 컴포넌트로 분리했습니다.
MissionListVC에서 사용되고 있는 버튼 2개 버전 플로팅 버튼(**STDoubleFloatingButton**)과 개인 랭킹에서 버튼 1개 플로팅 버튼(**STSingleFloatingButton**)을 따로 구현했습니다.

MissionListVC에서 **isAppJam** flag를 두고 UI 분기처리했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
TODO 주석으로 화면 전환이 필요한 부분 표시해두었습니다.

```swift
singleFloatingButton.buttonTapped
  .withUnretained(self)
   .sink { owner, _ in
     // TODO: - 화면 전환 연결
  }.store(in: self.cancelBag)
```

TODO 주석으로 API 연결 시 수정이 필요한 부분 표시해두었습니다.

`MissionListRepository`
```swift
  private func fetchMissionList(type: MissionListFetchType) -> AnyPublisher<[MissionListModel], Error> {
    switch type {
    case .all:
      return missionService.fetchAllMissionList()
        .map { $0.toDomain() }
        .eraseToAnyPublisher()
    case .complete:
      return missionService.fetchCompleteMissionList()
        .map { $0.toDomain() }
        .eraseToAnyPublisher()
    case .incomplete:
      return missionService.fetchIncompleteMissionList()
        .map { $0.toDomain() }
        .eraseToAnyPublisher()
    // TODO: - API 연결 시 수정
    default:
        return missionService.fetchAllMissionList()
          .map { $0.toDomain() }
          .eraseToAnyPublisher()
    }
  }
```


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|앱잼 탬프|<img width="300" height="650" alt="Simulator Screenshot - iPhone 16 Pro - 2025-12-17 at 16 58 02" src="https://github.com/user-attachments/assets/ae84ccf4-e7f1-4707-b1d2-495320edc207" />|

## 📮 관련 이슈
- Resolved: #802 
