### PR TITLE
[Feat] #821 - universal link 

### DIFF
--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>$(APPLINK)</string>
+	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
@@ -10,7 +10,7 @@
 	</array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>$(APPLINK)</string>
+		<string>applinks:sopt-internal-dev.sopt.org</string>
 	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
@@ -63,4 +63,8 @@ extension SceneDelegate {
     func redirectSignInVC(url: String) {
         appCoordinator.start(with: .signInSuccess(url: url))
     }
+    
+    func handleUniversalLink(_ url: String) {
+        appCoordinator.start(with: .universalWebLink(url: url))
+    }
 }

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
@@ -68,7 +68,7 @@ extension SceneDelegate {
         appCoordinator.start(with: .universalWebLink(url: url))
     }
     
-    func handleUniversalLinkWithUserAcitivity(_ userActivity: NSUserActivity) {
+    func handleUniversalLinkWithUserActivity(_ userActivity: NSUserActivity) {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else {
             print("❌ Not a universal link")

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
@@ -67,4 +67,14 @@ extension SceneDelegate {
     func handleUniversalLink(_ url: String) {
         appCoordinator.start(with: .universalWebLink(url: url))
     }
+    
+    func handleUniversalLinkWithUserAcitivity(_ userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            print("❌ Not a universal link")
+            return
+        }
+
+        handleUniversalLink(incomingURL.absoluteString)
+    }
 }

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
@@ -72,6 +72,7 @@ extension SceneDelegate {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else {
             print("❌ Not a universal link")
+            appCoordinator.start()
             return
         }
 

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -45,6 +45,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         parseContexts(openURLContexts: URLContexts)
     }
     
+    func scene(
+        _ scene: UIScene,
+        continue userActivity: NSUserActivity
+    ) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            print("❌ Not a universal link")
+            return
+        }
+
+        handleUniversalLink(incomingURL.absoluteString)
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {}
     
     func sceneDidBecomeActive(_ scene: UIScene) {

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -38,7 +38,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        self.appCoordinator.start()
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUniversalLinkWithUserAcitivity(userActivity)
+        } else {
+            self.appCoordinator.start()
+        }
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -49,13 +53,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ scene: UIScene,
         continue userActivity: NSUserActivity
     ) {
-        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-              let incomingURL = userActivity.webpageURL else {
-            print("❌ Not a universal link")
-            return
-        }
-
-        handleUniversalLink(incomingURL.absoluteString)
+        handleUniversalLinkWithUserAcitivity(userActivity)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -39,7 +39,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
         
         if let userActivity = connectionOptions.userActivities.first {
-            handleUniversalLinkWithUserAcitivity(userActivity)
+            handleUniversalLinkWithUserActivity(userActivity)
         } else {
             self.appCoordinator.start()
         }
@@ -53,7 +53,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ scene: UIScene,
         continue userActivity: NSUserActivity
     ) {
-        handleUniversalLinkWithUserAcitivity(userActivity)
+        handleUniversalLinkWithUserActivity(userActivity)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
@@ -11,10 +11,13 @@ import Foundation
 /// Coordinator에서 DeepLinkOption의 종류를 지정하는 enum입니다.
 public enum DeepLinkOption {
     case signInSuccess(url: String)
+    case universalWebLink(url: String)
     
     public var url: String {
         switch self {
         case .signInSuccess(let url):
+            return url
+        case .universalWebLink(let url):
             return url
         }
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -121,8 +121,9 @@ public final class ApplicationCoordinator: BaseCoordinator {
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .filter { _ in
-                self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
-            }.sink { [weak self] error in
+                self.tabBarController != nil
+            }
+            .sink { [weak self] error in
                 self?.handleNotificationLinkError(error: error)
                 self?.notificationHandler.clearNotificationRecord()
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -81,6 +81,8 @@ public final class ApplicationCoordinator: BaseCoordinator {
                     by: .rootWindow(animated: false, message: nil),
                     with: url
                 )
+            case .universalWebLink(let url):
+                notificationHandler.receive(webLink: url)
             }
         } else {
             runSplashFlow()
@@ -105,10 +107,12 @@ public final class ApplicationCoordinator: BaseCoordinator {
         
         self.notificationHandler.webLink
             .compactMap { $0 }
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .filter { _ in
-                self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
-            }.sink { [weak self] url in
+                self.tabBarController != nil
+            }
+            .sink { [weak self] url in
                 self?.handleWebLink(webLink: url)
                 self?.notificationHandler.clearNotificationRecord()
             }.store(in: cancelBag)
@@ -122,6 +126,8 @@ public final class ApplicationCoordinator: BaseCoordinator {
                 self?.handleNotificationLinkError(error: error)
                 self?.notificationHandler.clearNotificationRecord()
             }.store(in: cancelBag)
+        
+        self.notificationHandler.sendNotificationIfNeeded()
     }
     
     // MARK: - handleDeepLink
@@ -410,7 +416,7 @@ extension ApplicationCoordinator {
         )
         coordinator.delegate = self
         coordinator.start()
-        
+    
         self.tabBarController = coordinator.tabBarController
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -106,8 +106,8 @@ public final class ApplicationCoordinator: BaseCoordinator {
             }.store(in: cancelBag)
         
         self.notificationHandler.webLink
-            .compactMap { $0 }
             .dropFirst()
+            .compactMap { $0 }
             .receive(on: DispatchQueue.main)
             .filter { _ in
                 self.tabBarController != nil

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/NotificationHelpers/NotificationHandler.swift
@@ -107,4 +107,14 @@ extension NotificationHandler {
         self.webLink.send(nil)
         self.notificationLinkError.send(nil)
     }
+    
+    public func sendNotificationIfNeeded() {
+        if let wLink = self.webLink.value {
+            self.webLink.send(wLink)
+        }
+        
+        if let dLink = self.deepLink.value {
+            self.deepLink.send(dLink)
+        }
+    }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
+++ b/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>$(APPLINK)</string>
+    </array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
+++ b/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
@@ -10,7 +10,7 @@
 	</array>
     <key>com.apple.developer.associated-domains</key>
     <array>
-        <string>$(APPLINK)</string>
+        <string>applinks:playground.sopt.org</string>
     </array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
@@ -63,4 +63,8 @@ extension SceneDelegate {
     func redirectSignInVC(url: String) {
         appCoordinator.start(with: .signInSuccess(url: url))
     }
+    
+    func handleUniversalLink(_ url: String) {
+        appCoordinator.start(with: .universalWebLink(url: url))
+    }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
@@ -68,7 +68,7 @@ extension SceneDelegate {
         appCoordinator.start(with: .universalWebLink(url: url))
     }
     
-    func handleUniversalLinkWithUserAcitivity(_ userActivity: NSUserActivity) {
+    func handleUniversalLinkWithUserActivity(_ userActivity: NSUserActivity) {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else {
             print("❌ Not a universal link")

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
@@ -67,4 +67,14 @@ extension SceneDelegate {
     func handleUniversalLink(_ url: String) {
         appCoordinator.start(with: .universalWebLink(url: url))
     }
+    
+    func handleUniversalLinkWithUserAcitivity(_ userActivity: NSUserActivity) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            print("❌ Not a universal link")
+            return
+        }
+
+        handleUniversalLink(incomingURL.absoluteString)
+    }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
@@ -72,6 +72,7 @@ extension SceneDelegate {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else {
             print("❌ Not a universal link")
+            appCoordinator.start()
             return
         }
 

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -38,7 +38,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
         
         if let userActivity = connectionOptions.userActivities.first {
-            handleUniversalLinkWithUserAcitivity(userActivity)
+            handleUniversalLinkWithUserActivity(userActivity)
         } else {
             self.appCoordinator.start()
         }
@@ -52,7 +52,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ scene: UIScene,
         continue userActivity: NSUserActivity
     ) {
-        handleUniversalLinkWithUserAcitivity(userActivity)
+        handleUniversalLinkWithUserActivity(userActivity)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -37,7 +37,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        self.appCoordinator.start()
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUniversalLinkWithUserAcitivity(userActivity)
+        } else {
+            self.appCoordinator.start()
+        }
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -48,10 +52,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         _ scene: UIScene,
         continue userActivity: NSUserActivity
     ) {
-        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-              let incomingURL = userActivity.webpageURL else { return }
-
-        handleUniversalLink(incomingURL.absoluteString)
+        handleUniversalLinkWithUserAcitivity(userActivity)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -44,6 +44,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         parseContexts(openURLContexts: URLContexts)
     }
     
+    func scene(
+        _ scene: UIScene,
+        continue userActivity: NSUserActivity
+    ) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else { return }
+
+        handleUniversalLink(incomingURL.absoluteString)
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {}
     
     func sceneDidBecomeActive(_ scene: UIScene) {


### PR DESCRIPTION
## 🌴 PR 요약
외부 링크(문자, 카카오톡 등)에서 SOPT 앱으로 직접 진입할 수 있도록 Universal Links를 구현했습니다.

🌱 작업한 브랜치
- feat/#821

## 🌱 PR Point

1. Universal Links 설정

- **Associated Domains 추가**

2. SceneDelegate 딥링크 핸들러 구현

- **`scene(_:continue:)` 메서드 추가**

3. ApplicationCoordinator 개선
-  `universalWebLink` 옵션 처리 추가
- `NotificationHandler`를 통한 웹링크 전달
4. NotificationHandler 활용
- TabBar 생성 완료 후 대기 중이던 링크 처리하는 **`sendNotificationIfNeeded()` 메서드 사용**
- 웹링크/딥링크 통합 관리

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
**서버 설정 필요**
dev/prod 도메인 둘 다 AASA 파일 배포를 부탁드린 상태입니다.

## 📮 관련 이슈
- Resolved: #821 
