### PR TITLE
[Hotfix] #865 - 익명 콕찌르기 시 프로필 이미지 노출 버그 수정

### DIFF
--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
@@ -161,8 +161,8 @@ extension PokeNotificationListContentView {
     self.user = model
     self.userId = model.userId
     self.profileImageView.setImage(
-        with: model.isAnonymous ? DSKitAsset.Assets.icPokeDefaultProfile.image.className : model.profileImage,
-      relation: PokeRelation(rawValue: model.relationName) ?? .nonFriend
+        with: model.isAnonymous ? "" : model.profileImage,
+        relation: PokeRelation(rawValue: model.relationName) ?? .nonFriend
     )
     self.partInfoLabel.text = "\(model.generation)기 \(model.part)"
     self.descriptionLabel.attributedText = model.message.applyMDSFont()

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileCardView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileCardView.swift
@@ -119,8 +119,11 @@ public final class PokeProfileCardView: UIView, PokeCompatible {
 
     func setData(with model: PokeUserModel) {
         self.user = model
-        self.profileImageView.setImage(with: model.profileImage, placeholder: DSKitAsset.Assets.icPokeDefaultProfile.image)
-        self.nameLabel.text = model.name
+        self.profileImageView.setImage(
+            with: model.isAnonymous ? "" : model.profileImage,
+            placeholder: DSKitAsset.Assets.icDefaultProfile.image
+        )
+        self.nameLabel.text = model.isAnonymous ? model.anonymousName : model.name
         self.partLabel.text = String(describing: model.generation) + "기" + " " + model.part
         self.kokButton.isEnabled = !model.isAlreadyPoke
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
@@ -182,7 +182,7 @@ public final class PokeProfileListView: UIView, PokeCompatible {
     func setData(with model: PokeUserModel) {
         self.user = model
         self.profileImageView.setImage(
-            with: model.profileImage,
+            with: model.isAnonymous ? "" : model.profileImage,
             relation: model.pokeRelation
         )
         self.partLabel.text = "\(model.generation)기 \(model.part)"


### PR DESCRIPTION
## 🌴 PR 요약
익명으로 콕찌르기를 했을 때 상대방에게 찌른 사람의 실제 프로필 이미지가 노출되는 버그 수정

🌱 작업한 브랜치
- feature/#87

## 🌱 PR Point
### 1) PokeProfileListView — 익명 분기 자체가 삭제됨
- #848에서 `anonymousImage` 필드 제거 시 삼항 연산자 전체가 삭제되어, `isAnonymous` 여부와 관계없이 항상 실제 프로필 이미지가 표시됨
- `PokeProfileListView`: `isAnonymous` 삼항 분기 복구하여 해결


 ### 2) PokeNotificationListContentView — 잘못된 대체값 사용
- `model.anonymousImage` 제거 후 `DSKitAsset.Assets.icPokeDefaultProfile.image.className`으로 대체했으나, `.className`은 UIImage의 클래스명 문자열("UIImage")을 반환하므로 익명 분기가 사실상 무효화됨
- `PokeNotificationListContentView`: `.className` → 빈 문자열로 변경하여 `setImage` 내 `isEmpty` 분기에서
`icPokeDefaultProfile` placeholder가 표시되도록 수정


### 이미지 정리
| 영역 | 사용 컴포넌트 | 이미지 노출 방식 |
| :--: | :--: | :--: |
| 누가 나를 찔렀어요 | `PokeNotificationListContentView` | `isAnonymous`일 때 빈 문자열 전달 →  `icPokeDefaultProfile` |
| 내 친구를 찔러보세요 | `PokeProfileListView` | isAnonymous` 삼항 분기 복구 → `icPokeDefaultProfile` 표시 |
| 나와 공통점이 있는 친구들을 찔러보세요' | `PokeProfileCardView` | `isAnonymous`일 때 `icDefaultProfile` 표시 및 `anonymousName` 처리 추가 |

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|익명의 경우 기본 프로필 노출|<img width="375" alt="image" src="https://github.com/user-attachments/assets/710400b7-970b-48ae-8939-2ff3bfdfbf92" />|
| 섹션 별 디폴트 이미지 수정 | <img width="375" alt="image" src="https://github.com/user-attachments/assets/88cf9d71-22e8-4746-accd-b58a469146fe" /> |

## 📮 관련 이슈
- Resolved: #865
