### PR TITLE
[Fix] #795 - 솝트로그 섹션 hidden 기준 변경 및 누락된 cell 표시

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
@@ -21,6 +21,7 @@ extension SoptlogResponseEntity {
             soptampCount: self.soptampCount,
             viewCount: self.viewCount,
             myClapCount: self.myClapCount,
+            clapCount: self.clapCount,
             totalPokeCount: self.totalPokeCount,
             newFriendsPokeCount: self.newFriendsPokeCount,
             bestFriendsPokeCount: self.bestFriendsPokeCount,

--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptlogTransform.swift
@@ -15,6 +15,7 @@ extension SoptlogResponseEntity {
     public func toDomain() -> SoptlogModel {
         return SoptlogModel(
             isActive: self.isActive,
+            isAppjamParticipant: self.isAppjamParticipant,
             isFortuneChecked: self.isFortuneChecked,
             todayFortuneText: self.todayFortuneText,
             soptampCount: self.soptampCount,

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct  SoptlogModel {
     public let isActive: Bool
+    public let isAppjamParticipant: Bool
     
     /// 솝마디 상태
     public let isFortuneChecked: Bool
@@ -28,6 +29,7 @@ public struct  SoptlogModel {
     
     public init(
         isActive: Bool,
+        isAppjamParticipant: Bool,
         isFortuneChecked: Bool,
         todayFortuneText: String,
         soptampCount: Int?,
@@ -39,6 +41,7 @@ public struct  SoptlogModel {
         soulmatesPokeCount: Int
     ) {
         self.isActive = isActive
+        self.isAppjamParticipant = isAppjamParticipant
         self.isFortuneChecked = isFortuneChecked
         self.todayFortuneText = todayFortuneText
         self.soptampCount = soptampCount

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptlogModel.swift
@@ -20,6 +20,7 @@ public struct  SoptlogModel {
     public let soptampCount: Int?
     public let viewCount: Int?
     public let myClapCount: Int?
+    public let clapCount: Int?
     
     /// 콕찌르기 정보
     public let totalPokeCount: Int
@@ -35,6 +36,7 @@ public struct  SoptlogModel {
         soptampCount: Int?,
         viewCount: Int?,
         myClapCount: Int?,
+        clapCount: Int?,
         totalPokeCount: Int,
         newFriendsPokeCount: Int,
         bestFriendsPokeCount: Int,
@@ -47,6 +49,7 @@ public struct  SoptlogModel {
         self.soptampCount = soptampCount
         self.viewCount = viewCount
         self.myClapCount = myClapCount
+        self.clapCount = clapCount
         self.totalPokeCount = totalPokeCount
         self.newFriendsPokeCount = newFriendsPokeCount
         self.bestFriendsPokeCount = bestFriendsPokeCount

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SectionLayoutKind/SoptlogSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SectionLayoutKind/SoptlogSectionLayoutKind.swift
@@ -24,11 +24,11 @@ enum SoptlogSectionLayoutKind: Int, CaseIterable {
         }
     }
     
-    /// 활동 상태에 따라 표시할 섹션 목록
-    static func visibleSections(isActiveUser: Bool) -> [SoptlogSectionLayoutKind] {
+    /// 앱잼 참여 상태에 따라 표시할 섹션 목록
+    static func visibleSections(isAppjamParticipant: Bool) -> [SoptlogSectionLayoutKind] {
         var sections: [SoptlogSectionLayoutKind] = [.logo]
         
-        if isActiveUser {
+        if isAppjamParticipant {
             sections.append(.soptampLog)
         }
         

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -12,6 +12,7 @@ import Core
 import Domain
 
 struct SoptlogPresentationModel {
+    let isAppjamParticipant: Bool
     let soptampMenus: [SoptlogMenuModel]
     let pokeMenus: [SoptlogMenuModel]
     let alarm: Alarm
@@ -73,6 +74,7 @@ extension SoptlogModel {
         ]
 
         return SoptlogPresentationModel(
+            isAppjamParticipant: isAppjamParticipant,
             soptampMenus: soptampMenus,
             pokeMenus: pokeMenus,
             alarm: SoptlogPresentationModel.Alarm(

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Model/SoptlogPresentationModel.swift
@@ -43,6 +43,12 @@ extension SoptlogModel {
                 value: "\(myClapCount ?? 0)회",
                 hasTooltip: false,
                 hasChevron: false
+            ),
+            SoptlogMenuModel(
+                title: I18N.Soptlog.Menu.clapCount,
+                value: "\(clapCount ?? 0)회",
+                hasTooltip: false,
+                hasChevron: false
             )
         ]
 

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/VC/SoptlogVC.swift
@@ -27,12 +27,10 @@ final class SoptlogVC: UIViewController, SoptlogViewControllable {
     private var soptlogInfo: SoptlogPresentationModel?
     internal var isPokeEmpty: Bool = true
     
-    private var isActiveUser: Bool {
-        UserDefaultKeyList.Auth.isActiveUser ?? false
-    }
-    
     private var visibleSections: [SoptlogSectionLayoutKind] {
-        SoptlogSectionLayoutKind.visibleSections(isActiveUser: isActiveUser)
+        SoptlogSectionLayoutKind.visibleSections(
+            isAppjamParticipant: soptlogInfo?.isAppjamParticipant ?? false
+        )
     }
     
     // MARK: - UI Components

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -10,6 +10,7 @@ import Foundation
 
 public struct SoptlogResponseEntity: Decodable {
     public let isActive: Bool
+    public let isAppjamParticipant: Bool
     
     /// 솝마디 상태
     public let isFortuneChecked: Bool

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptlogResponseEntity.swift
@@ -20,6 +20,7 @@ public struct SoptlogResponseEntity: Decodable {
     public let soptampCount: Int?
     public let viewCount: Int?
     public let myClapCount: Int?
+    public let clapCount: Int?
     
     /// 콕찌르기 정보
     public let totalPokeCount: Int


### PR DESCRIPTION
## 🌴 PR 요약
<img width="473" height="208" alt="image" src="https://github.com/user-attachments/assets/06126fe6-ac7e-4607-b560-2ede4e0e6d7a" />  

- 앱잼탬프가 추가됨에 따라 솝트로그 섹션의 솝탬프 영역 hidden처리 기준을 수정했습니다.
- 누락된 '쳐준 박수' 셀을 추가했습니다.

🌱 작업한 브랜치
- feature/#795

## 🌱 PR Point
없음

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
없음


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|앱잼 참여자|<img width="375" alt="image" src="https://github.com/user-attachments/assets/fa7dfa54-ca9c-4d88-aa9e-2c344d429121" />|
|앱잼 미참여자|<img width="375" alt="image" src="https://github.com/user-attachments/assets/d0faef7d-41fa-4434-b2d9-7bc87f93ae61" />|

## 📮 관련 이슈
- Resolved: #795
