### PR TITLE
[Fix] #840 - 솝탬프 사진 수정 기능 오류 해결

### DIFF
--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/ListDetailScene/ViewModel/ListDetailViewModel.swift
@@ -270,6 +270,8 @@ extension ListDetailViewModel {
                 if let mine = model.isMine {
                     owner.isOtherUser = !mine
                 }
+                owner.currentText.send(model.content)
+                owner.currentDate.send(model.activityDate)
                 return model
             }
             .assign(to: \.self.listDetailModel, on: output)


### PR DESCRIPTION
## 🌴 PR 요약
솝탬프 수정 기능 오류를 해결했습니다.

🌱 작업한 브랜치
- feature/#840

## 🌱 PR Point
사진 수정 시 contents 필드가 비워지는 문제가 있었습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #840
- 
https://github.com/user-attachments/assets/c19dc0e1-fbb2-4669-b96a-63dcde3b711a