### PR TITLE
[Fix] #868 - QA 반영

### DIFF
--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -17,6 +17,7 @@ public protocol PokeMainUseCase {
     var pokedResponse: PassthroughSubject<PokeUserModel, Never> { get }
     var madeNewFriend: PassthroughSubject<PokeUserModel, Never> { get }
     var errorMessage: PassthroughSubject<String?, Never> { get }
+    var errorOccured: PassthroughSubject<Void, Never> { get }
     
     func getWhoPokedToMe()
     func getFriend()
@@ -34,6 +35,7 @@ public class DefaultPokeMainUseCase {
     public let pokedResponse = PassthroughSubject<PokeUserModel, Never>()
     public let madeNewFriend = PassthroughSubject<PokeUserModel, Never>()
     public let errorMessage = PassthroughSubject<String?, Never>()
+    public let errorOccured = PassthroughSubject<Void, Never>()
     
     public init(repository: PokeMainRepositoryInterface) {
         self.repository = repository
@@ -44,8 +46,9 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
     
     public func getWhoPokedToMe() {
         repository.getWhoPokeToMe()
-            .catch { _ in
-                Just<PokeUserModel?>(nil)
+            .catch { [weak self] error -> Just<PokeUserModel?> in
+                self?.errorOccured.send()
+                return Just(nil)
             }
             .withUnretained(self)
             .sink { event in
@@ -57,24 +60,30 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
     
     public func getFriend() {
         repository.getFriend()
-            .sink { [weak self] event in
+            .catch { [weak self] error -> Just<[PokeUserModel]> in
+                self?.errorOccured.send()
+                return Just([])
+            }
+            .withUnretained(self)
+            .sink { event in
                 print("GetFriend State: \(event)")
-                // 친구 관계가 없을떄는 서버에서 에러를 응답하기 때문에 빈배열로 값을 방출함
-                if case .failure = event { self?.myFriend.send([])}
-            } receiveValue: { [weak self] friend in
-                self?.myFriend.send(friend)
+            } receiveValue: { owner, friend in
+                owner.myFriend.send(friend)
             }.store(in: cancelBag)
     }
     
     public func getFriendRandomUser(randomType: PokeRandomUserType, size: Int) {
         repository.getFriendRandomUser(randomType: randomType.rawValue, size: size)
-            .sink { [weak self] event in
+            .catch { [weak self] error -> Just<PokeFriendRandomUserModel> in
+                
+                self?.errorOccured.send()
+                return Just(PokeFriendRandomUserModel(randomInfoList: []))
+            }
+            .withUnretained(self)
+            .sink { event in
                 print("GetFriendRandomUser State: \(event)")
-                if case .failure = event {
-                    self?.friendRandomUsers.send(PokeFriendRandomUserModel(randomInfoList: []))
-                }
-            } receiveValue: { [weak self] randomUsers in
-                self?.friendRandomUsers.send(randomUsers)
+            } receiveValue: { owner, randomUsers in
+                owner.friendRandomUsers.send(randomUsers)
             }.store(in: cancelBag)
     }
     

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/PokeMainUseCase.swift
@@ -68,8 +68,11 @@ extension DefaultPokeMainUseCase: PokeMainUseCase {
     
     public func getFriendRandomUser(randomType: PokeRandomUserType, size: Int) {
         repository.getFriendRandomUser(randomType: randomType.rawValue, size: size)
-            .sink { event in
+            .sink { [weak self] event in
                 print("GetFriendRandomUser State: \(event)")
+                if case .failure = event {
+                    self?.friendRandomUsers.send(PokeFriendRandomUserModel(randomInfoList: []))
+                }
             } receiveValue: { [weak self] randomUsers in
                 self?.friendRandomUsers.send(randomUsers)
             }.store(in: cancelBag)

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
@@ -97,9 +97,8 @@ extension DefaultSplashUseCase: SplashUseCase {
         let needForceUpdate = currentAppVersion.compare(minimumVersion, options: .numeric) == .orderedAscending
         let needOptionalUpdate = currentAppVersion.compare(appStoreVersion, options: .numeric) == .orderedAscending
         
-        return .none
-//        return needForceUpdate ? .forcedUpdate(forcedUpdateData.appNotice) :
-//                needOptionalUpdate ? .optionalUpdate(optionalUpdateData) : .none
+        return needForceUpdate ? .forcedUpdate(forcedUpdateData.appNotice) :
+                needOptionalUpdate ? .optionalUpdate(optionalUpdateData) : .none
     }
     
     private func handleUpdateType(_ type: UpdateType) throws {

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SplashUseCase.swift
@@ -97,8 +97,9 @@ extension DefaultSplashUseCase: SplashUseCase {
         let needForceUpdate = currentAppVersion.compare(minimumVersion, options: .numeric) == .orderedAscending
         let needOptionalUpdate = currentAppVersion.compare(appStoreVersion, options: .numeric) == .orderedAscending
         
-        return needForceUpdate ? .forcedUpdate(forcedUpdateData.appNotice) :
-                needOptionalUpdate ? .optionalUpdate(optionalUpdateData) : .none
+        return .none
+//        return needForceUpdate ? .forcedUpdate(forcedUpdateData.appNotice) :
+//                needOptionalUpdate ? .optionalUpdate(optionalUpdateData) : .none
     }
     
     private func handleUpdateType(_ type: UpdateType) throws {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -230,5 +230,11 @@ extension PokeMainViewModel {
             .sink { message in
                 ToastUtils.showMDSToast(type: .alert, text: message)
             }.store(in: cancelBag)
+        
+        useCase.errorOccured
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: false)
+            .sink { _ in
+                AlertUtils.presentNetworkAlertVC()
+            }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptlogFeature/Sources/SoptlogScene/ViewModel/SoptlogViewModel.swift
@@ -86,6 +86,7 @@ extension SoptlogViewModel {
             }.store(in: cancelBag)
                 
         input.cellTap
+            .filter { $0.section == .pokeLog }
             .withUnretained(self)
             .sink { owner, tapInfo in
                 switch tapInfo.row {


### PR DESCRIPTION
## 🌴 PR 요약
- 솝트로그 이곳저곳 눌렀을 때 모두 콕찌르기로 넘어가는 버그 수정했습니다.
- 콕찌르기 pull to refresh 했을 때 영원히 indicator가 없어지지 않는 버그 수정했습니다.

🌱 작업한 브랜치
- fix/#868

## 🌱 PR Point

`getFriendRandomUser` 실패 시 아무 값도 방출하지 않아 `Publishers.Zip3`가 완료되지 않는 문제가 있었습니다.
실패 시 빈 `PokeFriendRandomUserModel`을 방출하도록 처리해 `endRefreshLoading`이 정상적으로 호출되도록 수정했습니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📮 관련 이슈
- Resolved: #868 
