### PR TITLE
[Feat] #801 - 앱잼 랭킹 뷰 API 연결

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -29,7 +29,15 @@ public extension TabBarItemType {
     func getTabIndex(userType: UserType) -> Int {
         switch userType {
         case .active:
-            return self.rawValue
+            switch self {
+            case .home:
+                return 0
+            case .soptamp:
+                return 1
+            case .soptlog:
+                return 2
+            default: return 0           // poke 탭이 비활성화 상태이므로 0으로 처리
+            }
         case .visitor, .inactive:
             switch self {
             case .home, .soptamp:
@@ -46,7 +54,12 @@ public extension TabBarItemType {
     static func from(index: Int, userType: UserType) -> TabBarItemType? {
         switch userType {
         case .active:
-            return TabBarItemType(rawValue: index)
+            switch index {
+            case 0: return .home
+            case 1: return .soptamp
+            case 2: return .soptlog
+            default: return nil
+            }
         case .visitor, .inactive:
             switch index {
             case 0: return .home

--- a/SOPT-iOS/Projects/Core/Sources/Utils/calculatePastTime.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Utils/calculatePastTime.swift
@@ -7,31 +7,26 @@
 
 import Foundation
 
-public func calculatePastTime(date: String) -> String {
-  
+public func calculatePastTime(date: String, dateFormat: String = "yyyy-MM-dd HH:mm:ss") -> String {
+
   let minute = 60
   let hour = minute * 60
   let day = hour * 60
   let week = day * 7
-  
+
   var message: String = ""
-  
-  let UTCDate = Date()
-  let formatter = DateFormatter()
-  formatter.timeZone = TimeZone(secondsFromGMT: 32400)
-  formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-  let defaultTimeZoneStr = formatter.string(from: UTCDate)
-  
+
   let format = DateFormatter()
-  format.dateFormat = "yyyy-MM-dd HH:mm:ss"
+  format.dateFormat = dateFormat
   format.locale = Locale(identifier: "ko_KR")
-  
+  format.timeZone = TimeZone(identifier: "Asia/Seoul")
+
   guard let tempDate = format.date(from: date) else {return ""}
-  let krTime = format.date(from: defaultTimeZoneStr)
-  
+
+  let now = Date()
+  let useTime = Int(now.timeIntervalSince(tempDate))
+
   let articleDate = format.string(from: tempDate)
-  var useTime = Int(krTime!.timeIntervalSince(tempDate))
-  useTime = useTime - 32400
   
   if useTime < minute {
     message = "방금 전"

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AppjamRankingRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AppjamRankingRepository.swift
@@ -1,0 +1,33 @@
+//
+//  AppjamRankingRepository.swift
+//  Data
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+public class AppjamRankingRepository {
+
+    private let appJamRankingService: AppJamRankingService
+
+    public init(service: AppJamRankingService) {
+        self.appJamRankingService = service
+    }
+}
+
+extension AppjamRankingRepository: AppjamRankingRepositoryInterface {
+    public func fetchTodayRanking(size: Int) async throws -> [AppjamRankTodayModel] {
+        let entity = try await appJamRankingService.fetchTodayRanking(size: size)
+        return entity.ranks.map { $0.toDomain() }
+    }
+
+    public func fetchRecentRanking(size: Int) async throws -> [AppjamRankRecentModel] {
+        let entity = try await appJamRankingService.fetchRecentRanking(size: size)
+        return entity.ranks.map { $0.toDomain() }
+    }
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AppjamRankRecentTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AppjamRankRecentTransform.swift
@@ -1,0 +1,28 @@
+//
+//  AppjamRankRecentTransform.swift
+//  Data
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension AppjamRankRecent {
+    public func toDomain() -> AppjamRankRecentModel {
+        return AppjamRankRecentModel(
+            stampId: self.stampId,
+            missionId: self.missionId,
+            userId: self.userId,
+            imageUrl: self.imageUrl,
+            createdAt: self.createdAt,
+            userName: self.userName,
+            userProfileImage: self.userProfileImage,
+            teamName: self.teamName,
+            teamNumber: self.teamNumber
+        )
+    }
+}

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AppjamRankTodayTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AppjamRankTodayTransform.swift
@@ -1,0 +1,23 @@
+//
+//  AppjamRankTodayTransform.swift
+//  Data
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+import Networks
+
+extension AppjamRankToday {
+    public func toDomain() -> AppjamRankTodayModel {
+        return AppjamRankTodayModel(
+            rank: self.rank,
+            teamName: self.teamName,
+            todayPoints: self.todayPoints,
+            totalPoints: self.totalPoints
+        )
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -239,5 +239,11 @@ extension AppDelegate {
                 SoptlogRepository(userService: DefaultUserService.standard)
             }
         )
+        container.register(
+            interface: AppjamRankingRepositoryInterface.self,
+            implement: {
+                AppjamRankingRepository(service: DefaultAppJamRankingService.standard)
+            }
+        )
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/AppjamRankRecentModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/AppjamRankRecentModel.swift
@@ -1,0 +1,43 @@
+//
+//  AppjamRankRecentModel.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct AppjamRankRecentModel {
+    public let stampId: Int
+    public let missionId: Int
+    public let userId: Int
+    public let imageUrl: String
+    public let createdAt: String
+    public let userName: String
+    public let userProfileImage: String
+    public let teamName: String
+    public let teamNumber: String
+
+    public init(
+        stampId: Int,
+        missionId: Int,
+        userId: Int,
+        imageUrl: String,
+        createdAt: String,
+        userName: String,
+        userProfileImage: String,
+        teamName: String,
+        teamNumber: String
+    ) {
+        self.stampId = stampId
+        self.missionId = missionId
+        self.userId = userId
+        self.imageUrl = imageUrl
+        self.createdAt = createdAt
+        self.userName = userName
+        self.userProfileImage = userProfileImage
+        self.teamName = teamName
+        self.teamNumber = teamNumber
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/AppjamRankTodayModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/AppjamRankTodayModel.swift
@@ -1,0 +1,23 @@
+//
+//  AppjamRankTodayModel.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct AppjamRankTodayModel {
+    public let rank: Int
+    public let teamName: String
+    public let todayPoints: Int
+    public let totalPoints: Int
+
+    public init(rank: Int, teamName: String, todayPoints: Int, totalPoints: Int) {
+        self.rank = rank
+        self.teamName = teamName
+        self.todayPoints = todayPoints
+        self.totalPoints = totalPoints
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppjamRankingRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppjamRankingRepositoryInterface.swift
@@ -1,0 +1,14 @@
+//
+//  AppjamRankingRepositoryInterface.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public protocol AppjamRankingRepositoryInterface {
+    func fetchTodayRanking(size: Int) async throws -> [AppjamRankTodayModel]
+    func fetchRecentRanking(size: Int) async throws -> [AppjamRankRecentModel]
+}

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AppjamRankingUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AppjamRankingUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  AppjamRankingUseCase.swift
+//  Domain
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public protocol AppjamRankingUseCase {
+    func fetchTodayRanking(size: Int) async throws -> [AppjamRankTodayModel]
+    func fetchRecentRanking(size: Int) async throws -> [AppjamRankRecentModel]
+}
+
+public class DefaultAppjamRankingUseCase {
+
+    private let repository: AppjamRankingRepositoryInterface
+
+    public init(repository: AppjamRankingRepositoryInterface) {
+        self.repository = repository
+    }
+}
+
+extension DefaultAppjamRankingUseCase: AppjamRankingUseCase {
+    public func fetchTodayRanking(size: Int) async throws -> [AppjamRankTodayModel] {
+        try await repository.fetchTodayRanking(size: size)
+    }
+
+    public func fetchRecentRanking(size: Int) async throws -> [AppjamRankRecentModel] {
+        try await repository.fetchRecentRanking(size: size)
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/AppJamRankingViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/AppJamRankingViewControllable.swift
@@ -20,6 +20,7 @@ public protocol AppJamRankingViewControllable: UIViewController { }
 
 public protocol AppJamRankingRoutingTrigger {
     var onNaviBackTap: (() -> Void)? { get set }
+    var onNetworkError: (() -> Void)? { get set }
 }
 
 // MARK: - ViewModelType

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/MissionListPresentable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/MissionListPresentable.swift
@@ -23,6 +23,7 @@ public protocol MissionListRoutingTrigger {
   var onEditTap: (() -> Void)? { get set }
   var onCellTap: ((MissionListModel, _ username: String?) -> Void)? { get set }
   var onReportButtonTap: (() -> Void)? { get set }
+    var onAppJamRankingButtonTap: (() -> Void)? { get set }
 }
 // TODO: coordinating vc -> vm 작업에서 활용
 public typealias MissionListViewModelType = ViewModelType & MissionListRoutingTrigger

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -18,6 +18,7 @@ final class StampBuilder {
     @Injected public var missionListRepository: MissionListRepositoryInterface
     @Injected public var rankingRepository: RankingRepositoryInterface
     @Injected public var listDetailRepository: ListDetailRepositoryInterface
+    @Injected public var appjamRankingRepository: AppjamRankingRepositoryInterface
 
     public init() { }
 }
@@ -97,7 +98,8 @@ extension StampBuilder: StampFeatureBuildable {
     }
     
     public func makeAppJamRankingVC() -> AppJamRankingPresentable {
-        let viewModel = AppJamRankingViewModel()
+        let useCase = DefaultAppjamRankingUseCase(repository: appjamRankingRepository)
+        let viewModel = AppJamRankingViewModel(useCase: useCase)
         let appJamRankingVC = AppJamRankingVC(viewModel: viewModel)
         return (appJamRankingVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -213,6 +213,11 @@ extension StampCoordinator {
             self.rootController?.popViewController(animated: true)
         }
         
+        ranking.vm.onNetworkError = { [weak self] in
+            guard let self else { return }
+            AlertUtils.presentNetworkAlertVC()
+        }
+        
         rootController?.pushViewController(ranking.vc, animated: true)
     }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -95,6 +95,11 @@ public final class StampCoordinator: BaseCoordinator {
             safariViewController.playgroundStyle()
             self.rootController?.present(safariViewController, animated: true)
         }
+
+        missionList.vc.onAppJamRankingButtonTap = { [weak self] in
+            guard let self else { return }
+            self.runRankingFlow(rankingViewType: .appJamRanking)
+        }
     }
 }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -40,7 +40,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     lazy var dataSource: UICollectionViewDiffableDataSource<MissionListSection, MissionListModel>! = nil
     
     // MARK: - MissionListCoordinatable
-    
+
     public var onSwiped: (() -> Void)?
     public var onNaviBackTap: (() -> Void)?
     public var onPartRankingButtonTap: ((RankingViewType) -> Void)?
@@ -48,6 +48,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     public var onEditTap: (() -> Void)?
     public var onCellTap: ((MissionListModel, String?) -> Void)?
     public var onReportButtonTap: (() -> Void)?
+    public var onAppJamRankingButtonTap: (() -> Void)?
     
     private var usersActiveGenerationStatus: UsersActiveGenerationStatusViewResponse?
     
@@ -257,7 +258,7 @@ extension MissionListVC {
         singleFloatingButton.buttonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                // TODO: - 화면 전환 연결
+                owner.onAppJamRankingButtonTap?()
             }.store(in: self.cancelBag)
         
         swipeHandler

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -25,6 +25,7 @@ public class MissionListViewModel: MissionListViewModelType {
     public var onEditTap: (() -> Void)?
     public var onCellTap: ((Domain.MissionListModel, String?) -> Void)?
     public var onReportButtonTap: (() -> Void)?
+    public var onAppJamRankingButtonTap: (() -> Void)?
     
     // MARK: - Properties
     

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/AppJamRanking/AppJamMissionCardCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/AppJamRanking/AppJamMissionCardCVC.swift
@@ -122,22 +122,14 @@ extension AppJamMissionCardCVC {
 // MARK: - Methods
 
 extension AppJamMissionCardCVC {
-    func configureCell(
-        missionImage: String,
-        time: String,
-        missionTitle: String,
-        userName: String,
-        profileImage: String? = nil
+    func configureCell(model: AppJamRankRecentPresentationModel) {
+        timeLabel.text = model.relativeTime
+        missionTitleLabel.text = model.teamName
+        userLabel.text = model.userName
+        missionImageView.setImage(with: model.imageUrl)
         
-    ) {
-        timeLabel.text = time
-        missionTitleLabel.text = missionTitle
-        userLabel.text = userName
-        missionImageView.setImage(with: missionImage)
-        
-        if let profileURL = profileImage {
-            profileView.setImage(with: profileURL)
+        if !model.userProfileImage.isEmpty {
+            profileView.setImage(with: model.userProfileImage)
         }
     }
 }
-

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/AppJamRanking/AppJamRankingCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/AppJamRanking/AppJamRankingCVC.swift
@@ -124,14 +124,14 @@ extension AppJamRankingCVC {
 // MARK: - Methods
 
 extension AppJamRankingCVC {
-    func configureCell(rank: Int, teamName: String, totalScore: Int, incrementScore: Int) {
-        self.rank = rank
+    func configureCell(model: AppJamRankTodayPresentationModel) {
+        self.rank = model.rank
         updateRankBadge()
         
-        rankLabel.text = "\(rank)"
-        teamNameLabel.text = teamName
-        totalScoreLabel.text = "총 \(totalScore)점"
-        incrementScoreLabel.text = "+\(incrementScore)점"
+        rankLabel.text = "\(model.rank)"
+        teamNameLabel.text = model.teamName
+        totalScoreLabel.text = "총 \(model.totalPoints)점"
+        incrementScoreLabel.text = "+\(model.todayPoints)점"
     }
     
     private func updateRankBadge() {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/AppJamRanking/AppJamRankingSection.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/AppJamRanking/AppJamRankingSection.swift
@@ -11,8 +11,7 @@ enum AppJamRankingSection: Int, CaseIterable {
     case ranking = 1
 }
 
-// TODO: - 아이템 타입 수정 필요
 enum AppJamRankingItem: Hashable, Sendable {
-    case mission(String)
-    case ranking(String)
+    case mission(AppJamRankRecentPresentationModel)
+    case ranking(AppJamRankTodayPresentationModel)
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Model/AppJamRankingPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Model/AppJamRankingPresentationModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import Domain
+import Core
 
 // MARK: - Today Ranking Presentation Model
 
@@ -33,7 +34,7 @@ struct AppJamRankRecentPresentationModel: Hashable {
     let missionId: Int
     let userId: Int
     let imageUrl: String
-    let createdAt: String
+    let relativeTime: String
     let userName: String
     let userProfileImage: String
     let teamName: String
@@ -44,7 +45,7 @@ struct AppJamRankRecentPresentationModel: Hashable {
         self.missionId = domainModel.missionId
         self.userId = domainModel.userId
         self.imageUrl = domainModel.imageUrl
-        self.createdAt = domainModel.createdAt
+        self.relativeTime = calculatePastTime(date: domainModel.createdAt, dateFormat: "yyyy-MM-dd'T'HH:mm:ss.SSS")
         self.userName = domainModel.userName
         self.userProfileImage = domainModel.userProfileImage
         self.teamName = domainModel.teamName

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Model/AppJamRankingPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Model/AppJamRankingPresentationModel.swift
@@ -1,0 +1,53 @@
+//
+//  AppJamRankingPresentationModel.swift
+//  StampFeature
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+// MARK: - Today Ranking Presentation Model
+
+struct AppJamRankTodayPresentationModel: Hashable {
+    let rank: Int
+    let teamName: String
+    let todayPoints: Int
+    let totalPoints: Int
+
+    init(from domainModel: AppjamRankTodayModel) {
+        self.rank = domainModel.rank
+        self.teamName = domainModel.teamName
+        self.todayPoints = domainModel.todayPoints
+        self.totalPoints = domainModel.totalPoints
+    }
+}
+
+// MARK: - Recent Mission Presentation Model
+
+struct AppJamRankRecentPresentationModel: Hashable {
+    let stampId: Int
+    let missionId: Int
+    let userId: Int
+    let imageUrl: String
+    let createdAt: String
+    let userName: String
+    let userProfileImage: String
+    let teamName: String
+    let teamNumber: String
+
+    init(from domainModel: AppjamRankRecentModel) {
+        self.stampId = domainModel.stampId
+        self.missionId = domainModel.missionId
+        self.userId = domainModel.userId
+        self.imageUrl = domainModel.imageUrl
+        self.createdAt = domainModel.createdAt
+        self.userName = domainModel.userName
+        self.userProfileImage = domainModel.userProfileImage
+        self.teamName = domainModel.teamName
+        self.teamNumber = domainModel.teamNumber
+    }
+}

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/AppJamRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/AppJamRankingVC.swift
@@ -161,12 +161,7 @@ extension AppJamRankingVC {
                 ) as? AppJamMissionCardCVC else {
                     return UICollectionViewCell()
                 }
-                cell.configureCell(
-                    missionImage: model.imageUrl,
-                    time: model.createdAt,
-                    missionTitle: model.teamName,
-                    userName: model.userName
-                )
+                cell.configureCell(model: model)
                 return cell
 
             case .ranking(let model):
@@ -176,12 +171,7 @@ extension AppJamRankingVC {
                 ) as? AppJamRankingCVC else {
                     return UICollectionViewCell()
                 }
-                cell.configureCell(
-                    rank: model.rank,
-                    teamName: model.teamName,
-                    totalScore: model.totalPoints,
-                    incrementScore: model.todayPoints
-                )
+                cell.configureCell(model: model)
                 return cell
             }
         }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/AppJamRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/AppJamRankingVC.swift
@@ -17,16 +17,18 @@ import SnapKit
 final class AppJamRankingVC: UIViewController, AppJamRankingViewControllable {
     
     // MARK: - Properties
-    
+
     private let viewModel: AppJamRankingViewModel
     private var cancelBag = CancelBag()
     private lazy var dataSource: UICollectionViewDiffableDataSource<AppJamRankingSection, AppJamRankingItem>! = nil
+
+    private let viewWillAppearPublisher = PassthroughSubject<Void, Never>()
     
     // MARK: - UI Components
     
     private let naviBar = STNavigationBar(type: .titleWithLeftButton)
         .setTitleTypoStyle(.SoptampFont.h2)
-        .setTitle(I18N.RankingList.rankingForPartTitle)
+        .setTitle(I18N.RankingList.appjamRankingTitle)
         .setRightButton(.none)
     
     private lazy var collectionView: UICollectionView = {
@@ -43,14 +45,19 @@ final class AppJamRankingVC: UIViewController, AppJamRankingViewControllable {
     }()
     
     // MARK: - View Life Cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
         setLayout()
         registerCells()
         setDataSource()
-        applySnapshot()
+        bindViewModel()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearPublisher.send(())
     }
     
     // MARK: - Initialization
@@ -90,6 +97,34 @@ extension AppJamRankingVC {
 // MARK: - Methods
 
 extension AppJamRankingVC {
+    private func bindViewModel() {
+        let input = AppJamRankingViewModel.Input(
+            viewWillAppear: viewWillAppearPublisher.asDriver(),
+            refreshStarted: refresher.publisher(for: .valueChanged).mapVoid().asDriver(),
+            naviBackButtonTapped: naviBar.leftButtonTapped.asDriver()
+        )
+
+        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+
+        output.$todayRankingList
+            .combineLatest(output.$recentMissionList)
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, data in
+                let (todayRanking, recentMissions) = data
+                owner.applySnapshot(todayRanking: todayRanking, recentMissions: recentMissions)
+            }.store(in: cancelBag)
+
+        output.isLoading
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, isLoading in
+                if !isLoading {
+                    owner.endRefresh()
+                }
+            }.store(in: cancelBag)
+    }
+
     private func endRefresh() {
         self.refresher.endRefreshing()
     }
@@ -118,35 +153,34 @@ extension AppJamRankingVC {
         dataSource = UICollectionViewDiffableDataSource<AppJamRankingSection, AppJamRankingItem>(
             collectionView: collectionView
         ) { [weak self] collectionView, indexPath, item in
-            guard let section = AppJamRankingSection(rawValue: indexPath.section) else {
-                return UICollectionViewCell()
-            }
-            
-            switch section {
-            case .missionCards:
+            switch item {
+            case .mission(let model):
                 guard let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: AppJamMissionCardCVC.className,
                     for: indexPath
                 ) as? AppJamMissionCardCVC else {
                     return UICollectionViewCell()
                 }
-                // TODO: 실제 데이터로 교체
-                cell.configureCell(missionImage: "https://picsum.photos/146/232", time: "1분 전", missionTitle: "스터디룸 청소하기", userName: "노바고은비")
+                cell.configureCell(
+                    missionImage: model.imageUrl,
+                    time: model.createdAt,
+                    missionTitle: model.teamName,
+                    userName: model.userName
+                )
                 return cell
-                
-            case .ranking:
+
+            case .ranking(let model):
                 guard let cell = collectionView.dequeueReusableCell(
                     withReuseIdentifier: AppJamRankingCVC.className,
                     for: indexPath
                 ) as? AppJamRankingCVC else {
                     return UICollectionViewCell()
                 }
-                // TODO: 실제 데이터로 교체
                 cell.configureCell(
-                    rank: indexPath.row + 1,
-                    teamName: "노바",
-                    totalScore: 3000,
-                    incrementScore: 1000
+                    rank: model.rank,
+                    teamName: model.teamName,
+                    totalScore: model.totalPoints,
+                    incrementScore: model.todayPoints
                 )
                 return cell
             }
@@ -182,18 +216,20 @@ extension AppJamRankingVC {
         }
     }
     
-    private func applySnapshot() {
+    private func applySnapshot(
+        todayRanking: [AppJamRankTodayPresentationModel],
+        recentMissions: [AppJamRankRecentPresentationModel]
+    ) {
         var snapshot = NSDiffableDataSourceSnapshot<AppJamRankingSection, AppJamRankingItem>()
-        
+
         snapshot.appendSections([.missionCards, .ranking])
-        
-        // 임시 데이터 - TODO: 실제 데이터로 교체
-        let missionCardItems = Array(0..<5).map { AppJamRankingItem.mission("mission_\($0)") }
+
+        let missionCardItems = recentMissions.map { AppJamRankingItem.mission($0) }
         snapshot.appendItems(missionCardItems, toSection: .missionCards)
-        
-        let rankingItems = Array(0..<8).map { AppJamRankingItem.ranking("ranking_\($0)") }
+
+        let rankingItems = todayRanking.map { AppJamRankingItem.ranking($0) }
         snapshot.appendItems(rankingItems, toSection: .ranking)
-        
-        dataSource.apply(snapshot, animatingDifferences: false)
+
+        dataSource.apply(snapshot, animatingDifferences: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
@@ -18,6 +18,7 @@ public class AppJamRankingViewModel: AppJamRankingViewModelType {
 
     private let useCase: AppjamRankingUseCase
     private var cancelBag = CancelBag()
+    private var fetchTask: Task<Void, Never>?
 
     // MARK: - Inputs
 
@@ -44,6 +45,10 @@ public class AppJamRankingViewModel: AppJamRankingViewModelType {
     public init(useCase: AppjamRankingUseCase) {
         self.useCase = useCase
     }
+
+    deinit {
+        fetchTask?.cancel()
+    }
 }
 
 extension AppJamRankingViewModel {
@@ -53,8 +58,9 @@ extension AppJamRankingViewModel {
         input.viewWillAppear.merge(with: input.refreshStarted)
             .withUnretained(self)
             .sink { owner, _ in
+                owner.fetchTask?.cancel()
                 output.isLoading.send(true)
-                Task { [weak owner] in
+                owner.fetchTask = Task { [weak owner] in
                     await owner?.fetchRankingData(output: output)
                 }
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
@@ -16,44 +16,79 @@ public class AppJamRankingViewModel: AppJamRankingViewModelType {
 
     // MARK: - Properties
 
+    private let useCase: AppjamRankingUseCase
     private var cancelBag = CancelBag()
-    
+
     // MARK: - Inputs
-    
+
     public struct Input {
         let viewWillAppear: Driver<Void>
+        let refreshStarted: Driver<Void>
         let naviBackButtonTapped: Driver<Void>
     }
-    
+
     // MARK: - Outputs
-    
-    public struct Output {
+
+    public class Output {
         let isLoading = PassthroughSubject<Bool, Never>()
+        @Published var todayRankingList = [AppJamRankTodayPresentationModel]()
+        @Published var recentMissionList = [AppJamRankRecentPresentationModel]()
     }
-    
+
     // MARK: - AppJamCoordinatable
-    
+
     public var onNaviBackTap: (() -> Void)?
+
+    // MARK: - init
+
+    public init(useCase: AppjamRankingUseCase) {
+        self.useCase = useCase
+    }
 }
 
 extension AppJamRankingViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
-        
-        input.viewWillAppear
+
+        input.viewWillAppear.merge(with: input.refreshStarted)
             .withUnretained(self)
             .sink { owner, _ in
-                // TODO: API 호출
+                output.isLoading.send(true)
+                Task { [weak owner] in
+                    await owner?.fetchRankingData(output: output)
+                }
             }.store(in: cancelBag)
-        
+
         input.naviBackButtonTapped
             .withUnretained(self)
             .sink { owner, _ in
-                // TODO: VC에서 바인딩 필요
-                #warning("TODO: VC에서 바인딩 필요")
                 owner.onNaviBackTap?()
             }.store(in: cancelBag)
-        
+
         return output
+    }
+
+    @MainActor
+    private func fetchRankingData(output: Output) async {
+        async let todayTask = fetchTodayRanking()
+        async let recentTask = fetchRecentMissions()
+
+        do {
+            let (todayRanking, recentMissions) = try await (todayTask, recentTask)
+            output.todayRankingList = todayRanking.map { AppJamRankTodayPresentationModel(from: $0) }
+            output.recentMissionList = recentMissions.map { AppJamRankRecentPresentationModel(from: $0) }
+            output.isLoading.send(false)
+        } catch {
+            print("AppJamRankingViewModel fetch error: \(error)")
+            output.isLoading.send(false)
+        }
+    }
+
+    private func fetchTodayRanking() async throws -> [Domain.AppjamRankTodayModel] {
+        try await useCase.fetchTodayRanking(size: 10)
+    }
+
+    private func fetchRecentMissions() async throws -> [Domain.AppjamRankRecentModel] {
+        try await useCase.fetchRecentRanking(size: 3)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
@@ -39,10 +39,11 @@ public class AppJamRankingViewModel: AppJamRankingViewModelType {
     // MARK: - AppJamCoordinatable
 
     public var onNaviBackTap: (() -> Void)?
+    public var onNetworkError: (() -> Void)?
 
     // MARK: - init
 
-    public init(useCase: AppjamRankingUseCase) {
+    init(useCase: AppjamRankingUseCase) {
         self.useCase = useCase
     }
 
@@ -85,7 +86,7 @@ extension AppJamRankingViewModel {
             output.recentMissionList = recentMissions.map { AppJamRankRecentPresentationModel(from: $0) }
             output.isLoading.send(false)
         } catch {
-            print("AppJamRankingViewModel fetch error: \(error)")
+            onNetworkError?()
             output.isLoading.send(false)
         }
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -84,7 +84,7 @@ extension TabBarViewModel {
         homeUseCase.getAppServices()
             .withUnretained(self)
             .sink { owner, appServices in
-                owner.updateBadges(from: appServices)
+//                owner.updateBadges(from: appServices)
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -84,7 +84,7 @@ extension TabBarViewModel {
         homeUseCase.getAppServices()
             .withUnretained(self)
             .sink { owner, appServices in
-//                owner.updateBadges(from: appServices)
+                owner.updateBadges(from: appServices)
             }
             .store(in: cancelBag)
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/AppjamRankAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/AppjamRankAPI.swift
@@ -1,0 +1,62 @@
+//
+//  AppjamRankAPI.swift
+//  Networks
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+import Moya
+
+public enum AppjamRankAPI {
+    case recent(size: Int)
+    case today(size: Int)
+}
+
+extension AppjamRankAPI: BaseAPI {
+    
+    public static var apiType: APIType = .appjamRank
+    
+    // MARK: - Path
+    public var path: String {
+        switch self {
+        case .recent:
+            return "/recent"
+        case .today:
+            return "/today"
+        }
+    }
+    
+    // MARK: - Method
+    public var method: Moya.Method {
+        switch self {
+        default: return .get
+        }
+    }
+    
+    // MARK: - Parameters
+    private var queryParameters: Parameters? {
+        var params: Parameters = [:]
+        switch self {
+        case .recent(let size):
+            params["size"] = size
+        case .today(let size):
+            params["size"] = size
+        }
+        return params
+    }
+
+    private var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
+
+    public var task: Task {
+        switch self {
+        case .recent, .today:
+            return .requestParameters(parameters: queryParameters ?? [:], encoding: parameterEncoding)
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AppjamRankRecentResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AppjamRankRecentResponseEntity.swift
@@ -1,0 +1,25 @@
+//
+//  AppjamRankRecentResponseEntity.swift
+//  Networks
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct AppjamRankRecentResponseEntity: Decodable {
+    public let ranks: [AppjamRankRecent]
+}
+
+public struct AppjamRankRecent: Decodable {
+    public let stampId: Int
+    public let missionId: Int
+    public let userId: Int
+    public let imageUrl: String
+    public let createdAt: String
+    public let userName: String
+    public let userProfileImage: String
+    public let teamName: String
+    public let teamNumber: String
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AppjamRankTodayResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/AppjamRankTodayResponseEntity.swift
@@ -1,0 +1,20 @@
+//
+//  AppjamRankTodayResponseEntity.swift
+//  Networks
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public struct AppjamRankTodayResponseEntity: Decodable {
+    public let ranks: [AppjamRankToday]
+}
+
+public struct AppjamRankToday: Decodable {
+    public let rank: Int
+    public let teamName: String
+    public let todayPoints: Int
+    public let totalPoints: Int
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
@@ -12,27 +12,28 @@ import Moya
 import Core
 
 public enum APIType {
-  case attendance
-  case auth
-  case mission
-  case rank
-  case stamp
-  case user
-  case firebase
-  case config
-  case notification
-  case description
-  case poke
-  case s3
-  case fortune
-  case coreAuth
-  case social
-  case home
-  case calendar
+    case attendance
+    case auth
+    case mission
+    case rank
+    case stamp
+    case user
+    case firebase
+    case config
+    case notification
+    case description
+    case poke
+    case s3
+    case fortune
+    case coreAuth
+    case social
+    case home
+    case calendar
+    case appjamRank
 }
 
 public protocol BaseAPI: TargetType, AccessTokenAuthorizable {
-  static var apiType: APIType { get set }
+    static var apiType: APIType { get set }
 }
 
 extension BaseAPI {
@@ -45,72 +46,74 @@ extension BaseAPI {
 }
 
 extension BaseAPI {
-  public var baseURL: URL {
-    var base = Config.Network.baseURL
-    let operationBaseURL = Config.Network.operationBaseURL
-    let coreAuthBaseURL = Config.Network.coreAuthBaseURL
-      
-    switch Self.apiType {
-    case .attendance:
-      base = operationBaseURL
-    case .auth:
-      base += "/auth"
-    case .mission:
-      base += "/mission"
-    case .rank:
-      base += "/rank"
-    case .stamp:
-      base += "/stamp"
-    case .user:
-      base += "/user"
-    case .firebase:
-      base += "/firebase"
-    case .config:
-      base += "/config"
-    case .notification:
-      base += "/notification"
-    case .description:
-      base += "/description"
-    case .poke:
-      base += "/poke"
-    case .s3:
-      base += "/s3"
-    case .fortune:
-      base += "/fortune"
-    case .coreAuth:
-      base = coreAuthBaseURL + "/auth"
-    case .social:
-      base = coreAuthBaseURL + "/social"
-    case .home:
-      base += "/home"
-    case .calendar:
-      base += "/calendar"
+    public var baseURL: URL {
+        var base = Config.Network.baseURL
+        let operationBaseURL = Config.Network.operationBaseURL
+        let coreAuthBaseURL = Config.Network.coreAuthBaseURL
+        
+        switch Self.apiType {
+        case .attendance:
+            base = operationBaseURL
+        case .auth:
+            base += "/auth"
+        case .mission:
+            base += "/mission"
+        case .rank:
+            base += "/rank"
+        case .stamp:
+            base += "/stamp"
+        case .user:
+            base += "/user"
+        case .firebase:
+            base += "/firebase"
+        case .config:
+            base += "/config"
+        case .notification:
+            base += "/notification"
+        case .description:
+            base += "/description"
+        case .poke:
+            base += "/poke"
+        case .s3:
+            base += "/s3"
+        case .fortune:
+            base += "/fortune"
+        case .coreAuth:
+            base = coreAuthBaseURL + "/auth"
+        case .social:
+            base = coreAuthBaseURL + "/social"
+        case .home:
+            base += "/home"
+        case .calendar:
+            base += "/calendar"
+        case .appjamRank:
+            base += "/appjamrank"
+        }
+        
+        guard let url = URL(string: base) else {
+            fatalError("baseURL could not be configured")
+        }
+        
+        return url
     }
     
-    guard let url = URL(string: base) else {
-      fatalError("baseURL could not be configured")
+    public var headers: [String: String]? {
+        return HeaderType.json.value
     }
     
-    return url
-  }
-  
-  public var headers: [String: String]? {
-      return HeaderType.json.value
-  }
-  
-  public var validationType: ValidationType {
-    return .customCodes(Array(200..<600).filter { $0 != 401 })
-  }
+    public var validationType: ValidationType {
+        return .customCodes(Array(200..<600).filter { $0 != 401 })
+    }
 }
 
 
 public enum HeaderType {
-  case json
-  
-  public var value: [String: String] {
-    switch self {
-    case .json:
-      return ["Content-Type": "application/json"]
+    case json
+    
+    public var value: [String: String] {
+        switch self {
+        case .json:
+            return ["Content-Type": "application/json"]
+        }
     }
-  }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
@@ -33,7 +33,7 @@ public enum APIType {
 }
 
 public protocol BaseAPI: TargetType, AccessTokenAuthorizable {
-    static var apiType: APIType { get set }
+    static var apiType: APIType { get }
 }
 
 extension BaseAPI {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/AppJamRankingService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/AppJamRankingService.swift
@@ -1,0 +1,28 @@
+//
+//  AppJamRankingService.swift
+//  Networks
+//
+//  Created by 강윤서 on 1/5/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Moya
+
+public typealias DefaultAppJamRankingService = BaseService<AppjamRankAPI>
+
+public protocol AppJamRankingService {
+    func fetchTodayRanking(size: Int) async throws -> AppjamRankTodayResponseEntity
+    func fetchRecentRanking(size: Int) async throws -> AppjamRankRecentResponseEntity
+}
+
+extension DefaultAppJamRankingService: AppJamRankingService {
+    public func fetchTodayRanking(size: Int) async throws -> AppjamRankTodayResponseEntity {
+        try await requestObjectAsync(.today(size: size))
+    }
+
+    public func fetchRecentRanking(size: Int) async throws -> AppjamRankRecentResponseEntity {
+        try await requestObjectAsync(.recent(size: size))
+    }
+}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -238,5 +238,11 @@ extension AppDelegate {
                 SoptlogRepository(userService: DefaultUserService.standard)
             }
         )
+        container.register(
+            interface: AppjamRankingRepositoryInterface.self,
+            implement: {
+                AppjamRankingRepository(service: DefaultAppJamRankingService.standard)
+            }
+        )
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
- 앱잼 랭킹 뷰 API를 연결했습니다.
- 앱잼 랭킹 뷰로 이동하는 화면전환 구현

🌱 작업한 브랜치
- feature/#801

## 🌱 PR Point
### refresh 로직 추가
- 기획 명세에는 없었지만, 별도로 refreshControl을 추가 구현했습니다.
- 이 과정에서 네트워크 중복 호출이 되지 않도록 ViewModel에서 fetch 작업을 Task 변수로 관리하였습니다.
ex) refresh가 완료되지 않았을 때 pop한 뒤 해당 뷰로 재진입하는 경우 동일한 작업을 수행하는 여러 개의 Task가 존재할 수 있음

### calculatePastTime 메소드 수정
미션 완료 시각을 '1분전'과 같이 나타내는 과정에서 기존에 존재하던 메소드를 사용했습니다.

**1. 불필요한 변환 제거**
- AS-IS: 현재 시간 → 문자열 → Date
- TO-BE: `Date()` 직접 사용

**2. DateFormatter 하나로 통일**
- AS-IS: `formatter`, `krTimeFormatter` 두 개
- TO-BE: `format` 하나만 사용

**3. 타임존 처리 간소화**
- AS-IS: `TimeZone(secondsFromGMT: 32400) + useTime - 32400`으로 이중 계산
- TO-BE: `TimeZone(identifier: "Asia/Seoul")`로 통일

calculatePastTime 메소드가 사용되는 곳이 없어 수정에 영향을 받는 모듈은 없었습니다.

### TabBar 구성 에러 수정
poke 탭이 숨김처리 됨에 따라 TabBarItemType에서 매핑 에러가 발생하여 rawValue를 사용하지 않고 수동으로 값을 매핑해주었습니다.
- AppCoordinator에서 탭 3개 사용
- TabBarItemType(rawvalue:)를 사용하여 인덱스는 3까지 사용하게 됨 -> 실제 존재하는 탭 개수와 인덱스 개수가 맞지 않음

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 화면전환은 담당자분께서 필요에 따라 수정해주세요.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|앱잼 랭킹 뷰|<img width="375" alt="image" src="https://github.com/user-attachments/assets/1eccd4d4-76a3-4fd1-ae13-72f5e9073c55" />|

## 📮 관련 이슈
- Resolved: #801
