### PR TITLE
[Fix] #835 - 파트별 랭킹 진입 시 빈화면이 나타나는 문제 처리

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -34,10 +34,9 @@ public extension TabBarItemType {
                 return 0
             case .soptamp:
                 return 1
-            case .poke:
-                return 2
             case .soptlog:
-                return 3
+                return 2
+            default: return 0           // poke 탭이 비활성화 상태이므로 0으로 처리
             }
         case .visitor:
             switch self {
@@ -46,7 +45,7 @@ public extension TabBarItemType {
             case .poke:
                 return 1
             case .soptlog:
-                return 1
+                return 2
             }
         }
     }
@@ -58,8 +57,7 @@ public extension TabBarItemType {
             switch index {
             case 0: return .home
             case 1: return .soptamp
-            case 2: return .poke
-            case 3: return .soptlog
+            case 2: return .soptlog
             default: return nil
             }
         case .visitor:

--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -34,9 +34,10 @@ public extension TabBarItemType {
                 return 0
             case .soptamp:
                 return 1
-            case .soptlog:
+            case .poke:
                 return 2
-            default: return 0           // poke 탭이 비활성화 상태이므로 0으로 처리
+            case .soptlog:
+                return 3
             }
         case .visitor:
             switch self {
@@ -45,7 +46,7 @@ public extension TabBarItemType {
             case .poke:
                 return 1
             case .soptlog:
-                return 2
+                return 1
             }
         }
     }
@@ -57,7 +58,8 @@ public extension TabBarItemType {
             switch index {
             case 0: return .home
             case 1: return .soptamp
-            case 2: return .soptlog
+            case 2: return .poke
+            case 3: return .soptlog
             default: return nil
             }
         case .visitor:

--- a/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Enum/TabBarItemType.swift
@@ -40,12 +40,10 @@ public extension TabBarItemType {
             }
         case .visitor:
             switch self {
-            case .home, .soptamp:
+            case .home, .soptamp, .poke:
                 return 0
-            case .poke:
-                return 1
             case .soptlog:
-                return 2
+                return 1
             }
         }
     }

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -275,10 +275,6 @@ public struct I18N {
             public static let instagram = "인스타그램"
         }
         
-        public struct AppService {
-            public static let headerTitle = "SOPT 더 재밌게 즐기기!"
-        }
-        
         public struct PopularPosts {
             public static let headerTitle = "실시간 인기글"
             public static let morePosts = "다른 게시물 보러가기"

--- a/SOPT-iOS/Projects/Data/Sources/Transform/AttendanceScheduleTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/AttendanceScheduleTransform.swift
@@ -31,7 +31,7 @@ extension TodayAttendance {
     public func toDomain() -> TodayAttendanceModel {
         return .init(status: self.status,
                      attendedAt: DateFormatManager.shared.transformDateFormat(self.attendedAt,
-                                                                           from: .dateTimeDash,
+                                                                           from: .isoWithoutMillis,
                                                                            to: .time))
     }
 }

--- a/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AttendanceFeature/Sources/ShowAttendanceScene/ViewModel/ShowAttendanceViewModel.swift
@@ -101,11 +101,11 @@ extension ShowAttendanceViewModel {
                     self.sceneType = .scheduledDay
                     
                     let convertedStartDate = DateFormatManager.shared.serverTimeToString(model.startDate,
-                                                                                         from: .isoWithoutMillis,
-                                                                                         to: .monthDayWeekTime)
+                                                                                         from: .monthDayWeekTime,
+                                                                                         to: .isoWithoutMillis)
                     let convertedEndDate = DateFormatManager.shared.serverTimeToString(model.endDate,
-                                                                                       from: .isoWithoutMillis,
-                                                                                       to: .monthDayWeekTime)
+                                                                                       from: .monthDayWeekTime,
+                                                                                       to: .isoWithoutMillis)
                     let newModel = AttendanceScheduleModel(type: model.type,
                                                            id: model.id,
                                                            location: model.location,

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
@@ -39,8 +39,6 @@ extension HomeForMemberVC {
                 return self?.createCalendarSection()
             case .mainProduct:
                 return self?.createMainProductSection()
-//            case .appService:
-//                return self?.createAppServiceSection()
             case .popularPosts:
                 return self?.createPopularPostsSection()
             case .socialLinks:

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForMemberCompositionalLayout.swift
@@ -39,8 +39,8 @@ extension HomeForMemberVC {
                 return self?.createCalendarSection()
             case .mainProduct:
                 return self?.createMainProductSection()
-            case .appService:
-                return self?.createAppServiceSection()
+//            case .appService:
+//                return self?.createAppServiceSection()
             case .popularPosts:
                 return self?.createPopularPostsSection()
             case .socialLinks:

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForVisitorCompositionalLayout.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/CompositionalLayout/HomeForVisitorCompositionalLayout.swift
@@ -32,8 +32,6 @@ extension HomeForVisitorVC {
                 return self?.createDashBoardSection()
             case .mainProduct:
                 return self?.createMainProductSection()
-            case .appService:
-                return self?.createAppServiceSection()
             }
         }
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Item/HomeForMemberItem.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/Item/HomeForMemberItem.swift
@@ -12,7 +12,6 @@ enum HomeForMemberItem: Hashable {
     case dashBoard(HomePresentationModel.DashBoard)
     case recentSchedule(HomePresentationModel.RecentSchedule)
     case productService(HomePresentationModel.ProductService)
-    case appService(HomePresentationModel.AppService)
     case popularPost(HomePresentationModel.PopularPost)
     case latestPost(HomePresentationModel.LatestPost) 
     case survey(HomePresentationModel.Survey)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForMemberSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForMemberSectionLayoutKind.swift
@@ -14,7 +14,6 @@ enum HomeForMemberSectionLayoutKind: Int, CaseIterable {
     case dashBoard
     case calendar
     case mainProduct
-//    case appService
     case popularPosts
     case latestPosts
     case survey
@@ -24,8 +23,6 @@ enum HomeForMemberSectionLayoutKind: Int, CaseIterable {
 extension HomeForMemberSectionLayoutKind: HomeSectionUIConfigurable {
     var headerTitle: String {
         switch self {
-//        case .appService:
-//            return I18N.Home.AppService.headerTitle
         case .popularPosts:
             return I18N.Home.PopularPosts.headerTitle
         case .latestPosts:

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForMemberSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForMemberSectionLayoutKind.swift
@@ -14,7 +14,7 @@ enum HomeForMemberSectionLayoutKind: Int, CaseIterable {
     case dashBoard
     case calendar
     case mainProduct
-    case appService
+//    case appService
     case popularPosts
     case latestPosts
     case survey
@@ -24,8 +24,8 @@ enum HomeForMemberSectionLayoutKind: Int, CaseIterable {
 extension HomeForMemberSectionLayoutKind: HomeSectionUIConfigurable {
     var headerTitle: String {
         switch self {
-        case .appService:
-            return I18N.Home.AppService.headerTitle
+//        case .appService:
+//            return I18N.Home.AppService.headerTitle
         case .popularPosts:
             return I18N.Home.PopularPosts.headerTitle
         case .latestPosts:

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForVisitorSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForVisitorSectionLayoutKind.swift
@@ -13,7 +13,7 @@ import Core
 enum HomeForVisitorSectionLayoutKind: Int, CaseIterable {
     case dashBoard
     case mainProduct
-    case appService
+//    case appService
 }
 
 extension HomeForVisitorSectionLayoutKind: HomeSectionUIConfigurable {
@@ -21,8 +21,8 @@ extension HomeForVisitorSectionLayoutKind: HomeSectionUIConfigurable {
         switch self {
         case .mainProduct:
             return I18N.Home.MainProduct.headerTitleForVisitor
-        case .appService:
-            return I18N.Home.AppService.headerTitle
+//        case .appService:
+//            return I18N.Home.AppService.headerTitle
         default:
             return ""
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForVisitorSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/CollectionView/SectionLayoutKind/HomeForVisitorSectionLayoutKind.swift
@@ -13,7 +13,6 @@ import Core
 enum HomeForVisitorSectionLayoutKind: Int, CaseIterable {
     case dashBoard
     case mainProduct
-//    case appService
 }
 
 extension HomeForVisitorSectionLayoutKind: HomeSectionUIConfigurable {
@@ -21,8 +20,6 @@ extension HomeForVisitorSectionLayoutKind: HomeSectionUIConfigurable {
         switch self {
         case .mainProduct:
             return I18N.Home.MainProduct.headerTitleForVisitor
-//        case .appService:
-//            return I18N.Home.AppService.headerTitle
         default:
             return ""
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -271,9 +271,6 @@ extension HomeForMemberVC {
                 case .productService(let productService):
                     return collectionView.dequeueConfiguredReusableCell(using: mainProductRegistration,
                                                                         for: indexPath, item: productService)
-                case .appService(let appService):
-                    return collectionView.dequeueConfiguredReusableCell(using: appServiceRegistration,
-                                                                        for: indexPath, item: appService)
                 case .popularPost(let popularPost):
                     return collectionView.dequeueConfiguredReusableCell(using: popularPostRegistration,
                                                                         for: indexPath, item: popularPost)
@@ -398,7 +395,6 @@ extension HomeForMemberVC {
         snapshot.appendItems([.dashBoard(data.dashBoard)], toSection: .dashBoard)
         snapshot.appendItems([.recentSchedule(data.recentSchedule)], toSection: .calendar)
         snapshot.appendItems(self.viewModel.productServiceList.map { .productService($0) }, toSection: .mainProduct)
-//        snapshot.appendItems(data.appServices.map { .appService($0) }, toSection: .appService)
         snapshot.appendItems(data.popularPosts.map { .popularPost($0) }, toSection: .popularPosts)
         snapshot.appendItems(data.latestPosts.map { .latestPost($0) }, toSection: .latestPosts)
         snapshot.appendItems([.survey(data.survey)], toSection: .survey)
@@ -417,7 +413,7 @@ extension HomeForMemberVC {
         let items: [HomeForMemberItem] = [
             .dashBoard(data.dashBoard),
             .recentSchedule(data.recentSchedule)
-        ] + data.appServices.map { .appService($0) }
+        ] 
         
         let existingItems = snapshot.itemIdentifiers.filter { items.contains($0) }
         
@@ -517,9 +513,7 @@ extension HomeForMemberVC: UICollectionViewDelegate, UICollectionViewDataSource 
             case .recentSchedule(let model):
                 self.cellTapped.send(.recentSchedule(model))
             case .productService(let model):
-                self.cellTapped.send(.productService(model))
-            case .appService(let model):
-                self.cellTapped.send(.appService(model))
+                self.cellTapped.send(.productService(model))            
             case .popularPost(let model):
                 self.cellTapped.send(.popularPost(model))
             case .latestPost(let model):

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForMemberVC.swift
@@ -393,12 +393,12 @@ extension HomeForMemberVC {
     private func applySnapshot(with data: HomePresentationModel) {
         var snapshot = NSDiffableDataSourceSnapshot<HomeForMemberSectionLayoutKind, HomeForMemberItem>()
         
-        snapshot.appendSections([.dashBoard, .calendar, .mainProduct, .appService, .popularPosts, .latestPosts, .survey, .socialLinks])
+        snapshot.appendSections([.dashBoard, .calendar, .mainProduct, .popularPosts, .latestPosts, .survey, .socialLinks])
         
         snapshot.appendItems([.dashBoard(data.dashBoard)], toSection: .dashBoard)
         snapshot.appendItems([.recentSchedule(data.recentSchedule)], toSection: .calendar)
         snapshot.appendItems(self.viewModel.productServiceList.map { .productService($0) }, toSection: .mainProduct)
-        snapshot.appendItems(data.appServices.map { .appService($0) }, toSection: .appService)
+//        snapshot.appendItems(data.appServices.map { .appService($0) }, toSection: .appService)
         snapshot.appendItems(data.popularPosts.map { .popularPost($0) }, toSection: .popularPosts)
         snapshot.appendItems(data.latestPosts.map { .latestPost($0) }, toSection: .latestPosts)
         snapshot.appendItems([.survey(data.survey)], toSection: .survey)

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/VC/HomeForVisitorVC.swift
@@ -163,7 +163,6 @@ extension HomeForVisitorVC {
         
         snapshot.appendItems([.dashBoard(HomePresentationModel.DashBoard())], toSection: .dashBoard)
         snapshot.appendItems(self.viewModel.productServiceList.map { .productService($0) }, toSection: .mainProduct)
-        snapshot.appendItems(appService.map { .appService($0) }, toSection: .appService)
         
         dataSource.apply(snapshot, animatingDifferences: true)
     }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -134,9 +134,7 @@ extension HomeForMemberViewModel {
                     AmplitudeInstance.shared.trackWithUserType(event: .clickAllCalendar)
                 case .productService(let model):
                     owner.onMainProductCellTapped?(model.product.serviceDomainLink)
-                    owner.eventTracker.trackAmplitude(event: model.product.toAmplitudeEventType)
-                case .appService(let model):
-                    owner.onAppServiceCellTapped?(model.deepLink)
+                    owner.eventTracker.trackAmplitude(event: model.product.toAmplitudeEventType)                
                     
                     #warning("코드리뷰 후 삭제 or 수정 예정")
 //                    if model.serviceName == "콕찌르기" {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -46,7 +46,7 @@ public final class PokeCoordinator: BaseCoordinator {
 
     public func showPokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool) {
         var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot, isRouteFromTabBar: isRouteFromTabBar,  coordinator: self)
-
+        
         if isRouteFromTabBar {
             self.rootController = self.navigationController
             self.navigationController?.setViewControllers([pokeMain.vc], animated: false)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -172,7 +172,7 @@ extension PokeMainVC {
         
         navigationView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20.adjusted)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
             make.height.equalTo(44)
         }
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/VC/PokeMainVC.swift
@@ -172,7 +172,7 @@ extension PokeMainVC {
         
         navigationView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(8)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(20.adjusted)
             make.height.equalTo(44)
         }
         

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -383,6 +383,7 @@ extension ApplicationCoordinator {
 
         runHomeFlow(type: userType)
         runStampTabFlow()
+        runPokeTabFlow()        
         
         switch userType {
         case .active, .inactive:
@@ -464,7 +465,6 @@ extension ApplicationCoordinator {
                 factory: HomeBuilder(),
                 userType: type
             )
-            
             newCoordinator.delegate = self
             coordinator = newCoordinator
         }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -383,7 +383,6 @@ extension ApplicationCoordinator {
 
         runHomeFlow(type: userType)
         runStampTabFlow()
-        runPokeTabFlow()
         
         switch userType {
         case .active, .inactive:
@@ -391,7 +390,6 @@ extension ApplicationCoordinator {
             viewControllers = [
                 homeNavigationController,
                 stampNavigationController,
-                pokeNavigationController,
                 soptlogNavigationController
             ]
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -444,7 +444,7 @@ extension ApplicationCoordinator {
                 case .notification:
                     self?.runNotificationFlow()
                 case .soptlog:
-                    self?.tabBarController?.selectedIndex = 1
+                    self?.tabBarController?.selectedIndex = 3
                 case .deepLink(let url):
                     self?.notificationHandler.receive(deepLink: url)
                     guard let deepLink = self?.notificationHandler.deepLink.value else { return }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -390,6 +390,7 @@ extension ApplicationCoordinator {
             viewControllers = [
                 homeNavigationController,
                 stampNavigationController,
+                pokeNavigationController,
                 soptlogNavigationController
             ]
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -383,7 +383,7 @@ extension ApplicationCoordinator {
 
         runHomeFlow(type: userType)
         runStampTabFlow()
-        runPokeTabFlow()        
+        runPokeTabFlow()
         
         switch userType {
         case .active, .inactive:

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SectionLayoutKind/SoptlogSectionLayoutKind.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/CollectionView/SectionLayoutKind/SoptlogSectionLayoutKind.swift
@@ -27,11 +27,8 @@ enum SoptlogSectionLayoutKind: Int, CaseIterable {
     /// 앱잼 참여 상태에 따라 표시할 섹션 목록
     static func visibleSections(isAppjamParticipant: Bool) -> [SoptlogSectionLayoutKind] {
         var sections: [SoptlogSectionLayoutKind] = [.logo]
-        
-        if isAppjamParticipant {
-            sections.append(.soptampLog)
-        }
-        
+                
+        sections.append(.soptampLog)
         sections.append(.pokeLog)
         sections.append(.banner)
         

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STChartRectangleView.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Components/STChartRectangleView.swift
@@ -210,7 +210,7 @@ extension STChartRectangleView {
   }
   
   public func setData(score: Int, username: String) {
-    self.usernameLabel.text = username
+    self.usernameLabel.text = username.isEmpty ? "-" : username
     self.scoreLabel.text = "\(score)점"
     self.scoreLabel.partFontChange(targetString: "점",
                                    font: DSKitFontFamily.Pretendard.medium.font(size: 12))

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingChartCVC.swift
@@ -77,9 +77,12 @@ extension PartRankingChartCVC {
     
     private func setChartData(chartRectangleModel: [PartRankingModel]) {
         for (index, rectangle) in chartStackView.arrangedSubviews.enumerated() {
-            guard let chartRectangle = rectangle as? STPartChartRectangleView else { return }
-            guard let model = chartRectangleModel[safe: index] else { return }            
-            chartRectangle.setData(rank: model.rank, partName: model.part)
+            guard let chartRectangle = rectangle as? STPartChartRectangleView else { continue }
+            if let model = chartRectangleModel[safe: index] {
+                chartRectangle.setData(rank: model.rank, partName: model.part)
+            } else {
+                chartRectangle.setData(rank: index + 1, partName: "-")
+            }
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingChartCVC.swift
@@ -72,14 +72,13 @@ extension PartRankingChartCVC {
     public func setData(model: PartRankingChartModel) {
         let models = model.ranking
         self.models = models
-        
         self.setChartData(chartRectangleModel: models)
     }
     
     private func setChartData(chartRectangleModel: [PartRankingModel]) {
         for (index, rectangle) in chartStackView.arrangedSubviews.enumerated() {
             guard let chartRectangle = rectangle as? STPartChartRectangleView else { return }
-            guard let model = chartRectangleModel[safe: index] else { return }
+            guard let model = chartRectangleModel[safe: index] else { return }            
             chartRectangle.setData(rank: model.rank, partName: model.part)
         }
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
@@ -104,6 +104,7 @@ extension RankingChartCVC {
     }
     
     public func setData(model: RankingChartModel) {
+        self.cancelBag = CancelBag()
         
         // 데이터 바인딩을 위한 모델 순서 재정렬
         let noDataRankingModel = RankingModel(username: "", score: 0, sentence: "")

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
@@ -106,9 +106,22 @@ extension RankingChartCVC {
     public func setData(model: RankingChartModel) {
         
         // 데이터 바인딩을 위한 모델 순서 재정렬
-        let arrangedModel = [model.ranking[1], model.ranking[0], model.ranking[2]]
-        self.models = arrangedModel
+        let noDataRankingModel = RankingModel(username: "-", score: 0, sentence: "")
+
+        let arrangedModel: [RankingModel]
+
+        switch model.ranking.count {
+        case 3:
+            arrangedModel = [model.ranking[1], model.ranking[0], model.ranking[2]]
+        case 2:
+            arrangedModel = [model.ranking[1], model.ranking[0], noDataRankingModel]
+        case 1:
+            arrangedModel = [noDataRankingModel, model.ranking[0], noDataRankingModel]
+        default:
+            arrangedModel = [noDataRankingModel, noDataRankingModel, noDataRankingModel]
+        }
         
+        self.models = arrangedModel
         self.setSpeechBalloonViews(balloonModels: arrangedModel)
         self.setChartData(chartRectangleModel: arrangedModel)
     }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/Ranking/RankingChartCVC.swift
@@ -106,7 +106,7 @@ extension RankingChartCVC {
     public func setData(model: RankingChartModel) {
         
         // 데이터 바인딩을 위한 모델 순서 재정렬
-        let noDataRankingModel = RankingModel(username: "-", score: 0, sentence: "")
+        let noDataRankingModel = RankingModel(username: "", score: 0, sentence: "")
 
         let arrangedModel: [RankingModel]
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -235,12 +235,10 @@ extension RankingVC {
         var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
         snapshot.appendSections([.chart, .list])
         
-        guard model.count >= 4 else { return }
+//        guard model.count >= 4 else { return }                
         
-        guard
-            let chartCellModels = Array(model[0...2]) as? [RankingModel],
-            let rankingListModel = Array(model[3...model.count - 1]) as? [RankingModel]
-        else { return }
+        let chartCellModels = Array(model.prefix(3))
+        let rankingListModel = model.count > 3 ? Array(model[3...]) : []
         
         let chartCellModel = RankingChartModel.init(ranking: chartCellModels)
         snapshot.appendItems([chartCellModel], toSection: .chart)

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/RankingVC.swift
@@ -207,7 +207,7 @@ extension RankingVC {
                     
                     chartCell.setData(model: chartCellModel)
                     chartCell.usernameTapped = { [weak self] balloonModel in
-                        guard let self else { return }
+                        guard let self, !balloonModel.username.isEmpty else { return }
                         
                         let item = balloonModel.toRankingListTapItem()
                         self.onCellTap?(item.username, item.sentence)
@@ -234,9 +234,7 @@ extension RankingVC {
     func applySnapshot(model: [RankingModel]) {
         var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
         snapshot.appendSections([.chart, .list])
-        
-//        guard model.count >= 4 else { return }                
-        
+
         let chartCellModels = Array(model.prefix(3))
         let rankingListModel = model.count > 3 ? Array(model[3...]) : []
         

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
@@ -27,7 +27,7 @@ final class TabBarController: UITabBarController {
     private var tabTypes: [TabBarItemType] {
         switch userType {
         case .active, .inactive:
-            return [.home, .soptamp, .poke, .soptlog]
+            return [.home, .soptamp, .soptlog]
         case .visitor:
             return [.home, .soptlog]
         }

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Controller/TabBarController.swift
@@ -27,7 +27,7 @@ final class TabBarController: UITabBarController {
     private var tabTypes: [TabBarItemType] {
         switch userType {
         case .active, .inactive:
-            return [.home, .soptamp, .soptlog]
+            return [.home, .soptamp, .poke, .soptlog]
         case .visitor:
             return [.home, .soptlog]
         }

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -44,6 +44,6 @@ let package = Package(
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.5.0"),
         .package(url: "https://github.com/amplitude/Amplitude-Swift", from: "1.11.10"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
-        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "7.0.0")
+        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "7.0.0"),
     ]
 )

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -11,7 +11,7 @@ let packageSettings = PackageSettings(
         "Alamofire": .framework,
         "GoogleSignIn": .framework,
         "GTMAppAuth": .framework,
-        "AppAuth": .framework,
+        "AppAuth": .staticFramework,
         "GULEnvironment": .framework,
         "GULLogger": .framework,
         "GULNSData": .framework,

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -11,7 +11,7 @@ let packageSettings = PackageSettings(
         "Alamofire": .framework,
         "GoogleSignIn": .framework,
         "GTMAppAuth": .framework,
-        "AppAuth": .staticFramework,
+        "AppAuth": .framework,
         "GULEnvironment": .framework,
         "GULLogger": .framework,
         "GULNSData": .framework,
@@ -44,6 +44,6 @@ let package = Package(
         .package(url: "https://github.com/airbnb/lottie-ios", from: "4.5.0"),
         .package(url: "https://github.com/amplitude/Amplitude-Swift", from: "1.11.10"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
-        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "7.0.0"),
+        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "9.0.0"),
     ]
 )


### PR DESCRIPTION
## 🌴 PR 요약
- 파트별 랭킹 진입 시 빈화면이 나타나는 오류를 수정했습니다.
- 출석 진행 시 시간이 00:00 으로 나타나는 오류를 수정했습니다.
- "SOPT 더 재밌게 즐기기" 섹션을 제거했습니다.

🌱 작업한 브랜치
- feature/ #835 

## 🌱 PR Point

기존에는 파트별 인원이 4명 이상인 경우에만 차트뷰를 그려주도록 하드코딩이 되어있었습니다.
```swift
   func applySnapshot(model: [RankingModel]) {
        var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
        snapshot.appendSections([.chart, .list])
        
        guard model.count >= 4 else { return }
...
```

변경 후 인원수와 관계없이 차트와 리스트뷰를 보여주도록 수정했습니다.
```swift
    func applySnapshot(model: [RankingModel]) {
        var snapshot = NSDiffableDataSourceSnapshot<RankingSection, AnyHashable>()
        snapshot.appendSections([.chart, .list])

        let chartCellModels = Array(model.prefix(3))
        let rankingListModel = model.count > 3 ? Array(model[3...]) : []
```

모델 순서를 재정렬하는 부분도 순위별로 더미데이터를 추가해서 인덱스 오류를 방지했습니다.
```swift
    public func setData(model: RankingChartModel) {
        
        // 데이터 바인딩을 위한 모델 순서 재정렬
        let noDataRankingModel = RankingModel(username: "", score: 0, sentence: "")

        let arrangedModel: [RankingModel]

        switch model.ranking.count {
        case 3:
            arrangedModel = [model.ranking[1], model.ranking[0], model.ranking[2]]
        case 2:
            arrangedModel = [model.ranking[1], model.ranking[0], noDataRankingModel]
        case 1:
            arrangedModel = [noDataRankingModel, model.ranking[0], noDataRankingModel]
        default:
            arrangedModel = [noDataRankingModel, noDataRankingModel, noDataRankingModel]
        }
```

차트에 데이터가 없을떄 화면이동 방지
```swift
                    chartCell.usernameTapped = { [weak self] balloonModel in
                        guard let self, !balloonModel.username.isEmpty else { return }
                        
                        let item = balloonModel.toRankingListTapItem()
                        self.onCellTap?(item.username, item.sentence)
                    }
```

## 📌 참고 사항
차트 데이터가 없을때 디자인이 맞는지 체크해주시면 감사하겠습니다~

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|파트별 랭킹뷰|<img width="300" height="2622" alt="simulator_screenshot_A7B1054E-4C46-4D4E-9221-9A21B53A9628" src="https://github.com/user-attachments/assets/46d36018-0a37-435a-9d1d-80e7c62d39d5" />|

## 📮 관련 이슈
- Resolved: #835 


