### PR TITLE
[Feat] #845 - 콕찌르기 온보딩 추가

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
@@ -29,6 +29,12 @@ extension PokeMainRepository: PokeMainRepositoryInterface {
             .eraseToAnyPublisher()
     }
     
+    public func getIsNewUser() -> AnyPublisher<Bool, Error> {
+        pokeService.isNewUser()
+            .map { $0.isNew }
+            .eraseToAnyPublisher()
+    }
+    
     public func getFriend() -> AnyPublisher<[PokeUserModel], Error> {
         pokeService.getFriend()
             .map { $0.map { $0.toDomain() } }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
@@ -12,4 +12,5 @@ public protocol PokeMainRepositoryInterface: PokeRepositoryInterface {
     func getWhoPokeToMe() -> AnyPublisher<PokeUserModel?, Error>
     func getFriend() -> AnyPublisher<[PokeUserModel], Error>
     func getFriendRandomUser(randomType: String, size: Int) -> AnyPublisher<PokeFriendRandomUserModel, Error>
+    func getIsNewUser() -> AnyPublisher<Bool, Error>
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -11,79 +11,85 @@ import Combine
 import Core
 
 public protocol PokeMainUseCase {
-  var pokedToMeUser: PassthroughSubject<PokeUserModel?, Never> { get }
-  var myFriend: PassthroughSubject<[PokeUserModel], Never> { get }
-  var friendRandomUsers: PassthroughSubject<PokeFriendRandomUserModel, Never> { get }
-  var pokedResponse: PassthroughSubject<PokeUserModel, Never> { get }
-  var madeNewFriend: PassthroughSubject<PokeUserModel, Never> { get }
-  var errorMessage: PassthroughSubject<String?, Never> { get }
-
-  func getWhoPokedToMe()
-  func getFriend()
-  func getFriendRandomUser(randomType: PokeRandomUserType, size: Int)
-  func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool)
+    var pokedToMeUser: PassthroughSubject<PokeUserModel?, Never> { get }
+    var myFriend: PassthroughSubject<[PokeUserModel], Never> { get }
+    var friendRandomUsers: PassthroughSubject<PokeFriendRandomUserModel, Never> { get }
+    var pokedResponse: PassthroughSubject<PokeUserModel, Never> { get }
+    var madeNewFriend: PassthroughSubject<PokeUserModel, Never> { get }
+    var errorMessage: PassthroughSubject<String?, Never> { get }
+    
+    func getWhoPokedToMe()
+    func getFriend()
+    func getFriendRandomUser(randomType: PokeRandomUserType, size: Int)
+    func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool)
+    func getIsNewUser() -> AnyPublisher<Bool, Error>
 }
 
 public class DefaultPokeMainUseCase {
-  public let repository: PokeMainRepositoryInterface
-  public let cancelBag = CancelBag()
-
-  public let pokedToMeUser = PassthroughSubject<PokeUserModel?, Never>()
-  public let myFriend = PassthroughSubject<[PokeUserModel], Never>()
-  public let friendRandomUsers = PassthroughSubject<PokeFriendRandomUserModel, Never>()
-  public let pokedResponse = PassthroughSubject<PokeUserModel, Never>()
-  public let madeNewFriend = PassthroughSubject<PokeUserModel, Never>()
-  public let errorMessage = PassthroughSubject<String?, Never>()
-
-  public init(repository: PokeMainRepositoryInterface) {
-    self.repository = repository
-  }
+    public let repository: PokeMainRepositoryInterface
+    public let cancelBag = CancelBag()
+    
+    public let pokedToMeUser = PassthroughSubject<PokeUserModel?, Never>()
+    public let myFriend = PassthroughSubject<[PokeUserModel], Never>()
+    public let friendRandomUsers = PassthroughSubject<PokeFriendRandomUserModel, Never>()
+    public let pokedResponse = PassthroughSubject<PokeUserModel, Never>()
+    public let madeNewFriend = PassthroughSubject<PokeUserModel, Never>()
+    public let errorMessage = PassthroughSubject<String?, Never>()
+    
+    public init(repository: PokeMainRepositoryInterface) {
+        self.repository = repository
+    }
 }
 
 extension DefaultPokeMainUseCase: PokeMainUseCase {
-  public func getWhoPokedToMe() {
-    repository.getWhoPokeToMe()
-      .catch { _ in
-        Just<PokeUserModel?>(nil)
-      }
-      .withUnretained(self)
-      .sink { event in
-        print("GetPokedToMe State: \(event)")
-      } receiveValue: { owner, pokeUser in
-        owner.pokedToMeUser.send(pokeUser)
-      }.store(in: cancelBag)
-  }
-
-  public func getFriend() {
-    repository.getFriend()
-      .sink { event in
-        print("GetFriend State: \(event)")
-      } receiveValue: { [weak self] friend in
-        self?.myFriend.send(friend)
-      }.store(in: cancelBag)
-  }
-
-  public func getFriendRandomUser(randomType: PokeRandomUserType, size: Int) {
-    repository.getFriendRandomUser(randomType: randomType.rawValue, size: size)
-      .sink { event in
-        print("GetFriendRandomUser State: \(event)")
-      } receiveValue: { [weak self] randomUsers in
-        self?.friendRandomUsers.send(randomUsers)
-      }.store(in: cancelBag)
-  }
-
-  public func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool) {
-    self.repository
-      .poke(userId: userId, message: message.content, isAnonymous: isAnonymous)
-      .catch { [weak self] error in
-        let message = error.toastMessage
-        self?.errorMessage.send(message)
-        return Empty<PokeUserModel, Never>()
-      }.sink { [weak self] user in
-        self?.pokedResponse.send(user)
-        if willBeNewFriend {
-          self?.madeNewFriend.send(user)
-        }
-      }.store(in: self.cancelBag)
-  }
+    public func getIsNewUser() -> AnyPublisher<Bool, Error> {
+        repository.getIsNewUser()
+            .eraseToAnyPublisher()
+    }
+    
+    public func getWhoPokedToMe() {
+        repository.getWhoPokeToMe()
+            .catch { _ in
+                Just<PokeUserModel?>(nil)
+            }
+            .withUnretained(self)
+            .sink { event in
+                print("GetPokedToMe State: \(event)")
+            } receiveValue: { owner, pokeUser in
+                owner.pokedToMeUser.send(pokeUser)
+            }.store(in: cancelBag)
+    }
+    
+    public func getFriend() {
+        repository.getFriend()
+            .sink { event in
+                print("GetFriend State: \(event)")
+            } receiveValue: { [weak self] friend in
+                self?.myFriend.send(friend)
+            }.store(in: cancelBag)
+    }
+    
+    public func getFriendRandomUser(randomType: PokeRandomUserType, size: Int) {
+        repository.getFriendRandomUser(randomType: randomType.rawValue, size: size)
+            .sink { event in
+                print("GetFriendRandomUser State: \(event)")
+            } receiveValue: { [weak self] randomUsers in
+                self?.friendRandomUsers.send(randomUsers)
+            }.store(in: cancelBag)
+    }
+    
+    public func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool) {
+        self.repository
+            .poke(userId: userId, message: message.content, isAnonymous: isAnonymous)
+            .catch { [weak self] error in
+                let message = error.toastMessage
+                self?.errorMessage.send(message)
+                return Empty<PokeUserModel, Never>()
+            }.sink { [weak self] user in
+                self?.pokedResponse.send(user)
+                if willBeNewFriend {
+                    self?.madeNewFriend.send(user)
+                }
+            }.store(in: self.cancelBag)
+    }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -64,9 +64,8 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
         repository.getFriend()
             .sink { [weak self] event in
                 print("GetFriend State: \(event)")
-                if case .failure = event {
-                    self?.myFriend.send([])
-                }
+                // 친구 관계가 없을떄는 서버에서 에러를 응답하기 때문에 빈배열로 값을 방출함
+                if case .failure = event { self?.myFriend.send([])}
             } receiveValue: { [weak self] friend in
                 self?.myFriend.send(friend)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -62,8 +62,11 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
     
     public func getFriend() {
         repository.getFriend()
-            .sink { event in
+            .sink { [weak self] event in
                 print("GetFriend State: \(event)")
+                if case .failure = event {
+                    self?.myFriend.send([])
+                }
             } receiveValue: { [weak self] friend in
                 self?.myFriend.send(friend)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/LegacyPokeFeatureBuildable.swift
@@ -15,7 +15,7 @@ public protocol LegacyPokeFeatureBuildable {
     func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> LegacyPokeMainPresentable
     func makePokeMyFriends(coordinator: Coordinator) -> LegacyPokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> LegacyPokeMyFriendsListPresentable
-    func makePokeOnboarding() -> LegacyPokeOnboardingPresentable
+    func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> LegacyPokeOnboardingPresentable
     func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable
     func makePokeNotificationList(coordinator: Coordinator) -> LegacyPokeNotificationPresentable
     func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -15,7 +15,7 @@ public protocol PokeFeatureBuildable {
     func makePokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeMainPresentable
     func makePokeMyFriends(coordinator: Coordinator) -> PokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
-    func makePokeOnboarding() -> PokeOnboardingPresentable
+    func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> PokeOnboardingPresentable
     func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
     func makePokeNotificationList(coordinator: Coordinator) -> PokeNotificationPresentable
     func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeMainPresentable.swift
@@ -22,6 +22,7 @@ public protocol PokeMainRoutingTrigger {
   var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)? { get set }
   var onNewFriendMade: ((String) -> Void)? { get set }
   var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)? { get set }
+  var onPokeOnboardingNeeded: ((Bool) -> Void)? { get set }
 }
 
 public typealias PokeMainViewModelType = ViewModelType & PokeMainRoutingTrigger

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -38,9 +38,9 @@ extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
         return (pokeMyFriendsVC, viewModel)
     }
     
-    public func makePokeOnboarding() -> PokeFeatureInterface.LegacyPokeOnboardingPresentable {
+    public func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> PokeFeatureInterface.LegacyPokeOnboardingPresentable {
         let usecase = DefaultPokeOnboardingUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeOnboardingViewModel(usecase: usecase)
+        let viewModel = PokeOnboardingViewModel(usecase: usecase, coordinator: coordinator)
         let viewController = PokeOnboardingVC(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeOnboardingCoordinator.swift
@@ -40,7 +40,7 @@ extension LegacyPokeOnboardingCoordinator {
     }
     
     func makePokeOnboardingView() -> LegacyPokeOnboardingPresentable {
-        var pokeOnboarding = self.factory.makePokeOnboarding()
+        var pokeOnboarding = self.factory.makePokeOnboarding(coordinator: self)
         
         pokeOnboarding.vm.onNaviBackTapped = { [weak self] in
             self?.router.dismissModule(animated: true)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -21,9 +21,9 @@ public final class PokeBuilder {
 }
 
 extension PokeBuilder: PokeFeatureBuildable {
-    public func makePokeOnboarding() -> PokeFeatureInterface.PokeOnboardingPresentable {
+    public func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> PokeFeatureInterface.PokeOnboardingPresentable {
         let usecase = DefaultPokeOnboardingUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeOnboardingViewModel(usecase: usecase)
+        let viewModel = PokeOnboardingViewModel(usecase: usecase, coordinator: coordinator)
         let viewController = PokeOnboardingVC(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -61,9 +61,13 @@ public final class PokeCoordinator: BaseCoordinator {
             self.navigationController?.present(newNav, animated: true)
         }
         
+        pokeMain.vm.onPokeOnboardingNeeded = { [weak self] isNeeded in
+            if isNeeded { self?.runPokeOnboardingFlow() }
+        }
+        
         pokeMain.vm.onPokeNotificationsTap = { [weak self] in
             self?.runPokeNotificationListFlow()
-        }
+        }                
         
         pokeMain.vm.onMyFriendsTap = { [weak self] in
             self?.runPokeMyFriendsFlow()
@@ -110,6 +114,17 @@ public final class PokeCoordinator: BaseCoordinator {
         
         addDependency(pokeNotificationListCoordinator)
         pokeNotificationListCoordinator.start()
+    }
+    
+    private func runPokeOnboardingFlow() {
+        guard let navigationController = self.rootController else { return }
+        
+        let pokeOnboardingCoordinator = PokeOnboardingCoordinator(
+            navigationController: navigationController,
+            factory: factory
+        )
+        
+        pokeOnboardingCoordinator.start()
     }
     
     private func runPokeMyFriendsFlow() {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -64,15 +64,15 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
             bottomSheetManager.present(toPresent: viewController, on: self?.rootController)
         }
         
-        pokeOnboarding.vm.onPokeButtonTapped = { [weak self] userModel in
-            guard let bottomSheet = self?.factory
+        pokeOnboarding.vm.onPokeButtonTapped = { [self] userModel in
+            guard let bottomSheet = self.factory
                 .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone)
                     .vc
                     .viewController as? PokeMessageTemplateBottomSheet
             else { return .empty() }
             
             let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
-            bottomSheetManager.present(toPresent: bottomSheet, on: self?.rootController)
+            bottomSheetManager.present(toPresent: bottomSheet, on: self.rootController)
             
             return bottomSheet
                 .signalForClick()

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -51,7 +51,7 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
     }
     
     private func makePokeOnboardingView() -> PokeOnboardingPresentable {
-        var pokeOnboarding = factory.makePokeOnboarding()
+        var pokeOnboarding = factory.makePokeOnboarding(coordinator: self)
         
         pokeOnboarding.vm.onNaviBackTapped = { [weak self] in
             self?.navigationController.dismiss(animated: true)            
@@ -63,15 +63,15 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
             bottomSheetManager.present(toPresent: viewController, on: self?.rootController)
         }
         
-        pokeOnboarding.vm.onPokeButtonTapped = { [self] userModel in
-            guard let bottomSheet = self.factory
+        pokeOnboarding.vm.onPokeButtonTapped = { [weak self] userModel in
+            guard let bottomSheet = self?.factory
                 .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone)
                     .vc
                     .viewController as? PokeMessageTemplateBottomSheet
             else { return .empty() }
             
             let bottomSheetManager = BottomSheetManager(configuration: .messageTemplate(minHeight: PokeMessageTemplateBottomSheet.minimumContentHeight))
-            bottomSheetManager.present(toPresent: bottomSheet, on: self.rootController)
+            bottomSheetManager.present(toPresent: bottomSheet, on: self?.rootController)
             
             return bottomSheet
                 .signalForClick()

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -54,8 +54,7 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
         var pokeOnboarding = factory.makePokeOnboarding()
         
         pokeOnboarding.vm.onNaviBackTapped = { [weak self] in
-            self?.navigationController.dismiss(animated: true)
-            self?.finishFlow?()
+            self?.navigationController.dismiss(animated: true)            
         }
         
         pokeOnboarding.vm.onFirstVisitInOnboarding = { [weak self] in

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -28,7 +28,6 @@ public class PokeMainViewModel: PokeMainViewModelType {
     public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
     public var onNewFriendMade: ((String) -> Void)?
     public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
-    public var viewDidLoad: (() -> Void)?
     public var onPokeOnboardingNeeded: ((Bool) -> Void)?
     
     // MARK: - Properties

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -28,10 +28,12 @@ public class PokeMainViewModel: PokeMainViewModelType {
     public var onPokeButtonTapped: ((PokeUserModel) -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)>)?
     public var onNewFriendMade: ((String) -> Void)?
     public var onAnonymousFriendUpgrade: ((PokeUserModel) -> Void)?
+    public var viewDidLoad: (() -> Void)?
+    public var onPokeOnboardingNeeded: ((Bool) -> Void)?
     
     // MARK: - Properties
     
-    private let useCase: PokeMainUseCase
+    private let useCase: PokeMainUseCase 
     private let isRouteFromRoot: Bool
     private var cancelBag = CancelBag()
     private let eventTracker = PokeEventTracker()
@@ -158,6 +160,13 @@ extension PokeMainViewModel {
     }
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
+        useCase.getIsNewUser()
+            .sink { _ in}
+            receiveValue: { [weak self] isNewUser in
+                self?.onPokeOnboardingNeeded?(isNewUser)
+            }
+            .store(in: cancelBag)
+        
         useCase.pokedToMeUser
             .compactMap { $0 }
             .sink { output.pokedToMeUser.send($0) }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
@@ -262,7 +262,7 @@ extension PokeOnboardingVC: UICollectionViewDataSource {
         
         cell.signalForPokeButtonClick()
             .withUnretained(self)
-            .sink(receiveValue: { owner, userModel in
+            .sink(receiveValue: { owner, userModel in                
                 owner.pokeButtonTapped.send(userModel)
             }).store(in: cell.cancelBag)
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
@@ -37,11 +37,13 @@ public final class PokeOnboardingViewModel: PokeOnboardingViewModelType {
     // MARK: Privates
     private let usecase: PokeOnboardingUsecase
     private let eventTracker = PokeEventTracker()
+    private let coordinator: AnyCoordinatorObject 
     
     
     // MARK: - Lifecycles
-    public init(usecase: PokeOnboardingUsecase) {
+    public init(usecase: PokeOnboardingUsecase, coordinator: AnyCoordinatorObject) {
         self.usecase = usecase
+        self.coordinator = coordinator
     }
 }
 
@@ -70,7 +72,6 @@ extension PokeOnboardingViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onNaviBackTapped?()
-                owner.onPokeButtonTapped = nil
             }.store(in: cancelBag)
         
         input.pokeButtonTapped

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/ViewModel/PokeOnboardingViewModel.swift
@@ -70,12 +70,13 @@ extension PokeOnboardingViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onNaviBackTapped?()
+                owner.onPokeButtonTapped = nil
             }.store(in: cancelBag)
         
         input.pokeButtonTapped
             .flatMap { [weak self] userModel -> Driver<(PokeUserModel, PokeMessageModel, isAnonymous: Bool)> in
-                guard let self, let value = self.onPokeButtonTapped?(userModel) else { return .empty() }
                 
+                guard let self, let value = self.onPokeButtonTapped?(userModel) else {return .empty() }
                 return value
             }
             .sink(receiveValue: { [weak self] userModel, messageModel, isAnonymous in


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/ #845 

## 🌱 PR Point
- PokeMainViewModel에서 getIsNewUser() 결과를 onPokeOnboardingNeeded 트리거로 전달
- PokeCoordinator에서 onPokeOnboardingNeeded 로 전달받은 플래그에 따라서 runPokeOnboardingFlow 호출 여부 결정

## 📌 참고 사항
우선... 기존 레거시보다 더 레거시 방식으로 구현을 하게되었습니다. 이전에 홈에서 온보딩을 시작하는 히스토리는 파악이 되었는데 QA 일정까지 다시 구조를 개선하기에는 시간이 부족하다고 판단해서 우선 PokeCoordinator를 start하고 그위에 PokeOnboardingCoordinator를 start하는 방식으로 구현을 하게되었습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #845 
