### PR TITLE
[Fix] #856 - 솝탬프 파트별 랭킹 응답 API 수정 대응

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Transform/PartRankingTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PartRankingTransform.swift
@@ -14,7 +14,7 @@ import Networks
 
 extension PartRankingEntity {
   public func toDomain() -> PartRankingModel {
-    return .init(part: part, rank: rank, points: points)
+    return .init(part: part, rank: rank, points: points, pointsDecimal: pointsDecimal)
   }
 }
 

--- a/SOPT-iOS/Projects/Domain/Sources/Model/PartRankingModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/PartRankingModel.swift
@@ -9,21 +9,23 @@
 import Foundation
 
 public struct PartRankingModel: Hashable {
-  public let part: String
-  public let rank: Int
-  public let points: Int
-
-  public init(part: String, rank: Int, points: Int) {
-    self.part = part
-    self.rank = rank
-    self.points = points
-  }
+    public let part: String
+    public let rank: Int
+    public let points: Int
+    public let pointsDecimal: Double
+    
+    public init(part: String, rank: Int, points: Int, pointsDecimal: Double) {
+        self.part = part
+        self.rank = rank
+        self.points = points
+        self.pointsDecimal = pointsDecimal
+    }
 }
 
 public struct PartRankingChartModel: Hashable {
-  public let ranking: [PartRankingModel]
-  
-  public init(ranking: [PartRankingModel]) {
-    self.ranking = ranking
-  }
+    public let ranking: [PartRankingModel]
+    
+    public init(ranking: [PartRankingModel]) {
+        self.ranking = ranking
+    }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingListCVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/RankingScene/Cells/PartRanking/PartRankingListCVC.swift
@@ -99,8 +99,8 @@ extension PartRankingListCVC {
     public func setData(model: PartRankingModel) {
         self.model = model
         rankLabel.text = String(model.rank)
-        partNameLabel.text = model.part
-        scoreLabel.text = "\(model.points)점"
+        partNameLabel.text = model.part        
+        scoreLabel.text = "\(String(format: "%.2f", model.pointsDecimal))점"
         scoreLabel.partFontChange(targetString: "점",
                                   font: DSKitFontFamily.Pretendard.medium.font(size: 12))
         setDefaultRanking()

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PartRankingEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/PartRankingEntity.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 public struct PartRankingEntity: Decodable {
-  public let part: String
-  public let rank: Int
-  public let points: Int
+    public let part: String
+    public let rank: Int
+    public let points: Int
+    public let pointsDecimal: Double
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#856

## 🌱 PR Point
서버에서 파트별 랭킹을 파트원 수를 고려하도록 로직이 수정되었습니다 그에따라 기존 정수로 내려주던 points 필드를 제거하고
실수 형태인 pointsDecimal 필드를 추가하고 리스트에서도 pointsDecimal 필드를 사용하도록 수정했습니다.

```
    public let part: String
    public let rank: Int
    public let points: Int
    public let pointsDecimal: Double // 추가
```

```
extension PartRankingListCVC {
    
    public func setData(model: PartRankingModel) {
        self.model = model
        rankLabel.text = String(model.rank)
        partNameLabel.text = model.part
        scoreLabel.text = "\(String(format: "%.2f", model.pointsDecimal))점" // 2자릿수까지 보여주도록 수정
        scoreLabel.partFontChange(targetString: "점",
                                  font: DSKitFontFamily.Pretendard.medium.font(size: 12))
        setDefaultRanking()
    }
```
## 📌 참고 사항
dev에서는 여전히 서버에서 points를 동일하게 내려주긴 하는데
points 필드는 사용하지 않을 것 같은데 미리 제거하는게 좋을까요?

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|<img width="300" alt="simulator_screenshot_017246A4-2182-40BB-8C02-CF65F6F63C5F" src="https://github.com/user-attachments/assets/1e9d6408-ce04-4f2b-803a-6c4e46fe1532" />|


## 📮 관련 이슈
- Resolved: #856 
