### PR TITLE
[Fix] #789 - 탭 바, 솝트로그 에러처리 추가, 메모리 누수 및 FatalError 해결(UI 백그라운드 스레드)

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -81,24 +81,8 @@ extension HomeRepository: HomeRepositoryInterface {
     }
     
     public func getUserInfoAsync() async throws -> Domain.UserMainInfoModel? {
-        do {
-            let entity = try await userService.getUserMainInfoAsync()
-            return entity.toDomain()
-        } catch let error as APIError {
-            switch error {
-            case .network(let statusCode, _):
-                if statusCode == 401 {
-                    throw MainError.authFailed
-                }
-                throw MainError.networkError(message: "\(statusCode) 네트워크 에러")
-            case .tokenReissuanceFailed:
-                throw MainError.authFailed
-            default:
-                throw MainError.networkError(message: error.localizedDescription)
-            }
-        } catch {
-            throw MainError.networkError(message: error.localizedDescription)
-        }
+        let entity = try await userService.getUserMainInfoAsync()
+        return entity.toDomain()
     }
     
     public func getRecentScheduleAsync() async throws -> Domain.HomeRecentScheduleModel {

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertUtils.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertUtils.swift
@@ -18,6 +18,7 @@ public enum AlertUtils {
         description: String = "",
         customButtonTitle: String,
         customAction: (() -> Void)? = nil,
+        cancelAction: (() -> Void)? = nil,
         animated: Bool = false,
         completion: (() -> Void)? = nil
     ) {
@@ -25,6 +26,7 @@ public enum AlertUtils {
             .setTitle(title, description)
             .setCustomButtonTitle(customButtonTitle)
         alertVC.customAction = customAction
+        alertVC.cancelAction = cancelAction
         alertVC.modalPresentationStyle = .overFullScreen
         alertVC.modalTransitionStyle = .crossDissolve
         let vc = UIApplication.getMostTopViewController()!

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Alert/AlertVC.swift
@@ -18,6 +18,7 @@ public class AlertVC: UIViewController, AlertViewControllable {
     // MARK: - Properties
     
     public var customAction: (() -> Void)?
+    public var cancelAction: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -78,7 +79,9 @@ public class AlertVC: UIViewController, AlertViewControllable {
     
     @objc
     private func dismissCurrentVC() {
-        self.dismiss(animated: true)
+        self.dismiss(animated: true) {
+            self.cancelAction?()
+        }
     }
     
     @objc

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
@@ -19,8 +19,8 @@ public protocol HomeForMemberCoordinatable {
     var onAppServiceCellTapped: ((String) -> Void)? { get set }
     var onNotificationButtonTapped: (() -> Void)? { get set }
     var onSettingButtonTapped: ((UserType) -> Void)? { get set }
-    var onNeedSignIn: (() -> Void)? { get set }
-    var onNetworkError: (() -> Void)? { get set }
+    var onNeedSignIn: (@MainActor () -> Void)? { get set }
+    var onNetworkError: (@MainActor () -> Void)? { get set }
     var onPoke: ((_ isNewUser: Bool) -> Void)? { get set }
     var onExtendedFloatingButtonTapped: ((String) -> Void)? { get set }
     var onSurveyButtonTapped: ((String) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -100,6 +100,9 @@ final class HomeForMemberVC: UIViewController, HomeForMemberViewControllable {
     }
     
     deinit {
+        latestPostAnimationTask?.cancel()
+        fetchDataTask?.cancel()
+        
         cancelBag.cancel()
     }
     

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -82,8 +82,8 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public var onAppServiceCellTapped: ((String) -> Void)?
     public var onNotificationButtonTapped: (() -> Void)?
     public var onSettingButtonTapped: ((UserType) -> Void)?
-    public var onNeedSignIn: (() -> Void)?
-    public var onNetworkError: (() -> Void)?
+    public var onNeedSignIn: (@MainActor () -> Void)?
+    public var onNetworkError: (@MainActor () -> Void)?
     public var onPoke: ((Bool) -> Void)?
     public var onExtendedFloatingButtonTapped: ((String) -> Void)?
     public var onSurveyButtonTapped: ((String) -> Void)?
@@ -329,18 +329,14 @@ extension HomeForMemberViewModel {
             
             return model
         } catch let mainError as MainError {
-            await MainActor.run {
-                switch mainError {
-                case .networkError(_):
-                    self.onNetworkError?()
-                case .authFailed:
-                    self.onNeedSignIn?()
-                }
+            switch mainError {
+            case .networkError(_):
+                await self.onNetworkError?()
+            case .authFailed:
+                await self.onNeedSignIn?()
             }
         } catch {
-            await MainActor.run {
-                self.onNetworkError?()
-            }
+            await self.onNetworkError?()
         }
         
         return nil

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -43,7 +43,6 @@ extension ApplicationCoordinator: TabBarCoordinatorDelegate {
         case .signIn:
             clearChildViewControllers()
             self.runSignInFlow(by: .rootWindow(animated: true, message: nil))
-            self.removeDependency(coordinator)
         }
     }
 
@@ -64,7 +63,6 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
         case .signIn:
             clearChildViewControllers()
             runSignInFlow(by: .rootWindow(animated: true, message: nil))
-            removeDependency(coordinator)
         case .notification:
             runNotificationFlow()
         case .soptlog:
@@ -139,7 +137,12 @@ extension ApplicationCoordinator: MyPageCoordinatorDelegate {
 
 extension ApplicationCoordinator {
     private func clearChildViewControllers() {
+        self.tabBarController?.viewControllers = []
+        self.tabBarController = nil
+        
         self.homeNavigationController.viewControllers.removeAll()
+        self.stampNavigationController.viewControllers.removeAll()
+        self.pokeNavigationController.viewControllers.removeAll()
         self.soptlogNavigationController.viewControllers.removeAll()
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -99,6 +99,11 @@ extension ApplicationCoordinator: SoptlogCoordinatorDelegate {
         case .pokeMyFriends(let relation):
             self.selectedTab(.poke)
             self.runPokeMyFriendsFlow(relation: relation)
+        case .home:
+            self.selectedTab(.home)
+        case .signIn:
+            clearChildViewControllers()
+            runSignInFlow(by: .rootWindow(animated: true, message: nil))
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -834,6 +834,11 @@ extension ApplicationCoordinator {
                     self?.runDailySoptuneFlow()
                 case .webLink(let url):
                     self?.handleWebLink(webLink: url)
+                case .home:
+                    self?.tabBarController?.selectedIndex = 0
+                case .signIn:
+                    self?.runSignInFlow(by: .rootWindow(animated: true, message: nil))
+                    self?.removeDependency(legacyCoordinator)
                 default:
                     return
                 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -383,10 +383,11 @@ extension ApplicationCoordinator {
 
         runHomeFlow(type: userType)
         runStampTabFlow()
-        runSoptlogFlow(type: userType)
+        
 
         switch userType {
         case .active, .inactive:
+            runSoptlogFlow(type: userType)
             viewControllers = [
                 homeNavigationController,
                 stampNavigationController,
@@ -394,9 +395,10 @@ extension ApplicationCoordinator {
             ]
 
         case .visitor:
+            // Visitor는 빈 navigation controller 사용 (실제 화면 전환은 TabBarViewModel에서 막음)
             viewControllers = [
                 homeNavigationController,
-                // pokeNavigationController,
+                UINavigationController()
                 soptlogNavigationController
             ]
         }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -384,7 +384,6 @@ extension ApplicationCoordinator {
         runHomeFlow(type: userType)
         runStampTabFlow()
         
-
         switch userType {
         case .active, .inactive:
             runSoptlogFlow(type: userType)
@@ -399,7 +398,6 @@ extension ApplicationCoordinator {
             viewControllers = [
                 homeNavigationController,
                 UINavigationController()
-                soptlogNavigationController
             ]
         }
 
@@ -624,25 +622,27 @@ extension ApplicationCoordinator {
         
         switch Config.coordinatorFlag {
         case .legacy:
-            coordinator = LegacyPokeOnboardingCoordinator(
+            let legacyCoordinator = LegacyPokeOnboardingCoordinator(
                 router: LegacyRouter(
                     rootController: UIWindow.getRootNavigationController
                 ),
                 factory: LegacyPokeBuilder()
             )
+
+            legacyCoordinator.finishFlow = { [weak self, weak legacyCoordinator] in
+                legacyCoordinator?.childCoordinators = []
+                self?.removeDependency(legacyCoordinator)
+            }
+            addDependency(legacyCoordinator)
+            coordinator = legacyCoordinator
         case .new:
-            coordinator = PokeOnboardingCoordinator(
+            let newCoordinator = PokeOnboardingCoordinator(
                 navigationController: UIWindow.getRootNavigationController,
                 factory: PokeBuilder()
             )
-        }
-
-        coordinator.finishFlow = { [weak self, weak coordinator] in
-            coordinator?.childCoordinators = []
-            self?.removeDependency(coordinator)
+            coordinator = newCoordinator
         }
         
-        addDependency(coordinator)
         coordinator.start()
         
         return coordinator
@@ -870,6 +870,7 @@ extension ApplicationCoordinator {
 
 // MARK: - StampTabFlow
 
+#warning("TODO: 앱 서비스를 탭바로만 이동하는 것이 확정될 경우, 기존 메소드(runStampFlow, runPokeFlow)의 navigationController만 변경하고, runStampTabFlow/runPokeTabFlow 메소드들은 제거합니다.")
 extension ApplicationCoordinator {
     internal func runStampTabFlow() {
         let coordinator = StampCoordinator(
@@ -889,6 +890,7 @@ extension ApplicationCoordinator {
             navigationController: pokeNavigationController,
             factory: PokeBuilder()
         )
+        
         coordinator.start(isRouteFromTabBar: true)
     }
     

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogCoordinatorDestination.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogCoordinatorDestination.swift
@@ -16,4 +16,6 @@ public enum SoptlogCoordinatorDestination {
     case soptamp
     case pokeHome
     case pokeMyFriends(relation: PokeRelation)
+    case home
+    case signIn
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -17,6 +17,7 @@ public protocol SoptlogCoordinatable {
     var onToolTipTapped: ((CGRect) -> Void)? { get set }
     var onSoptuneTapped: (() -> Void)? { get set }
     var onNetworkError: (@MainActor () -> Void)? { get set }
+    var onAuthFailed: (@MainActor () -> Void)? { get set }
     var onSoptampHomeTapped: (() -> Void)? { get set }
     var onPokeHomeTapped: (() -> Void)? { get set }
     var onPokeMyFriendsTapped: ((PokeRelation) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Interface/Sources/SoptlogPresentable.swift
@@ -16,7 +16,7 @@ public protocol SoptlogViewControllable: LegacyViewControllable { }
 public protocol SoptlogCoordinatable {
     var onToolTipTapped: ((CGRect) -> Void)? { get set }
     var onSoptuneTapped: (() -> Void)? { get set }
-    var onNetworkError: (() -> Void)? { get set }
+    var onNetworkError: (@MainActor () -> Void)? { get set }
     var onSoptampHomeTapped: (() -> Void)? { get set }
     var onPokeHomeTapped: (() -> Void)? { get set }
     var onPokeMyFriendsTapped: ((PokeRelation) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/LegacySoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/LegacySoptlogCoordinator.swift
@@ -66,6 +66,21 @@ public final class LegacySoptlogCoordinator: DefaultSoptlogCoordinator {
             AlertUtils.presentNetworkAlertVC()
         }
         
+        soptlog.vm.onAuthFailed = { [weak self] in
+            AlertUtils.presentAlertVC(
+                type: .titleDescription,
+                title: I18N.Home.PopUp.needToLogin,
+                description: I18N.Home.PopUp.needToLoginDetail,
+                customButtonTitle: I18N.Home.PopUp.login,
+                customAction: { [weak self] in
+                    self?.requestCoordinating?(.signIn)
+                },
+                cancelAction: { [weak self] in
+                    self?.requestCoordinating?(.home)
+                }
+            )
+        }
+        
         self.rootViewController = soptlog.vc.viewController
         self.router.push(soptlog.vc)
     }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/Coordinator/SoptlogCoordinator.swift
@@ -79,6 +79,23 @@ public final class SoptlogCoordinator: BaseCoordinator {
             AlertUtils.presentNetworkAlertVC()
         }
         
+        soptlog.vm.onAuthFailed = { [weak self] in
+            AlertUtils.presentAlertVC(
+                type: .titleDescription,
+                title: I18N.Home.PopUp.needToLogin,
+                description: I18N.Home.PopUp.needToLoginDetail,
+                customButtonTitle: I18N.Home.PopUp.login,
+                customAction: { [weak self] in
+                    guard let self else { return }
+                    self.delegate?.soptlogCoordinator(self, to: .signIn)
+                },
+                cancelAction: { [weak self] in
+                    guard let self else { return }
+                    self.delegate?.soptlogCoordinator(self, to: .home)
+                }
+            )
+        }
+        
         self.rootViewController = soptlog.vc
         navigationController?.pushViewController(soptlog.vc, animated: true)
     }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -43,7 +43,7 @@ public class SoptlogViewModel: SoptlogViewModelType {
     
     public var onToolTipTapped: ((CGRect) -> Void)?
     public var onSoptuneTapped: (() -> Void)?
-    public var onNetworkError: (() -> Void)?
+    public var onNetworkError: (@MainActor () -> Void)?
     public var onSoptampHomeTapped: (() -> Void)?
     public var onPokeHomeTapped: (() -> Void)?
     public var onPokeMyFriendsTapped: ((PokeRelation) -> Void)?
@@ -134,7 +134,7 @@ extension SoptlogViewModel {
             case .networkError(_):
                 #warning("AlertVC가 메인스레드에서 보여지지 않는 문제 발생. #789에서 해결 필요")
                 print("🚨 네트워크 에러")
-                onNetworkError?()
+                await onNetworkError?()
             case .authFailed:
                 print("🚨 SoptlogViewModel: 인증에 실패했습니다.")
             }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -44,6 +44,7 @@ public class SoptlogViewModel: SoptlogViewModelType {
     public var onToolTipTapped: ((CGRect) -> Void)?
     public var onSoptuneTapped: (() -> Void)?
     public var onNetworkError: (@MainActor () -> Void)?
+    public var onAuthFailed: (@MainActor () -> Void)?
     public var onSoptampHomeTapped: (() -> Void)?
     public var onPokeHomeTapped: (() -> Void)?
     public var onPokeMyFriendsTapped: ((PokeRelation) -> Void)?
@@ -132,11 +133,11 @@ extension SoptlogViewModel {
         } catch let error as MainError {
             switch error {
             case .networkError(_):
-                #warning("AlertVC가 메인스레드에서 보여지지 않는 문제 발생. #789에서 해결 필요")
                 print("🚨 네트워크 에러")
                 await onNetworkError?()
             case .authFailed:
                 print("🚨 SoptlogViewModel: 인증에 실패했습니다.")
+                await onAuthFailed?()
             }
         } catch {
             print("🚨 SoptlogViewModel: Unknown error: \(error)")

--- a/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/AppJamRankingViewControllable.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Interface/Sources/Presentable/AppJamRankingViewControllable.swift
@@ -20,7 +20,7 @@ public protocol AppJamRankingViewControllable: UIViewController { }
 
 public protocol AppJamRankingRoutingTrigger {
     var onNaviBackTap: (() -> Void)? { get set }
-    var onNetworkError: (() -> Void)? { get set }
+    var onNetworkError: (@MainActor () -> Void)? { get set }
 }
 
 // MARK: - ViewModelType

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/AppJamRanking/AppJamRankingCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/CollectionView/AppJamRanking/AppJamRankingCompositionalLayout.swift
@@ -49,7 +49,6 @@ extension AppJamRankingVC {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        header.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 0, bottom: 0, trailing: 0)
         
         section.boundarySupplementaryItems = [header]
         

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/ViewModel/AppJamRankingViewModel.swift
@@ -39,7 +39,7 @@ public class AppJamRankingViewModel: AppJamRankingViewModelType {
     // MARK: - AppJamCoordinatable
 
     public var onNaviBackTap: (() -> Void)?
-    public var onNetworkError: (() -> Void)?
+    public var onNetworkError: (@MainActor () -> Void)?
 
     // MARK: - init
 

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/LegacyTabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/LegacyTabBarCoordinator.swift
@@ -58,6 +58,9 @@ public final class LegacyTabBarCoordinator: DefaultTabBarCoordinator {
                 customButtonTitle: I18N.Home.PopUp.login,
                 customAction: { [weak self] in
                     self?.requestCoordinating?(.signIn)
+                },
+                cancelAction: { [weak self] in
+                    self?.requestCoordinating?(.home)
                 }
             )
         }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Coordinator/TabBarCoordinator.swift
@@ -83,6 +83,24 @@ public final class TabBarCoordinator: BaseCoordinator {
             }
         }
         
+        tabBar.vm.showTabBarAlert = { [weak self] in
+            guard let self = self else { return }
+            AlertUtils.presentAlertVC(
+                type: .titleDescription,
+                title: I18N.Home.PopUp.needToLogin,
+                description: I18N.Home.PopUp.needToLoginDetail,
+                customButtonTitle: I18N.Home.PopUp.login,
+                customAction: { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.tabBarCoordinator(self, to: .signIn)
+                },
+                cancelAction: { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.tabBarCoordinator(self, to: .home)
+                }
+            )
+        }
+        
         self.tabBarController = tabBar.vc
         self.navigationController?.setViewControllers([tabBar.vc], animated: false)
     }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/ViewModel/TabBarViewModel.swift
@@ -65,6 +65,15 @@ extension TabBarViewModel {
             .withUnretained(self)
             .sink { owner, index in
                 guard let tabBar = TabBarItemType.from(index: index, userType: owner.userType) else { return }
+                
+                // Visitor가 Soptlog 탭을 선택하면 로그인 Alert 표시
+                if owner.userType == .visitor && tabBar == .soptlog {
+                    output.selectedIndex.send(0) // 홈 탭 인덱스
+                    owner.showTabBarAlert?()
+
+                    return
+                }
+                
                 owner.onTabBarItemTapped?(tabBar)
                 owner.trackAmplitude(itemType: tabBar)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
@@ -297,19 +297,41 @@ extension BaseService {
                 switch response {
                 case .success(let value):
                     do {
-                        let decoder = JSONDecoder()
-                        let body = try decoder.decode(T.self, from: value.data)
-                        continuation.resume(returning: body)
+                        guard let response = value.response else { 
+                            throw NSError(domain: "응답값이 비어있습니다", code: -1000)
+                        }
+                        
+                        switch response.statusCode {
+                        case 200...399:
+                            let decoder = JSONDecoder()
+                            let body = try decoder.decode(T.self, from: value.data)
+                            continuation.resume(returning: body)
+                        case 400...599:
+                            let decoder = JSONDecoder()
+                            let errorBody = try decoder.decode(ErrorResponse.self, from: value.data)
+                            let apiError = APIError.network(statusCode: response.statusCode, response: errorBody)
+                            print("🚨 APIError 발생: statusCode \(response.statusCode)")
+                            continuation.resume(throwing: apiError)
+                        default:
+                            throw NSError(domain: "알 수 없는 오류, errorCode: \(response.statusCode)", code: response.statusCode)
+                        }
                     } catch let error {
                         if let error = error as? APIError {
-                            print("🚨 APIError 발생: \(error.localizedDescription)")
+                            continuation.resume(throwing: error)
+                        } else {
+                            print("🚨 정의되지 않은 에러 발생: \(error.localizedDescription)")
                             continuation.resume(throwing: error)
                         }
-                        print("🚨 정의되지 않은 에러 발생: \(error.localizedDescription)")
-                        continuation.resume(throwing: MoyaError.jsonMapping(value))
                     }
                 case .failure(let error):
-                    continuation.resume(throwing: error)
+                    if case MoyaError.underlying(let error, _) = error,
+                       case AFError.requestRetryFailed(let retryError, _) = error,
+                       let retryError = retryError as? APIError,
+                       retryError == APIError.tokenReissuanceFailed {
+                        continuation.resume(throwing: retryError)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
             


### PR DESCRIPTION
## 🌴 PR 요약
솝트로그 진입 시 발생하는 FatalError 원인이 에러 처리 콜백이 백그라운드에서 호출되는 것 하나인 줄 알았는데, 여러 버그가 혼합되어있어 부득이하게 작업량이 많아졌습니다.🥲
- 에러처리 콜백이 메인 액터에서 실행되도록 수정
- 탭바, 솝트로그 에러 발생 시 AlertVC 띄우는 로직 추가
- requestObjectAsync 메소드에 에러 throw 로직 추가
- AppCoordinator에서 화면전환 리팩토링 플래그의 경우 불필요한 의존성 등록, 제거 로직 삭제
- 홈 뷰 task 명시적으로 취소 
- 방문자 로그인 화면 진입 시 Soptlog 뷰 레이아웃 에러 해결

🌱 작업한 브랜치
- feature/#789

## 🌱 PR Point
### 에러 콜백 MainActor 실행으로 변경
**문제 상황**
<img width="2788" height="1358" alt="image" src="https://github.com/user-attachments/assets/13c8f34c-1aad-4577-8dec-74c038353ca6" />  

비동기 네트워크 통신 후 에러 콜백 실행 시, Background Thread에서 UI 업데이트를 시도하여 크래시가 발생했습니다.

**문제 해결**
- 콜백 정의 단계에서 @MainActor를 강제하도록 수정했습니다.

<br>

### MainActor.run 제거
기존에 호출부에서 MainActor.run { ... }으로 감싸던 방식을, @MainActor 클로저 활용하는 방식으로 수정했습니다. 
**AS-IS**  
```swift
// viewModel

public var onNetworkError: (() -> Void)?

MainActor.run {
    onNetworkError?()
}
```
- 이 경우 `MainActor.run` 작성을 누락해도 컴파일 에러가 발생하지 않아, 실수로 백그라운드에서 UI 작업을 수행할 위험이 있습니다.

**TO-BE**
```swift
// viewModel

// 이제 이 클로저를 호출하거나 전달받는 코드는 반드시 메인 스레드 환경이어야 함을 컴파일러가 보증
public var onNetworkError: (@MainActor() -> Void)?

await onNetworkError?()
```
@MainActor 사용 시 아래와 같은 장점이 있다고 판단해 수정했습니다.
- 컴파일 타임 에러 체크: @MainActor가 지정된 콜백에 메인 액터가 아닌 곳에서 접근하려고 하면 컴파일 에러가 발생하여 실수를 방지할 수 있습니다.
- 호출부마다 `MainActor.run`으로 감싸는 보일러플레이트 코드가 제거되어 코드가 간결해집니다.
- UI와 관련된 모든 콜백이 메인 스레드에서 실행된다는 것을 타입만 보고도 명확히 알 수 있습니다.

<br>

### requestObjectAsync 실패 에러 처리
**문제 상황**
- requestObjectAsync에서 실패 시 에러를 매핑하지 않아 Data나 Domain 계층에서 각각 매핑을 해주고 있어 중복 코드 발생합니다.

**문제 해결**
- `requestObjectAsync`에서 statusCode 기반으로 APIError MoyaError로 매핑하는 분기를 추가했습니다. 

<br>

### AppCoordinator의 불필요한 의존성 로직 제거
https://github.com/sopt-makers/SOPT-iOS/discussions/514 에서 코디네이터 의존성 제거 방식을 수정했기 때문에 new 피처 플래그에서는 의존성 등록 및 제거가 불필요합니다.

<br>

### 방문자 로그인 진입 시 FatalError 해결
**문제 발생**
```swift
// ApplicationCoordinator.swift
runSoptlogFlow(type: userType)
        
switch userType {
case .active, .inactive:    
        // 생략
case .visitor:
    viewControllers = [
        homeNavigationController,
        soptlogNavigatoinController
    ]
}
```
- 방문자 모드임에도 runSoptlogFlow가 호출되어 토큰이 필요한 soptlogAPI를 요청
- API 실패 후 에러 처리가 되어있지 않아 CollectionView 레이아웃 에러 발생.

에러 대응 로직 추가 후에도, 아래 두 곳에서 동시에 Alert을 띄우는 현상 발생했습니다.
1. 탭바에서 솝트로그 탭을 선택했을 때 AlertVC present
2. 솝트로그 데이터를 fetch할 때 발생하는 authFailed 에러가 AlertVC present
가 되어 총 2개의 AlertVC가 나타나는 문제가 있었습니다.

<details><summary>AlertVC가 2번 나타나는 오류</summary>

https://github.com/user-attachments/assets/68c9564c-4c75-420e-86f2-6fd1f83d9ab7

- 첫번째 Alert: 탭 바에서 솝트로그 탭을 선택했을 때 present
- 두번째 Alert: 솝트로그에서 present된 Alert

</details>

**문제 해결**
유저 타입에 따라 솝트로그 플로우를 분리해 문제를 해결했습니다.
```swift
// ApplicationCoordinator.swift 
switch userType {
case .active, .inactive:
     runSoptlogFlow(type: userType)
    // 생략
case .visitor:
    // Visitor는 빈 navigation controller 사용 (실제 화면 전환은 TabBarViewModel에서 막음)
    viewControllers = [
        homeNavigationController,
        UINavigationController()
    ]
}
```
- 토큰이 없는 상태에서 불필요한 API 호출을 차단하여 FatalError를 방지했습니다.
- 탭 진입 시점에 발생하는 Alert가 1개로 줄어 사용자 시나리오의 혼선을 제거했습니다.
- 또한 방문자에게 불필요한 솝트로그 뷰 렌더링을 제거하여 리소스를 절약했습니다.

<br>

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 로그인 전환 시 홈 컴포넌트 메모리 잔존 문제 분석
**문제 상황**  
<img width="380" height="669" alt="image" src="https://github.com/user-attachments/assets/71faf13a-a9d7-4b80-9a4f-ec023934e600" />  

active/inactive 로그인 → 로그아웃 → 방문자 모드 홈 진입 → 다시 로그인 뷰 진입 시, 이전 홈 화면의 UI 컴포넌트들이 메모리에 남아있는 현상 확인했습니다.

<img width="1886" height="284" alt="image" src="https://github.com/user-attachments/assets/d577202a-563a-4a4f-9247-eda103b8e655" />

HomeForVisitorVC는 정상적으로 deinit 되었으나, 내부 컴포넌트들이 _subviewCache에 의해 강한 참조로 유지되고 있었습니다.

> **_subviewCache의 역할**
UIView가 서브뷰 접근 성능 최적화를 위해 내부적으로 관리하는 캐시 구조입니다.

**문제 원인**  
- 현재 AppCoordinator가 `homeNavigationController`의 인스턴스를 앱 생명주기 동안 재사용하고 있습니다. 
- 네비게이션 스택은 비워지더라도, 해당 컨테이너 뷰가 내부적으로 들고 있던 캐시 데이터가 여전히 메모리에 머물게 됩니다.

**해결 방안**  
- runTabBarFlow 호출 시마다 homeNavigation에 새 인스턴스를 할당하여 캐시를 초기화할 수 있습니다.
- 하지만, 회원의 경우 방문자로 로그인하는 경우가 드물고 캐시 데이터가 재진입 시 성능에 이점을 줄 수 있어, 메모리 점유 대비 성능 효율을 고려하여 현 구조를 유지하기로 판단했습니다.


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #789
