### PR TITLE
[Fix] #855 - 콕찌르기 온보딩 진입 조건 수정

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/UserDefaultKeyLIst.swift
@@ -30,6 +30,7 @@ public struct UserDefaultKeyList {
         @UserDefaultWrapper<String>(key: "soptampName") public static var soptampName
         @UserDefaultWrapper<String>(key: "pushToken") public static var pushToken
         @UserDefaultWrapper<Bool>(key: "isFirstVisitToPokeView") public static var isFirstVisitToPokeOnboardingView
+        @UserDefaultWrapper<Bool>(key: "isVisitedPokeMainView") public static var isVisitedPokeMainView
     }
     
     public struct AppNotice {

--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -63,12 +63,6 @@ extension HomeRepository: HomeRepositoryInterface {
             .eraseToAnyPublisher()
     }
     
-    public func checkPokeNewUser() -> AnyPublisher<Bool, any Error> {
-        pokeService.isNewUser()
-            .map{ $0.isNew }
-            .eraseToAnyPublisher()
-    }
-    
     public func getFloatingButtonInfo() -> AnyPublisher<HomeFloatingButtonModel, any Error> {
         homeService.getFloatingButtonInfo()
             .map{ $0.toDomain() }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/PokeMainRepository.swift
@@ -29,12 +29,6 @@ extension PokeMainRepository: PokeMainRepositoryInterface {
             .eraseToAnyPublisher()
     }
     
-    public func getIsNewUser() -> AnyPublisher<Bool, Error> {
-        pokeService.isNewUser()
-            .map { $0.isNew }
-            .eraseToAnyPublisher()
-    }
-    
     public func getFriend() -> AnyPublisher<[PokeUserModel], Error> {
         pokeService.getFriend()
             .map { $0.map { $0.toDomain() } }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -14,8 +14,7 @@ public protocol HomeRepositoryInterface {
     func registerPushToken(with token: String) -> AnyPublisher<Bool, Error>
     func getAppServices() -> AnyPublisher<[HomeAppServicesModel], Error>
     func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], Error>
-    func getReportUrl() -> AnyPublisher<SoptampReportUrlModel, Error>
-    func checkPokeNewUser() -> AnyPublisher<Bool, Error>
+    func getReportUrl() -> AnyPublisher<SoptampReportUrlModel, Error>    
     func getFloatingButtonInfo() -> AnyPublisher<HomeFloatingButtonModel, Error>
     
     /// async

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/PokeMainRepositoryInterface.swift
@@ -11,6 +11,5 @@ import Combine
 public protocol PokeMainRepositoryInterface: PokeRepositoryInterface {
     func getWhoPokeToMe() -> AnyPublisher<PokeUserModel?, Error>
     func getFriend() -> AnyPublisher<[PokeUserModel], Error>
-    func getFriendRandomUser(randomType: String, size: Int) -> AnyPublisher<PokeFriendRandomUserModel, Error>
-    func getIsNewUser() -> AnyPublisher<Bool, Error>
+    func getFriendRandomUser(randomType: String, size: Int) -> AnyPublisher<PokeFriendRandomUserModel, Error>    
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/HomeUseCase.swift
@@ -15,7 +15,6 @@ public protocol HomeUseCase {
     func getAppServices() -> AnyPublisher<[HomeAppServicesModel], Never>
     func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], Never>
     func getReportURL()
-    func checkPokeNewUser() -> AnyPublisher<Bool, Never>
     func getFloatingButtonInfo() -> AnyPublisher<HomeFloatingButtonModel, Never>
     
     func getHomeDescriptionAsync() async throws -> HomeDescriptionModel
@@ -85,15 +84,6 @@ extension DefaultHomeUseCase: HomeUseCase {
             } receiveValue: { owner, resultModel in
                 UserDefaultKeyList.Soptamp.reportUrl = resultModel.reportUrl
             }.store(in: cancelBag)
-    }
-    
-    public func checkPokeNewUser() -> AnyPublisher<Bool, Never> {
-        repository.checkPokeNewUser()
-            .catch { error in
-                print("HomeUseCase checkPokeNewUser에서 문제가 발생했습니다. \(error)")
-                return Empty<Bool, Never>()
-            }
-            .eraseToAnyPublisher()
     }
     
     public func getFloatingButtonInfo() -> AnyPublisher<HomeFloatingButtonModel, Never> {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -21,8 +21,7 @@ public protocol PokeMainUseCase {
     func getWhoPokedToMe()
     func getFriend()
     func getFriendRandomUser(randomType: PokeRandomUserType, size: Int)
-    func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool)
-    func getIsNewUser() -> AnyPublisher<Bool, Error>
+    func poke(userId: Int, message: PokeMessageModel, isAnonymous: Bool, willBeNewFriend: Bool)    
 }
 
 public class DefaultPokeMainUseCase {
@@ -42,10 +41,6 @@ public class DefaultPokeMainUseCase {
 }
 
 extension DefaultPokeMainUseCase: PokeMainUseCase {
-    public func getIsNewUser() -> AnyPublisher<Bool, Error> {
-        repository.getIsNewUser()
-            .eraseToAnyPublisher()
-    }
     
     public func getWhoPokedToMe() {
         repository.getWhoPokeToMe()

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -134,17 +134,7 @@ extension HomeForMemberViewModel {
                     AmplitudeInstance.shared.trackWithUserType(event: .clickAllCalendar)
                 case .productService(let model):
                     owner.onMainProductCellTapped?(model.product.serviceDomainLink)
-                    owner.eventTracker.trackAmplitude(event: model.product.toAmplitudeEventType)                
-                    
-                    #warning("코드리뷰 후 삭제 or 수정 예정")
-//                    if model.serviceName == "콕찌르기" {
-//                        owner.useCase.checkPokeNewUser()
-//                            .sink { isPokeNewUser in
-//                                owner.onPoke?(isPokeNewUser)
-//                            }.store(in: cancelBag)
-//                    } else {
-//                        owner.onAppServiceCellTapped?(model.deepLink)
-//                    }
+                    owner.eventTracker.trackAmplitude(event: model.product.toAmplitudeEventType)
                 case .socialLink(let type):
                     owner.onSocialLinkButtonTapped?(type.socialLink.serviceDomainLink)
                 case .popularPost(let model):
@@ -244,6 +234,7 @@ extension HomeForMemberViewModel {
                 owner.isFABTapped.toggle()
             }
             .store(in: cancelBag)
+        
 
         input.isMenuCellTapped
             .withUnretained(self)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -87,6 +87,13 @@ extension PokeMainViewModel {
             }.store(in: cancelBag)
         
         input.viewDidLoad
+            .map { _ in UserDefaultKeyList.User.isVisitedPokeMainView ?? false }
+            .sink { [weak self] isVisitedPokeMainView in
+                self?.onPokeOnboardingNeeded?(!isVisitedPokeMainView)
+            }
+            .store(in: cancelBag)
+        
+        input.viewDidLoad
             .sink { [weak self] _ in
                 self?.eventTracker.trackViewEvent(with: .viewPokeMain)
             }.store(in: cancelBag)
@@ -159,12 +166,6 @@ extension PokeMainViewModel {
     }
     
     private func bindOutput(output: Output, cancelBag: CancelBag) {
-        useCase.getIsNewUser()
-            .sink { _ in}
-            receiveValue: { [weak self] isNewUser in
-                self?.onPokeOnboardingNeeded?(isNewUser)
-            }
-            .store(in: cancelBag)
         
         useCase.pokedToMeUser
             .compactMap { $0 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -88,8 +88,9 @@ extension PokeMainViewModel {
         
         input.viewDidLoad
             .map { _ in UserDefaultKeyList.User.isVisitedPokeMainView ?? false }
-            .sink { [weak self] isVisitedPokeMainView in
-                self?.onPokeOnboardingNeeded?(!isVisitedPokeMainView)
+            .withUnretained(self)
+            .sink { owner, isVisitedPokeMainView in
+                owner.onPokeOnboardingNeeded?(!isVisitedPokeMainView)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
@@ -146,7 +146,6 @@ extension PokeOnboardingVC {
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         UserDefaultKeyList.User.isVisitedPokeMainView = true
-        UserDefaults.standard.synchronize()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
@@ -146,6 +146,7 @@ extension PokeOnboardingVC {
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         UserDefaultKeyList.User.isVisitedPokeMainView = true
+        UserDefaults.standard.synchronize()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeOnboardingScene/VC/PokeOnboardingVC.swift
@@ -142,6 +142,11 @@ extension PokeOnboardingVC {
         
         scrollView.contentSize = self.scrollContainerView.frame.size
     }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        UserDefaultKeyList.User.isVisitedPokeMainView = true
+    }
 }
 
 // MARK: - Configuring methods


### PR DESCRIPTION
## 🌴 PR 요약
아래의 내용대로 콕찌르기 온보딩 진입 조건 여부를 수정했습니다. 

기존: 온보딩 뷰에서 사용자가 콕 찌른 사람이 맞콕찔러줘야 메인 화면에 진입 가능
변경: 사용자가 콕찌르기 온보딩 뷰에 최초 진입 > 사용자가 온보딩 뷰를 이탈하고 이후 다시 콕찌르기 화면에 진입 > 온보딩 뷰에서의 콕찌르기 진행 여부에 상관없이 사용자는 바로 메인 화면 진입 가능

🌱 작업한 브랜치
- feature/#855

## 🌱 PR Point
### 콕찌르기 온보딩 진입 조건 수정
PokeMainVC 진입 시 UserDefaults에 저장된 콕찌르기 메인뷰 진입 여부(isVisitedPokeMainView)에 따라서
온보딩 노출 여부를 결정하도록 구현했습니다.

```swift
        input.viewDidLoad
            .map { _ in UserDefaultKeyList.User.isVisitedPokeMainView ?? false }
            .sink { [weak self] isVisitedPokeMainView in
                self?.onPokeOnboardingNeeded?(!isVisitedPokeMainView)
            }
            .store(in: cancelBag)
```

온보딩(PokeOnboardingVC)이 종료되는 시점(viewDidDisappear)에
isVisitedPokeMainView 값을 true로 업데이트하고 이후 재진입 시 온보딩이 다시 노출되지 않도록 처리했습니다.

- PokeOnboardingVC가 해제되는 시점에 ViewModel도 같이 해제되기 떄문에 viewDidDisappear 트리거를 감지할 수 없어서 뷰컨의 viewDidDisappear 에서 플래그를 수정했습니다.

```swift
    public override func viewDidDisappear(_ animated: Bool) {
        super.viewDidDisappear(animated)
        UserDefaultKeyList.User.isVisitedPokeMainView = true
        UserDefaults.standard.synchronize()
    }
```
## 📌 참고 사항
UserDefaults 쓰기 작업중 앱이 꺼지는 경우 저장이 안되는 문제가 있는데 해당 이슈에 대해서 아시는분이 계실까요?

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #855 
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 