### PR TITLE
[Fix] #829 - 박수 QA 반영

### DIFF
--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ClapListScene/VC/ClapListVC.swift
@@ -70,6 +70,14 @@ final class ClapListVC: UIViewController, ClapListViewControllable {
         self.bindViewModel()
         self.viewDidLoadSubject.send(())
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        guard let touch = touches.first else { return }
+        if !containerView.frame.contains(touch.location(in: view)) {
+            onNaviBackTap?()
+        }
+    }
 
     // MARK: - Init
 
@@ -99,7 +107,7 @@ extension ClapListVC {
         containerView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(164)
             $0.directionalHorizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(32)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
         backButton.snp.makeConstraints {
@@ -116,7 +124,7 @@ extension ClapListVC {
         clapListCollectionView.snp.makeConstraints {
             $0.top.equalTo(backButton.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview()
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -304,6 +304,7 @@ extension StampCoordinator {
         }
 
         clapList.vc.modalPresentationStyle = .overFullScreen
+        clapList.vc.modalTransitionStyle = .crossDissolve
         self.rootController?.topViewController?.present(clapList.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/VC/ListDetailVC.swift
@@ -158,7 +158,8 @@ extension ListDetailVC {
             .publisher(for: .touchUpInside)
             .withUnretained(self)
             .sink { owner, _ in
-                owner.onViewClapTap?(owner.viewModel.stampId, owner.viewModel.otherUserName ?? "")
+                owner.onViewClapTap?(owner.viewModel.stampId,
+                                     owner.viewModel.otherUserName ?? "")
             }.store(in: cancelBag)
     }
     
@@ -192,6 +193,8 @@ extension ListDetailVC {
             }
             .scan(0) { count, new in count + new }
             .debounce(for: .seconds(1), scheduler: RunLoop.main)
+            .scan((0, 0)) { (prev, newTotal) in (newTotal, newTotal - prev.0) }
+            .map{$0.1}
             .asDriver()
         
         let input = ListDetailViewModel.Input(

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -210,8 +210,7 @@ extension ListDetailViewModel {
         
         input.clapButtonTapped
             .withUnretained(self)
-            .sink {
-                owner, count in
+            .sink { owner, count in
                 owner.useCase.clap(stampId: owner.stampId, clapCount: count)
                 AmplitudeInstance.shared.track(
                     eventType: .clickUpdateClap,


### PR DESCRIPTION
## 🌴 PR 요약
- 박수 QA 수정 사항을 반영했습니다.

🌱 작업한 브랜치
- feature/#829

## 🌱 PR Point
### 박수 친 횟수가 제대로 반영되지 않는 오류 개선
**문제**
 `clapButton`을 여러 세션에 걸쳐 탭할 때, 박수 횟수가 실제 탭한 횟수보다 크게 전달되는 문제가 있었습니다.

**원인**
 `scan(0)`은 화면 생명주기 동안 누적값을 초기화하지 않습니다.
 `debounce`가 발동된 이후에도 이전 세션의 누적값이 그대로 남아 다음 세션에
 합산되고 있었습니다.

 | 세션 | 탭 횟수 | scan 누적값 | 서버 전달값 |
 |------|---------|------------|-----------|
 | 1세션 | 3번 | 3 | 3  |
 | 2세션 | 1번 | 4 | 4 ❌ |
 | 3세션 | 1번 | 5 | 5 ❌ |

**AS-IS**

 ```swift
// 생략
     .map { owner, _ in
         guard owner.myClapCount < 50 else { return 0 }
         owner.clap()
         return 1
     }
     .scan(0) { count, new in count + new } // -> 계속해서 누적된 값이 전달
     .debounce(for: .seconds(1), scheduler: RunLoop.main)
     .asDriver()
 ```

**TO-BE**

 ```swift
     .map { owner, _ in
         guard owner.myClapCount < 50 else { return 0 }
         owner.clap()
         return 1
     }
     .scan(0) { count, new in count + new } // 한 세션에서 계속 누적된 값 관리
     .debounce(for: .seconds(1), scheduler: RunLoop.main)
     //  prev: 지금까지 누적된 박수 횟수, newTotal: 이번 세션에서 친 박수
     // prev와 newTotal의 차이를 반환해서 실제 친 박수 횟수 return
     .scan((0, 0)) { (prev, newTotal) in (newTotal, newTotal - prev.0) } 
     .map { $0.1 }
     .asDriver()
 ```

`debounce` 이후 두 번째 `scan`으로 직전 세션의 누적값과 이번 세션의 누적값의 차이를 계산하여 문제를 해결했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
박수 목록에서 UI/UX를 개선했어요.
- collectionView Bottom 레이아웃이 피그마와 달라 수정했어요.
- 박수 목록이 나타날 때 crossDisolve 방식으로 present되도록 수정했어요.
- dimmed 영역을 클릭해도 dismiss되도록 수정했어요.

박수 친 목록은 서버 측에서 확인해주시기로 했습니다~!

## 📸 스크린샷
생략


## 📮 관련 이슈
- Resolved: #829
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 