### PR TITLE
[Fix] #842 - 알림(딥링크, 웹링크) 오류 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -117,6 +117,8 @@ extension ApplicationCoordinator: NotificationCoordinatorDelegate {
             handleDeepLink(deepLink: deepLink)
         case .webLink(let url):
             self.notificationHandler.receive(webLink: url)
+            guard let webLink = self.notificationHandler.webLink.value else { return }
+            handleWebLink(webLink: webLink)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -92,36 +92,65 @@ public final class ApplicationCoordinator: BaseCoordinator {
     private func bindNotification() {
         self.cancelBag.cancel()
         
-        self.notificationHandler.deepLink
-            .compactMap { $0 }
-            .receive(on: DispatchQueue.main)
-            .filter { _ in
-                self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
-            }
-            .sink { [weak self] deepLinkComponent in
-                self?.handleDeepLink(deepLink: deepLinkComponent)
-                self?.notificationHandler.clearNotificationRecord()
-            }.store(in: cancelBag)
-        
-        self.notificationHandler.webLink
-            .compactMap { $0 }
-            .receive(on: DispatchQueue.main)
-            .filter { _ in
-                self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
-            }.sink { [weak self] url in
-                self?.handleWebLink(webLink: url)
-                self?.notificationHandler.clearNotificationRecord()
-            }.store(in: cancelBag)
-        
-        self.notificationHandler.notificationLinkError
-            .compactMap { $0 }
-            .receive(on: DispatchQueue.main)
-            .filter { _ in
-                self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
-            }.sink { [weak self] error in
-                self?.handleNotificationLinkError(error: error)
-                self?.notificationHandler.clearNotificationRecord()
-            }.store(in: cancelBag)
+        switch Config.coordinatorFlag {
+        case .legacy:
+            self.notificationHandler.deepLink
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .filter{ _ in
+                    self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
+                }
+                .sink { [weak self] deepLinkComponent in
+                    self?.handleDeepLink(deepLink: deepLinkComponent)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+            
+            self.notificationHandler.webLink
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .filter{ _ in
+                    self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
+                }
+                .sink { [weak self] url in
+                    self?.handleWebLink(webLink: url)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+            
+            self.notificationHandler.notificationLinkError
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .filter{ _ in
+                    self.childCoordinators.contains(where: { $0 is DefaultTabBarCoordinator })
+                }
+                .sink { [weak self] error in
+                    self?.handleNotificationLinkError(error: error)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+        case .new:
+            self.notificationHandler.deepLink
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] deepLinkComponent in
+                    self?.handleDeepLink(deepLink: deepLinkComponent)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+            
+            self.notificationHandler.webLink
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] url in
+                    self?.handleWebLink(webLink: url)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+            
+            self.notificationHandler.notificationLinkError
+                .compactMap { $0 }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] error in
+                    self?.handleNotificationLinkError(error: error)
+                    self?.notificationHandler.clearNotificationRecord()
+                }.store(in: cancelBag)
+        }
     }
     
     // MARK: - handleDeepLink


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#842

## 🌱 PR Point
### ApplicationCoordinator 알림 처리 플래그 분기
- bindNotification() 내부 로직을 Config.coordinatorFlag (.legacy / .new) 기반으로 분리
- .new 케이스에서는 TabBarCoordinator 존재 여부 필터를 제거해 알림 수신 타이밍 이슈 개선

### 웹링크 딥링크 처리 누락 버그 수정
- ApplicationCoordinator+Delegate.swift의 .webLink 분기에서 handleWebLink(webLink:) 호출이 빠져 있어 추가
- SplashUseCase 업데이트 체크 임시 비활성화
- DEV/PROD 환경의 앱 버전 업데이트 체크 로직 주석 처리
- 항상 needUpdate.send(.none) 방출하도록 변경 (테스트/QA 목적)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
없음

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #842
