### PR TITLE
[Feature] #805 - 앱잼탬프 미션 상세뷰 + alert 

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -128,12 +128,14 @@ public struct I18N {
         public static let noMission = "아직 완료한 미션이 없습니다!"
         public static let multipleTen = "x 10"
         public static let specialMission = "특별미션"
+        public static let inactiveUserAlertTitle = "솝탬프 안내"
+        public static let inactiveUserAlertDescription = "각 미션의 인증 내용은 개인, 앱잼팀 랭킹에서\n확인해주세요."
         public static let allMission = "전체 미션"
         public static let completeMission = "완료 미션"
         public static let uncompleteMission = "미완료 미션"
         public static let appjamMission = "앱잼 미션"
     }
-    
+
     public struct RankingList {
         public static let noSentenceText = "설정된 한 마디가 없습니다."
         public static let partRankingTitle = "파트별 랭킹"

--- a/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/ListDetailRepository.swift
@@ -33,14 +33,21 @@ public class ListDetailRepository {
 }
 
 extension ListDetailRepository: ListDetailRepositoryInterface {
-    public func fetchListDetail(missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error> {
+    public func fetchListDetail(isAppjam: Bool?, missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error> {
         let username = username ?? UserDefaultKeyList.User.soptampName
         guard let username else {
             return Fail(error: NSError()).eraseToAnyPublisher()
         }
-        return stampService.fetchStampListDetail(missionId: missionId, username: username)
-            .map { $0.toDomain() }
-            .eraseToAnyPublisher()
+        if isAppjam == true {
+            //TODO: - 앱잼템프용 api로 변경
+            return stampService.fetchStampListDetail(missionId: missionId, username: username)
+                .map { $0.toDomain() }
+                .eraseToAnyPublisher()
+        } else {
+            return stampService.fetchStampListDetail(missionId: missionId, username: username)
+                .map { $0.toDomain() }
+                .eraseToAnyPublisher()
+        }
     }
 
     public func getPresignedURL() -> AnyPublisher<PresignedUrlModel, Error> {

--- a/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/ListDetailModel.swift
@@ -18,7 +18,8 @@ public struct ListDetailModel {
   public let myClapCount: Int?
   public let viewCount: Int
   public let isMine: Bool?
-  
+  public let profileInfo: ProfileInfo?
+
   public init(
     image: String,
     content: String,
@@ -28,7 +29,8 @@ public struct ListDetailModel {
     clapCount: Int,
     myClapCount: Int?,
     viewCount: Int,
-    isMine: Bool?
+    isMine: Bool?,
+    profileInfo: ProfileInfo? = nil
   ) {
     self.image = image
     self.content = content
@@ -39,5 +41,17 @@ public struct ListDetailModel {
     self.myClapCount = myClapCount
     self.viewCount = viewCount
     self.isMine = isMine
+    self.profileInfo = profileInfo
   }
+}
+
+
+public struct ProfileInfo {
+    public let name: String
+    public let imageURL: String?
+
+    public init(name: String, imageURL: String?) {
+        self.name = name
+        self.imageURL = imageURL
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/ListDetailRepositoryInterface.swift
@@ -12,7 +12,7 @@ import Combine
 import Foundation
 
 public protocol ListDetailRepositoryInterface {
-    func fetchListDetail(missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error>
+    func fetchListDetail(isAppjam: Bool?, missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error>
     func getPresignedURL() -> AnyPublisher<PresignedUrlModel, Error>
     func uploadMedia(imageData: Data, presignedUrl: String) -> AnyPublisher<Void, Error>
     func postStamp(stampData: ListDetailRequestModel) -> AnyPublisher<ListDetailModel, Error>

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/ListDetailUseCase.swift
@@ -12,7 +12,7 @@ import Combine
 import Foundation
 
 public protocol ListDetailUseCase {
-    func fetchListDetail(missionId: Int, username: String?)
+    func fetchListDetail(isAppjam: Bool?, missionId: Int, username: String?)
     func postStamp(stampData: ListDetailRequestModel)
     func putStamp(stampData: ListDetailRequestModel)
     func getPresignedURL()
@@ -49,8 +49,8 @@ public class DefaultListDetailUseCase {
 }
 
 extension DefaultListDetailUseCase: ListDetailUseCase {
-    public func fetchListDetail(missionId: Int, username: String?) {
-        repository.fetchListDetail(missionId: missionId, username: username)
+    public func fetchListDetail(isAppjam: Bool?, missionId: Int, username: String?) {
+        repository.fetchListDetail(isAppjam: isAppjam, missionId: missionId, username: username)
             .withUnretained(self)
             .sink(receiveCompletion: { event in
                 print("completion: \(event)")

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertType.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertType.swift
@@ -11,5 +11,6 @@ import Foundation
 public enum AlertType {
     case title
     case titleDescription
+    case titleDescriptionSingleButton 
     case networkErr
 }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
@@ -105,7 +105,7 @@ extension AlertVC {
         
         self.titleLabel.textColor = alertTheme.titleColor
         self.descriptionLabel.textColor = alertTheme.descriptionColor
-        self.cancelButton.setTitleColor(alertTheme.cancelButtonTitleColor(isNetworkErr: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton),
+        self.cancelButton.setTitleColor(alertTheme.cancelButtonTitleColor(isSingleButtonAlert: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton),
                                         for: .normal)
         self.customButton.setTitleColor(alertTheme.customButtonTitleColor, for: .normal)
         

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
@@ -95,7 +95,7 @@ extension AlertVC {
     private func setUI() {
         self.view.backgroundColor = .clear
         self.alertView.backgroundColor = alertTheme.backgroundColor
-        self.cancelButton.backgroundColor = alertTheme.cancelButtonColor(isNetworkErr: self.alertType == .networkErr)
+        self.cancelButton.backgroundColor = alertTheme.cancelButtonColor(isNetworkErr: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton)
         self.customButton.backgroundColor = alertTheme.customButtonColor
         
         self.titleLabel.font = .Main.headline2
@@ -105,14 +105,20 @@ extension AlertVC {
         
         self.titleLabel.textColor = alertTheme.titleColor
         self.descriptionLabel.textColor = alertTheme.descriptionColor
-        self.cancelButton.setTitleColor(alertTheme.cancelButtonTitleColor(isNetworkErr: self.alertType == .networkErr),
+        self.cancelButton.setTitleColor(alertTheme.cancelButtonTitleColor(isNetworkErr: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton),
                                         for: .normal)
         self.customButton.setTitleColor(alertTheme.customButtonTitleColor, for: .normal)
         
         self.descriptionLabel.textAlignment = .center
         self.descriptionLabel.numberOfLines = 2
-        
-        let cancelTitle = (self.alertType == .networkErr) ? I18N.Default.ok : I18N.Default.cancel
+
+        let cancelTitle: String
+        switch self.alertType {
+        case .networkErr, .titleDescriptionSingleButton:
+            cancelTitle = I18N.Default.ok
+        default:
+            cancelTitle = I18N.Default.cancel
+        }
         self.cancelButton.setTitle(cancelTitle, for: .normal)
         
         self.alertView.layer.cornerRadius = 10
@@ -177,7 +183,8 @@ extension AlertVC {
                 make.leading.equalTo(cancelButton.snp.trailing).offset(buttonSpacing)
                 make.height.equalTo(cancelButton.snp.height)
             }
-        case .networkErr:
+
+        case .titleDescriptionSingleButton, .networkErr:
             cancelButton.snp.makeConstraints { make in
                 make.leading.trailing.bottom.equalToSuperview().inset(7)
                 make.height.equalTo(38)

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
@@ -95,7 +95,7 @@ extension AlertVC {
     private func setUI() {
         self.view.backgroundColor = .clear
         self.alertView.backgroundColor = alertTheme.backgroundColor
-        self.cancelButton.backgroundColor = alertTheme.cancelButtonColor(isNetworkErr: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton)
+        self.cancelButton.backgroundColor = alertTheme.cancelButtonColor(isSingleButtonAlert: self.alertType == .networkErr || self.alertType == .titleDescriptionSingleButton)
         self.customButton.backgroundColor = alertTheme.customButtonColor
         
         self.titleLabel.font = .Main.headline2

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVCTheme.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVCTheme.swift
@@ -72,12 +72,12 @@ extension AlertVC.AlertTheme {
         }
     }
     
-    func cancelButtonTitleColor(isNetworkErr: Bool) -> UIColor {
+    func cancelButtonTitleColor(isSingleButtonAlert: Bool) -> UIColor {
         switch self {
         case .main:
-            return isNetworkErr ? DSKitAsset.Colors.black100.color : DSKitAsset.Colors.white.color
+            return isSingleButtonAlert ? DSKitAsset.Colors.black100.color : DSKitAsset.Colors.white.color
         case .soptamp:
-            return isNetworkErr ? DSKitAsset.Colors.black.color : DSKitAsset.Colors.white.color
+            return isSingleButtonAlert ? DSKitAsset.Colors.black.color : DSKitAsset.Colors.white.color
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVCTheme.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVCTheme.swift
@@ -63,12 +63,12 @@ extension AlertVC.AlertTheme {
         }
     }
     
-    func cancelButtonColor(isNetworkErr: Bool) -> UIColor {
+    func cancelButtonColor(isSingleButtonAlert: Bool) -> UIColor {
         switch self {
         case .main:
-            return isNetworkErr ? DSKitAsset.Colors.white.color : DSKitAsset.Colors.gray600.color
+            return isSingleButtonAlert ? DSKitAsset.Colors.white.color : DSKitAsset.Colors.gray600.color
         case .soptamp:
-            return isNetworkErr ? DSKitAsset.Colors.white.color : DSKitAsset.Colors.gray600.color
+            return isSingleButtonAlert ? DSKitAsset.Colors.white.color : DSKitAsset.Colors.gray600.color
         }
     }
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/StampFeatureBuildable.swift
@@ -19,7 +19,8 @@ public protocol StampFeatureBuildable {
         starLevel: StarViewLevel,
         missionId: Int,
         missionTitle: String,
-        otherUserName: String?
+        otherUserName: String?,
+        isAppjam: Bool
     ) -> ListDetailPresentable
     func makeMissionCompletedVC(
         starLevel: StarViewLevel,

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -37,12 +37,14 @@ extension StampBuilder: StampFeatureBuildable {
         starLevel: StarViewLevel,
         missionId: Int,
         missionTitle: String,
-        otherUserName: String?
+        otherUserName: String?,
+        isAppjam: Bool
     ) -> ListDetailPresentable {
         let useCase = DefaultListDetailUseCase(repository: listDetailRepository)
         let viewModel = ListDetailViewModel(
             useCase: useCase,
             sceneType: sceneType,
+            isAppjam: isAppjam, 
             starLevel: starLevel,
             missionId: missionId,
             missionTitle: missionTitle,

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -121,7 +121,9 @@ extension StampCoordinator {
     }
 
     @available(*, deprecated, message: "⚠️ 앱잼 템프인지 일반 미션인지 확인했나요? isAppjam 파라미터로 분기해주세요!")
-    private func showMissionDetail(_ model: MissionListModel, _ username: String?, isAppjam: Bool = false) {        guard let starLevel = StarViewLevel.init(rawValue: model.level) else { return }
+    //TODO: - isAppjam 기본값 제거
+    private func showMissionDetail(_ model: MissionListModel, _ username: String?, isAppjam: Bool = false) {
+        guard let starLevel = StarViewLevel.init(rawValue: model.level) else { return }
 
         var missionDetail = factory.makeListDetailVC(
             sceneType: model.toListDetailSceneType(),

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -117,18 +117,19 @@ extension StampCoordinator {
             level: level,
             isCompleted: true
         )
-        showMissionDetail(model, username)
+        showMissionDetail(model, username, isAppjam: true)
     }
 
-    private func showMissionDetail(_ model: MissionListModel, _ username: String?) {
-        guard let starLevel = StarViewLevel.init(rawValue: model.level) else { return }
+    @available(*, deprecated, message: "⚠️ 앱잼 템프인지 일반 미션인지 확인했나요? isAppjam 파라미터로 분기해주세요!")
+    private func showMissionDetail(_ model: MissionListModel, _ username: String?, isAppjam: Bool = false) {        guard let starLevel = StarViewLevel.init(rawValue: model.level) else { return }
 
         var missionDetail = factory.makeListDetailVC(
             sceneType: model.toListDetailSceneType(),
             starLevel: starLevel,
             missionId: model.id,
             missionTitle: model.title,
-            otherUserName: username
+            otherUserName: username,
+            isAppjam: isAppjam
         )
 
         missionDetail.vc.onComplete = { [weak self] starViewLevel, handler in

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -78,6 +78,7 @@ public class ListDetailVC: UIViewController, LegacyListDetailViewControllable, L
     private let contentStackView = UIStackView()
     private lazy var missionView = MissionView(level: starLevel, mission: missionTitle)
     private let missionImageView = UIImageView()
+    private let profileInfoView = ProfileInfoView()
     private let imagePlaceholderLabel = UILabel()
     private let textView = UITextView()
     private lazy var missionDateTextField = MissionDateView(frame: self.view.frame)
@@ -309,8 +310,13 @@ extension ListDetailVC {
         self.clapBadge.setCount(self.myClapCount)
         
         self.imageURL = model.image
+
+        if let profileInfo = model.profileInfo {
+            showProfileInfo(profileInfo)
+        } else {
+            hideProfileInfo()
+        }
     }
-    
     private func reloadData(_ scenetype: ListDetailSceneType) {
         self.sceneType = scenetype
         self.setUI(self.sceneType)
@@ -715,6 +721,8 @@ extension ListDetailVC {
         self.zoomImageView.layer.cornerRadius = 10
         self.zoomImageView.clipsToBounds = true
         self.zoomImageView.contentMode = .scaleAspectFit
+
+        self.profileInfoView.isHidden = true
     }
     
     private func setTextView(_ state: TextViewState) {
@@ -809,6 +817,30 @@ extension ListDetailVC {
         imagePlaceholderLabel.snp.makeConstraints { make in
             make.center.equalTo(missionImageView.snp.center)
         }
+    }
+
+    private func showProfileInfo(_ info: ProfileInfo) {
+        profileInfoView.configure(name: info.name, profileImageURL: info.imageURL)
+
+        if !contentStackView.arrangedSubviews.contains(profileInfoView) {
+            contentStackView.insertArrangedSubview(profileInfoView, at: 2)
+
+            profileInfoView.snp.makeConstraints {
+                $0.leading.trailing.equalToSuperview()
+            }
+        }
+
+        profileInfoView.isHidden = false
+    }
+
+    private func hideProfileInfo() {
+        if contentStackView.arrangedSubviews.contains(profileInfoView) {
+            contentStackView.removeArrangedSubview(profileInfoView)
+            profileInfoView.removeFromSuperview()
+
+            profileInfoView.snp.removeConstraints()
+        }
+        profileInfoView.isHidden = true
     }
     
     private func setScrollViewLayout() {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ProfileInfoView.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ProfileInfoView.swift
@@ -44,7 +44,7 @@ public final class ProfileInfoView: UIView {
         nameLabel.textColor = DSKitAsset.Colors.white.color
         nameLabel.text = "닉네임"
 
-        arrowImageView.image = DSKitAsset.Assets.icArrow.image
+        arrowImageView.image = DSKitAsset.Assets.icLeftArrow.image
         arrowImageView.tintColor = DSKitAsset.Colors.white.color
         arrowImageView.contentMode = .scaleAspectFit
     }
@@ -65,8 +65,7 @@ public final class ProfileInfoView: UIView {
         arrowImageView.snp.makeConstraints {
             $0.leading.equalTo(nameLabel.snp.trailing).offset(2)
             $0.centerY.equalToSuperview()
-            $0.size.equalTo(16)
-            $0.trailing.lessThanOrEqualToSuperview()
+            $0.size.equalTo(24)
         }
 
         self.snp.makeConstraints {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ProfileInfoView.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/View/ProfileInfoView.swift
@@ -1,0 +1,88 @@
+//
+//  ProfileInfoView.swift
+//  StampFeature
+//
+//  Created by 성현주 on 12/21/25.
+//  Copyright © 2025 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import SnapKit
+import Then
+import DSKit
+
+public final class ProfileInfoView: UIView {
+
+    // MARK: - UI Components
+
+    private let profileImageView = CustomProfileImageView().hideBorder()
+    private let nameLabel = UILabel()
+    private let arrowImageView = UIImageView()
+
+    // MARK: - Initialization
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - UI Setup
+
+    private func setUI() {
+        self.backgroundColor = .clear
+
+        profileImageView.hideBorder()
+
+        nameLabel.font = .SoptampFont.subtitle3
+        nameLabel.textColor = DSKitAsset.Colors.white.color
+        nameLabel.text = "닉네임"
+
+        arrowImageView.image = DSKitAsset.Assets.icArrow.image
+        arrowImageView.tintColor = DSKitAsset.Colors.white.color
+        arrowImageView.contentMode = .scaleAspectFit
+    }
+
+    private func setLayout() {
+        self.addSubviews(profileImageView, nameLabel, arrowImageView)
+
+        profileImageView.snp.makeConstraints {
+            $0.leading.centerY.equalToSuperview()
+            $0.size.equalTo(22)
+        }
+
+        nameLabel.snp.makeConstraints {
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(5)
+            $0.centerY.equalToSuperview()
+        }
+
+        arrowImageView.snp.makeConstraints {
+            $0.leading.equalTo(nameLabel.snp.trailing).offset(2)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(16)
+            $0.trailing.lessThanOrEqualToSuperview()
+        }
+
+        self.snp.makeConstraints {
+            $0.height.equalTo(22)
+        }
+    }
+}
+
+extension ProfileInfoView {
+    public func configure(name: String, profileImageURL: String? = nil) {
+        nameLabel.text = name
+
+        if let imageURL = profileImageURL, !imageURL.isEmpty {
+            profileImageView.setImage(with: imageURL)
+        } else {
+            profileImageView.setPlaceholder()
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -84,6 +84,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
         self.sceneType = sceneType
         self.starLevel = starLevel
         self.missionId = missionId
+        self.isAppjam = isAppjam
         self.missionTitle = missionTitle
         self.isOtherUser = !(otherUsername == nil)
         self.otherUserName = otherUsername
@@ -272,10 +273,9 @@ extension ListDetailViewModel {
                 }
 #if DEBUG
                 if owner.isAppjam == true {
-                    print("앱잼 모드: 프로필 정보 주입")
                     let testProfileInfo = ProfileInfo(
-                        name: "김앱잼",
-                        imageURL: nil  // 또는 실제 이미지 URL
+                        name: "성앱잼",
+                        imageURL: nil
                     )
 
                     return ListDetailModel(
@@ -296,7 +296,7 @@ extension ListDetailViewModel {
             }
             .assign(to: \.self.listDetailModel, on: output)
             .store(in: self.cancelBag)
-        
+
         editSuccess.asDriver()
             .withUnretained(self)
             .sink { owner, success in

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -32,7 +32,8 @@ public class ListDetailViewModel: ListDetailViewModelType {
     public var stampId: Int!
     public var isOtherUser: Bool
     public var otherUserName: String!
-    
+    public var isAppjam: Bool?
+
     var totalClapCount: Int = 0
     var myClapCount: Int = 0
     var viewcount: Int = 0
@@ -73,6 +74,7 @@ public class ListDetailViewModel: ListDetailViewModelType {
     public init(
         useCase: ListDetailUseCase,
         sceneType: ListDetailSceneType,
+        isAppjam: Bool? = nil,
         starLevel: StarViewLevel,
         missionId: Int,
         missionTitle: String,
@@ -100,9 +102,9 @@ extension ListDetailViewModel {
             }
             .sink { owner, _ in
                 owner.isOtherUser
-                ? owner.useCase.fetchListDetail(missionId: owner.missionId, username: owner.otherUserName)
-                : owner.useCase.fetchListDetail(missionId: owner.missionId, username: nil)
-                
+                ? owner.useCase.fetchListDetail(isAppjam: owner.isAppjam, missionId: owner.missionId, username: owner.otherUserName)
+                : owner.useCase.fetchListDetail(isAppjam: owner.isAppjam, missionId: owner.missionId, username: nil)
+
                 if owner.isOtherUser {
                     AmplitudeInstance.shared.track(
                         eventType: .clickFeedMission,
@@ -268,6 +270,28 @@ extension ListDetailViewModel {
                 if let mine = model.isMine {
                     owner.isOtherUser = !mine
                 }
+#if DEBUG
+                if owner.isAppjam == true {
+                    print("앱잼 모드: 프로필 정보 주입")
+                    let testProfileInfo = ProfileInfo(
+                        name: "김앱잼",
+                        imageURL: nil  // 또는 실제 이미지 URL
+                    )
+
+                    return ListDetailModel(
+                        image: model.image,
+                        content: model.content,
+                        date: model.date,
+                        stampId: model.stampId,
+                        activityDate: model.activityDate,
+                        clapCount: model.clapCount,
+                        myClapCount: model.myClapCount,
+                        viewCount: model.viewCount,
+                        isMine: model.isMine,
+                        profileInfo: testProfileInfo
+                    )
+                }
+#endif
                 return model
             }
             .assign(to: \.self.listDetailModel, on: output)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -438,10 +438,36 @@ extension MissionListVC: UICollectionViewDelegate {
         case 1:
             guard let tappedCell = collectionView.cellForItem(at: indexPath) as? MissionListCVC,
                   let model = tappedCell.model else { return }
-            onCellTap?(model, sceneType.usrename)
+            let userType = UserDefaultKeyList.Auth.getUserType()
+
+
+            if model.isCompleted {
+                onCellTap?(model, sceneType.usrename)
+                return
+            }
+
+            switch userType {
+            case .active:
+                onCellTap?(model, sceneType.usrename)
+            case .inactive, .visitor:
+                //TODO: - 앱잼안하는 활동유저의 경우대한 분기도 추가
+                showInactiveUserAlert()
+            }
+
         default:
             return
         }
+    }
+
+    private func showInactiveUserAlert() {
+        AlertUtils.presentAlertVC(
+            type: .titleDescriptionSingleButton,
+            theme: .soptamp,
+            title: I18N.MissionList.inactiveUserAlertTitle,
+            description: I18N.MissionList.inactiveUserAlertDescription,
+            customButtonTitle: I18N.Default.ok,
+            animated: true
+        )
     }
 }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -440,7 +440,6 @@ extension MissionListVC: UICollectionViewDelegate {
                   let model = tappedCell.model else { return }
             let userType = UserDefaultKeyList.Auth.getUserType()
 
-
             if model.isCompleted {
                 onCellTap?(model, sceneType.usrename)
                 return


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#805

## 🌱 PR Point
- 앱잼템프에서 미션상세뷰로 갈경우 추가되는 profile뷰를 추가했습니다
- 비활동, 앱잼안하는 활동유저의 경우 alert가 호출되도록 했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### showMissionDetail 함수 변경사항
기존 `showMissionDetail` 함수는 미션 리스트에서 디테일 화면으로 전환할 때 사용되던 함수인데요. 

앱잼탬프 기능 추가로 인해 다음과 같은 분기 처리가 필요해졌습니다:
- **UI**: 앱잼탬프 디테일 화면에는 프로필 정보 표시 필요
- **API**: 기존 디테일 API와 별도의 앱잼탬프 전용 API 호출 필요

변경 내용
`isAppjam` 파라미터를 추가하여 앱잼 여부를 구분할 수 있도록 수정했습니다.

```swift
private func showMissionDetail(
    _ model: MissionListModel, 
    _ username: String?, 
    isAppjam: Bool = false  // 추가
)
```
 사용 방법
- **일반 솝탬프**: 기존과 동일하게 사용 (default 값 `false`)
  ```swift
  showMissionDetail(model, username)
  ```

- **앱잼탬프**: `isAppjam: true`로 설정
  ```swift
  showMissionDetail(model, username, isAppjam: true)
  ```
isAppjam여부에서 따라서 레포지토리에서 분기해 적절한 api를 호출해줍니다.
```swift
extension ListDetailRepository: ListDetailRepositoryInterface {
    public func fetchListDetail(isAppjam: Bool?, missionId: Int, username: String?) -> AnyPublisher<ListDetailModel, Error> {
        let username = username ?? UserDefaultKeyList.User.soptampName
        guard let username else {
            return Fail(error: NSError()).eraseToAnyPublisher()
        }
        if isAppjam == true {
            //TODO: - 앱잼템프용 api로 변경
            return stampService.fetchStampListDetail(missionId: missionId, username: username)
                .map { $0.toDomain() }
                .eraseToAnyPublisher()
        } else {
            return stampService.fetchStampListDetail(missionId: missionId, username: username)
                .map { $0.toDomain() }
                .eraseToAnyPublisher()
        }
    }
```

주의사항
앱잼탬프 디테일로 진입할 때는 **반드시 `isAppjam: true`를 명시**해주세요. 그렇지 않으면 일반 솥탬프 API가 호출되어 프로필 정보가 표시되지 않습니다. 그래서 해당 함수에 임의로 deprecated추가해뒀습니다. 아마 노란색에러로 설명해줄거에요!
<img width="1434" height="175" alt="image" src="https://github.com/user-attachments/assets/a969ccb5-6e4b-4e56-a28b-8e00e1265910" />


왜? 이렇게 했냐면요
처음에는 Usertype으로 분기를 할려고 했는데, 일반 솝탬프도 존재하고, 앱잼탬프도 동시에 존재하는 구조다보니 유저타입으로 분기했을때, 해당 셀이 앱잼탬프인지 일반 솝탬프인지 구별할수 있는 방법이 없어 간단하게 호출부에서 파라미터 전달하는 방식으로 구현했습니다.
혹시 더 좋은 방법이 있다면 알려주세요~!!!

### ListDetailVC
listdetailVC에서는 model에 있는 값을 바탕으로 프로필뷰를 표시할지 말지 정합니다. 앱잼탬프의 경우 기존 솝탬프와 다른게 앱잼팀, profileimage, profilename등의 필드가 추가로 전달되는데, 그값의 유무에 따라 뷰가 보이도록 했습니다. 

### alert조건
missonListVC에서 셀을 클릭할때 해당 유저 타입으로 alert를 호출할지 말지 결정합니다. usertype으로 분기가 필요한데, 아직 앱잼하는 유저에대한 분기가 정해지지 않아서 이부분은 TODO로 남겨뒀습니다. 

### 남은 작업
- 앱잼하는 활동유저, 앱잼안하는 활동유저 분기 방식 확정
- missonDetailViewModel 디버그용 mockData 제거
- 앱잼탬프 미션디테일 api 연결 + todomain함수 변경
- 앱잼탬프용 화면전환 


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|비활동 유저 alert처리|![Simulator Screen Recording - iPhone 16e - 2025-12-21 at 13 50 22](https://github.com/user-attachments/assets/ffdadafe-66a8-4e60-9325-1f8be1fe838d)|

|기능|스크린샷|
|:--:|:--:|
|앱잼탬프일경우 뷰 분기|![Simulator Screen Recording - iPhone 16e - 2025-12-21 at 13 47 02](https://github.com/user-attachments/assets/2392df82-63eb-42fe-933a-8fb8834acded)|

## 📮 관련 이슈
- Resolved: #805
