### PR TITLE
[Fix] #838 - 파트별 랭킹 refresh 오류 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/VC/PartRankingVC.swift
@@ -137,6 +137,7 @@ extension PartRankingVC {
             .withUnretained(self)
             .sink(receiveValue: { owner, partRankingModels in
                 owner.applySnapshot(model: partRankingModels)
+                owner.endRefresh()
             }).store(in: cancelBag)
     }
     


### PR DESCRIPTION
## 🌴 PR 요약
- Refresh가 종료되지 않는 문제를 해결했습니다.

🌱 작업한 브랜치
- feature/#838

## 🌱 PR Point
- 함수 미호출로 refresh가 종료되지 않아 함수 호출을 추가했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|파트별 랭킹 refresh|https://github.com/user-attachments/assets/a6532d83-585b-4922-b136-ebe0f184a6b2|


## 📮 관련 이슈
- Resolved: #838
