### PR TITLE
[Refactor] #870 - Poke/Soptamp 탭바 단일 진입으로 ApplicationCoordinator Flow 정리

### DIFF
--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeCoordinatorDestination.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeCoordinatorDestination.swift
@@ -17,8 +17,7 @@ public enum HomeCoordinatorDestination {
     case attendance
     case soptlog
     case calendar
-    case poke(isNewUser: Bool)
-    
+
     case webLink(url: String)
     case deepLink(url: String)
 }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Interface/Sources/HomeForMemberPresentable.swift
@@ -21,7 +21,6 @@ public protocol HomeForMemberCoordinatable {
     var onSettingButtonTapped: ((UserType) -> Void)? { get set }
     var onNeedSignIn: (@MainActor () -> Void)? { get set }
     var onNetworkError: (@MainActor () -> Void)? { get set }
-    var onPoke: ((_ isNewUser: Bool) -> Void)? { get set }
     var onExtendedFloatingButtonTapped: ((String) -> Void)? { get set }
     var onSurveyButtonTapped: ((String) -> Void)? { get set }
     var onSocialLinkButtonTapped: ((String) -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/HomeCoordinator.swift
@@ -99,11 +99,6 @@ public final class HomeCoordinator: BaseCoordinator {
             AlertUtils.presentNetworkAlertVC()
         }
         
-        homeForMember.vm.onPoke = { [weak self] isNewUser in
-            guard let self else { return }
-            self.delegate?.homeCoordinator(self, to: .poke(isNewUser: isNewUser))
-        }
-        
         homeForMember.vm.onExtendedFloatingButtonTapped = { [weak self] url in
             guard let self else { return }
             self.delegate?.homeCoordinator(self, to: .deepLink(url: url))

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/Coordinator/LegacyHomeCoordinator.swift
@@ -82,10 +82,6 @@ public final class LegacyHomeCoordinator: DefaultHomeCoordinator {
             AlertUtils.presentNetworkAlertVC()
         }
         
-        homeForMember.vm.onPoke = { [weak self] isNewUser in
-            self?.requestCoordinating?(.poke(isNewUser: isNewUser))
-        }
-        
         homeForMember.vm.onExtendedFloatingButtonTapped = { [weak self] url in
             self?.requestCoordinating?(.deepLink(url: url))
         }

--- a/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
+++ b/SOPT-iOS/Projects/Features/HomeFeature/Sources/HomeScene/ViewModel/HomeForMemberViewModel.swift
@@ -82,7 +82,6 @@ public class HomeForMemberViewModel: HomeForMemberViewModelType {
     public var onSettingButtonTapped: ((UserType) -> Void)?
     public var onNeedSignIn: (@MainActor () -> Void)?
     public var onNetworkError: (@MainActor () -> Void)?
-    public var onPoke: ((Bool) -> Void)?
     public var onExtendedFloatingButtonTapped: ((String) -> Void)?
     public var onSurveyButtonTapped: ((String) -> Void)?
     public var onSocialLinkButtonTapped: ((String) -> Void)?

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -12,7 +12,7 @@ import Domain
 import BaseFeatureDependency
 
 public protocol PokeFeatureBuildable {
-    func makePokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeMainPresentable
+    func makePokeMain(isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeMainPresentable
     func makePokeMyFriends(coordinator: Coordinator) -> PokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
     func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> PokeOnboardingPresentable

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -23,9 +23,7 @@ public final class LegacyPokeBuilder {
 extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
     public func makePokeMain(isRouteFromRoot: Bool, coordinator: Coordinator) -> PokeFeatureInterface.LegacyPokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
-        let viewModel = PokeMainViewModel(useCase: useCase,
-                                          coordinator: coordinator,
-                                          isRouteFromRoot: isRouteFromRoot)
+        let viewModel = PokeMainViewModel(useCase: useCase, coordinator: coordinator)
         let pokeMainVC = PokeMainVC(viewModel: viewModel, isRouteFromTabBar: true)
         return (pokeMainVC, viewModel)
     }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -29,11 +29,9 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (viewController, viewModel)
     }
     
-    public func makePokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeFeatureInterface.PokeMainPresentable {
+    public func makePokeMain(isRouteFromTabBar: Bool, coordinator: Coordinator) -> PokeFeatureInterface.PokeMainPresentable {
         let useCase = DefaultPokeMainUseCase(repository: pokeMainRepository)
-        let viewModel = PokeMainViewModel(useCase: useCase,
-                                          coordinator: coordinator,
-                                          isRouteFromRoot: isRouteFromRoot)
+        let viewModel = PokeMainViewModel(useCase: useCase, coordinator: coordinator)
         let pokeMainVC = PokeMainVC(viewModel: viewModel, isRouteFromTabBar: isRouteFromTabBar)
         
         return (pokeMainVC, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -35,11 +35,12 @@ public final class PokeCoordinator: BaseCoordinator {
     
     // MARK: - Coordinator Life Cycle
 
-    public func start(isRouteFromTabBar: Bool = false) {
+    public func start(isRouteFromTabBar: Bool = true) {
         showPokeMain(isRouteFromRoot: false, isRouteFromTabBar: isRouteFromTabBar)
     }
+
     public override func start() {
-        start(isRouteFromTabBar: false)
+        start(isRouteFromTabBar: true)
     }
     
     // MARK: - Navigation

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -36,7 +36,7 @@ public final class PokeCoordinator: BaseCoordinator {
     // MARK: - Coordinator Life Cycle
 
     public func start(isRouteFromTabBar: Bool = true) {
-        showPokeMain(isRouteFromRoot: false, isRouteFromTabBar: isRouteFromTabBar)
+        showPokeMain(isRouteFromTabBar: isRouteFromTabBar)
     }
 
     public override func start() {
@@ -45,8 +45,8 @@ public final class PokeCoordinator: BaseCoordinator {
     
     // MARK: - Navigation
 
-    public func showPokeMain(isRouteFromRoot: Bool, isRouteFromTabBar: Bool) {
-        var pokeMain = factory.makePokeMain(isRouteFromRoot: isRouteFromRoot, isRouteFromTabBar: isRouteFromTabBar,  coordinator: self)
+    public func showPokeMain(isRouteFromTabBar: Bool) {
+        var pokeMain = factory.makePokeMain(isRouteFromTabBar: isRouteFromTabBar, coordinator: self)
         
         if isRouteFromTabBar {
             self.rootController = self.navigationController

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -33,7 +33,6 @@ public class PokeMainViewModel: PokeMainViewModelType {
     // MARK: - Properties
     
     private let useCase: PokeMainUseCase 
-    private let isRouteFromRoot: Bool
     private var cancelBag = CancelBag()
     private let eventTracker = PokeEventTracker()
     private let coordinator: AnyCoordinatorObject           /// Coordinator 프로토콜이 레거시에서만 사용되기 때문
@@ -67,10 +66,9 @@ public class PokeMainViewModel: PokeMainViewModelType {
     
     // MARK: - initialization
     // TODO: - Coordinator를 AnyCoordinatorObject로 변경
-    public init(useCase: PokeMainUseCase, coordinator: Coordinator, isRouteFromRoot: Bool = false) {
+    public init(useCase: PokeMainUseCase, coordinator: Coordinator) {
         self.useCase = useCase
         self.coordinator = coordinator
-        self.isRouteFromRoot = isRouteFromRoot
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -75,8 +75,8 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
             handleWebLink(webLink: url)
         case .calendar:
             showHomeCalendarDetail()
-        case .poke(let isNewUser):
-            _ = isNewUser ? runPokeOnboardingFlow() : runPokeFlow()
+        case .poke:
+            selectedTab(.poke)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -75,8 +75,6 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
             handleWebLink(webLink: url)
         case .calendar:
             showHomeCalendarDetail()
-        case .poke:
-            selectedTab(.poke)
         }
     }
 }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -579,7 +579,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runStampFlow() -> BaseCoordinator {
+    internal func runStampFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
         var coordinator: BaseCoordinator
 
         switch Config.coordinatorFlag {
@@ -604,7 +604,7 @@ extension ApplicationCoordinator {
                 factory: StampBuilder(),
                 mypageFactory: MyPageBuilder()
             )
-            newCoordinator.start(isRouteFromTabBar: true)
+            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
             coordinator = newCoordinator
         }
 
@@ -616,7 +616,7 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runPokeFlow() -> BaseCoordinator {
+    internal func runPokeFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
         var coordinator: BaseCoordinator
 
         switch Config.coordinatorFlag {
@@ -639,7 +639,7 @@ extension ApplicationCoordinator {
                 navigationController: pokeNavigationController,
                 factory: PokeBuilder()
             )
-            newCoordinator.start(isRouteFromTabBar: true)
+            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
             coordinator = newCoordinator
         }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -482,8 +482,6 @@ extension ApplicationCoordinator {
                     self?.handleWebLink(webLink: url)
                 case .calendar:
                     self?.showHomeCalendarDetail()
-                case .poke(let isNewUser):
-                    _ = isNewUser ? self?.runPokeOnboardingFlow() : self?.runPokeFlow()
                 }
             }
             addDependency(legacyCoordinator)

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -411,8 +411,8 @@ extension ApplicationCoordinator {
         var viewControllers: [UINavigationController] = []
 
         runHomeFlow(type: userType)
-        runStampTabFlow()
-        runPokeTabFlow()
+        runStampFlow()
+        runPokeFlow()
         
         switch userType {
         case .active, .inactive:
@@ -579,9 +579,9 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runStampFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
+    internal func runStampFlow() -> BaseCoordinator {
         var coordinator: BaseCoordinator
-        
+
         switch Config.coordinatorFlag {
         case .legacy:
             let legacyStampCoordinator = LegacyStampCoordinator(
@@ -597,14 +597,14 @@ extension ApplicationCoordinator {
             addDependency(legacyStampCoordinator)
             coordinator = legacyStampCoordinator
             coordinator.start()
-            
+
         case .new:
             let newCoordinator = StampCoordinator(
-                navigationController: UIWindow.getRootNavigationController,
+                navigationController: stampNavigationController,
                 factory: StampBuilder(),
                 mypageFactory: MyPageBuilder()
             )
-            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
+            newCoordinator.start(isRouteFromTabBar: true)
             coordinator = newCoordinator
         }
 
@@ -616,33 +616,33 @@ extension ApplicationCoordinator {
 
 extension ApplicationCoordinator {
     @discardableResult
-    internal func runPokeFlow(isRouteFromTabBar: Bool = true) -> BaseCoordinator {
+    internal func runPokeFlow() -> BaseCoordinator {
         var coordinator: BaseCoordinator
-        
+
         switch Config.coordinatorFlag {
         case .legacy:
             let legacyPokeCoordinator = LegacyPokeCoordinator(
                 router: LegacyRouter(rootController: UIWindow.getRootNavigationController),
                 factory: LegacyPokeBuilder()
             )
-            
+
             legacyPokeCoordinator.finishFlow = { [weak self, weak legacyPokeCoordinator] in
                 legacyPokeCoordinator?.childCoordinators = []
                 self?.removeDependency(legacyPokeCoordinator)
             }
             coordinator = legacyPokeCoordinator
             addDependency(coordinator)
-            
+
             coordinator.start()
         case .new:
             let newCoordinator = PokeCoordinator(
-                navigationController: UIWindow.getRootNavigationController,
+                navigationController: pokeNavigationController,
                 factory: PokeBuilder()
             )
-            newCoordinator.start(isRouteFromTabBar: isRouteFromTabBar)
+            newCoordinator.start(isRouteFromTabBar: true)
             coordinator = newCoordinator
         }
-    
+
         return coordinator
     }
     
@@ -898,32 +898,9 @@ extension ApplicationCoordinator {
     }
 }
 
-// MARK: - StampTabFlow
-
-#warning("TODO: 앱 서비스를 탭바로만 이동하는 것이 확정될 경우, 기존 메소드(runStampFlow, runPokeFlow)의 navigationController만 변경하고, runStampTabFlow/runPokeTabFlow 메소드들은 제거합니다.")
-extension ApplicationCoordinator {
-    internal func runStampTabFlow() {
-        let coordinator = StampCoordinator(
-            navigationController: stampNavigationController,
-            factory: StampBuilder(),
-            mypageFactory: MyPageBuilder()
-        )
-        coordinator.start(isRouteFromTabBar: true)
-    }
-}
-
 // MARK: - PokeTabFlow
 
 extension ApplicationCoordinator {
-    internal func runPokeTabFlow() {
-        let coordinator = PokeCoordinator(
-            navigationController: pokeNavigationController,
-            factory: PokeBuilder()
-        )
-        
-        coordinator.start(isRouteFromTabBar: true)
-    }
-    
     internal func runPokeMyFriendsFlow(relation: PokeRelation) {
         self.pokeNavigationController.popToRootViewController(animated: false)
         

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampCoordinator.swift
@@ -39,12 +39,12 @@ public final class StampCoordinator: BaseCoordinator {
 
     // MARK: - Coordinator Life Cycle
 
-    public func start(isRouteFromTabBar: Bool = false) {
+    public func start(isRouteFromTabBar: Bool = true) {
         showMissionList(sceneType: .default, isRouteFromTabBar: isRouteFromTabBar)
     }
 
     public override func start() {
-        start(isRouteFromTabBar: false)
+        start(isRouteFromTabBar: true)
     }
 
     // MARK: - Navigation


### PR DESCRIPTION
## 🌴 PR 요약
`Poke`와 `Soptamp`의 진입 경로가 탭바로 확정됨에 따라, 과도기에 추가된 별도 TabFlow 메서드와 관련된 더 이상 사용되지 않는 코드를 정리합니다.

🌱 작업한 브랜치
- feature/#870

## 🌱 PR Point
### Flow 통합
| 기존 | 변경 후 | 비고 |
|---|---|---|
| `runStampTabFlow()` | 제거 | `runStampFlow()`로 통합 |
| `runPokeTabFlow()` | 제거 | `runPokeFlow()`로 통합 |
| `runStampFlow(navigationController: UIWindow.getRootNavigationController)` | `runStampFlow(navigationController: stampNavigationController)` | 탭 전용 컨트롤러로 교체 |
| `runPokeFlow(navigationController: UIWindow.getRootNavigationController)` | `runPokeFlow(navigationController: pokeNavigationController)` | 탭 전용 컨트롤러로 교체 |
| `StampCoordinator.start(isRouteFromTabBar: Bool = false)` | `start(isRouteFromTabBar: Bool = true)` | 기본값 변경, 딥링크 `false` 명시 호출 유지 |
| `PokeCoordinator.start(isRouteFromTabBar: Bool = false)` | `start(isRouteFromTabBar: Bool = true)` | 기본값 변경, 딥링크 `false` 명시 호출 유지 |

### isRouteFromTabBar 기본값 변경
- `StampCoordinator`, `PokeCoordinator`의 `start(isRouteFromTabBar:)` 기본값 `false`에서 `true`로 변경
- 알림 딥링크(`PokeDeepLink`, `SoptampDeepLink`)에서 `false`로 명시 호출하는 모달 진입 경로는 유지

### 사용되지 않는 코드 제거
- Home → Poke 직접 진입 시 필요한 관련 코드 제거
    - `HomeCoordinatorDestination.poke` 케이스 제거
    - `HomeForMemberCoordinatable.onPoke`, `HomeForMemberViewModel.onPoke` 제거 (ViewModel에서 호출되지 않던 코드임)
    - `LegacyHomeCoordinator.requestCoordinating`의 `.poke` 케이스 제거
    - `PokeMainViewModel.isRouteFromRoot` — 저장만 되고 읽히지 않던 코드 제거

## 테스트
- [x] 앱 실행 후 탭바에서 Poke, Soptamp 정상 진입 확인
- [x] 알림 딥링크로 콕찌르기 알림 목록 진입 확인
- [x] 알림 딥링크로 Soptamp 미션 목록 진입 확인

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #870