### PR TITLE
[Feat] #874 - 솝레터 작성 뷰 구현

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -494,7 +494,15 @@ public struct I18N {
     }
 
     public struct Soptletter {
-        public static let navigationTitle = "솝레터 작성하기"
+        public static let navigationTitle = "솝레터 작성"
+        public static let descriptionText = "나와 같은 기수의 SOPT\n회원들에게 전하고 싶은 말을\n자유롭게 적어보세요."
+        public static let recipient = "익명의 무무"
+        public static let placeholder = "나와 같은 기수의 솝트인들에게 전하고 싶은 말을 자유롭게 적어보세요."
+        public static let charLimit = "0/250자"
+        public static let charLimitError = "공백 포함 250자 이하로만 작성할 수 있어요."
+        public static let submitButton = "작성 완료"
+        public static let submitSuccess = "메시지 작성을 완료했어요."
+        public static let submitFailure = "실패했습니다"
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Project.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Project.swift
@@ -24,6 +24,7 @@ let project = Project.makeModule(
         .Features.Poke.Feature,
         .Features.DailySoptune.Feature,
         .Features.Home.Feature,
-        .Features.Soptlog.Feature
+        .Features.Soptlog.Feature,
+        .Features.Soptletter.Feature
     ]
 )

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -57,7 +57,7 @@ extension ApplicationCoordinator: HomeCoordinatorDelegate {
     public func homeCoordinator(_ coordinator: HomeCoordinator, to destination: HomeCoordinatorDestination) {
         switch destination {
         case .attendance:
-            runAttendanceFlow()
+            runSoptletterWritingFlow() // TODO: 테스트용 임시 연결, 제거 필요
         case .setting(let userType):
             runMyPageFlow(of: userType)
         case .signIn:

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator+Delegate.swift
@@ -53,11 +53,12 @@ extension ApplicationCoordinator: TabBarCoordinatorDelegate {
 
 // MARK: - HomeCoordinatorDelegate
 
+// TODO: - Soptletter 추가 필요
 extension ApplicationCoordinator: HomeCoordinatorDelegate {
     public func homeCoordinator(_ coordinator: HomeCoordinator, to destination: HomeCoordinatorDestination) {
         switch destination {
         case .attendance:
-            runSoptletterWritingFlow() // TODO: 테스트용 임시 연결, 제거 필요
+            runAttendanceFlow()
         case .setting(let userType):
             runMyPageFlow(of: userType)
         case .signIn:

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -23,6 +23,7 @@ import DailySoptuneFeature
 import WebFeature
 import SoptlogFeature
 import TabBarFeature
+import SoptletterFeature
 
 public final class ApplicationCoordinator: BaseCoordinator {
     
@@ -572,6 +573,18 @@ extension ApplicationCoordinator {
         coordinator.start()
         
         return coordinator
+    }
+}
+
+// MARK: - SoptletterFlow
+
+extension ApplicationCoordinator {
+    internal func runSoptletterWritingFlow() {
+        let coordinator = SoptletterCoordinator(
+            navigationController: UIWindow.getRootNavigationController,
+            factory: SoptletterBuilder()
+        )
+        coordinator.start()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -577,7 +577,7 @@ extension ApplicationCoordinator {
 }
 
 // MARK: - SoptletterFlow
-
+// TODO: - 솝레터 목록뷰 완성 후 코디네이터 생명주기 관리 필요 (솝레터 메인 뷰모델이 관리)
 extension ApplicationCoordinator {
     internal func runSoptletterWritingFlow() {
         let coordinator = SoptletterCoordinator(

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Interface/Sources/SoptletterPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Interface/Sources/SoptletterPresentable.swift
@@ -9,11 +9,13 @@
 import UIKit
 
 import BaseFeatureDependency
+import Core
 
 public protocol SoptletterViewControllable: LegacyViewControllable {}
 
 public protocol SoptletterCoordinatable {
     var onNaviBackTap: (() -> Void)? { get set }
+    var onSubmitSuccess: (() -> Void)? { get set }
 }
 
 public typealias SoptletterWritingViewModelType = ViewModelType & SoptletterCoordinatable

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
@@ -45,6 +45,13 @@ public final class SoptletterCoordinator: BaseCoordinator {
             self?.navigationController?.popViewController(animated: true)
         }
 
+        soptletterWriting.vm.onSubmitSuccess = { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+            ToastUtils.showMDSToast(type: .actionButton, text: I18N.Soptletter.submitSuccess) {
+                // TODO: 솝레터 목록으로 이동
+            }
+        }
+
         navigationController?.pushViewController(soptletterWriting.vc, animated: true)
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
@@ -47,9 +47,7 @@ public final class SoptletterCoordinator: BaseCoordinator {
 
         soptletterWriting.vm.onSubmitSuccess = { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-            ToastUtils.showMDSToast(type: .actionButton, text: I18N.Soptletter.submitSuccess) {
-                // TODO: 솝레터 목록으로 이동
-            }
+            ToastUtils.showMDSToast(type: .success, text: I18N.Soptletter.submitSuccess)
         }
 
         navigationController?.pushViewController(soptletterWriting.vc, animated: true)

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
@@ -225,7 +225,8 @@ private extension SoptletterWritingVC {
         let input = SoptletterWritingViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
             naviBackTap: naviBackTap,
-            textChanged: textChangedSubject.asDriver()
+            textChanged: textChangedSubject.asDriver(),
+            submitTap: submitTapSubject.asDriver()
         )
 
         let output = self.viewModel.transform(from: input, cancelBag: cancelBag)

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
@@ -224,10 +224,18 @@ private extension SoptletterWritingVC {
     func bindViewModels() {
         let input = SoptletterWritingViewModel.Input(
             viewDidLoad: Just<Void>(()).asDriver(),
-            naviBackTap: naviBackTap
+            naviBackTap: naviBackTap,
+            textChanged: textChangedSubject.asDriver()
         )
 
-        let _ = self.viewModel.transform(from: input, cancelBag: cancelBag)
+        let output = self.viewModel.transform(from: input, cancelBag: cancelBag)
+
+        output.isSubmitEnabled
+            .receive(on: RunLoop.main)
+            .withUnretained(self)
+            .sink { owner, isEnabled in
+                owner.submitButton.isEnabled = isEnabled
+            }.store(in: cancelBag)
     }
 
     @objc func submitButtonTapped() {

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
@@ -86,7 +86,7 @@ public final class SoptletterWritingVC: UIViewController, SoptletterViewControll
 
     private let textView = UITextView().then {
         $0.backgroundColor = .clear
-        $0.textColor = DSKitAsset.Colors.gray200.color
+        $0.textColor = DSKitAsset.Colors.gray10.color
         $0.font = DSKitFontFamily.Suit.regular.font(size: 16)
         $0.textContainerInset = .zero
         $0.textContainer.lineFragmentPadding = 0
@@ -247,6 +247,16 @@ private extension SoptletterWritingVC {
 // MARK: - UITextViewDelegate
 
 extension SoptletterWritingVC: UITextViewDelegate {
+    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let currentText = textView.text ?? ""
+        guard let textRange = Range(range, in: currentText) else { return true }
+        let updatedText = currentText.replacingCharacters(in: textRange, with: text)
+        if updatedText.count == maxCharCount + 1 {
+            ToastUtils.showMDSToast(type: .alert, text: I18N.Soptletter.charLimitError)
+        }
+        return updatedText.count <= maxCharCount + 1
+    }
+
     public func textViewDidChange(_ textView: UITextView) {
         guard !isSettingAttributedText else { return }
 
@@ -270,8 +280,8 @@ extension SoptletterWritingVC: UITextViewDelegate {
         inputContainerView.layer.borderColor = isOver ? DSKitAsset.Colors.error.color.cgColor : nil
 
         guard isOver else {
-            if textView.textColor != DSKitAsset.Colors.gray200.color {
-                textView.textColor = DSKitAsset.Colors.gray200.color
+            if textView.textColor != DSKitAsset.Colors.gray10.color {
+                textView.textColor = DSKitAsset.Colors.gray10.color
             }
             return
         }
@@ -279,7 +289,7 @@ extension SoptletterWritingVC: UITextViewDelegate {
         let attributed = NSMutableAttributedString(string: text)
         let normalFont = DSKitFontFamily.Suit.regular.font(size: 16)
         attributed.addAttributes([
-            .foregroundColor: DSKitAsset.Colors.gray200.color,
+            .foregroundColor: DSKitAsset.Colors.gray10.color,
             .font: normalFont
         ], range: NSRange(location: 0, length: maxCharCount))
         attributed.addAttributes([

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
@@ -24,12 +24,102 @@ public final class SoptletterWritingVC: UIViewController, SoptletterViewControll
     public let viewModel: SoptletterWritingViewModel
     private let cancelBag = CancelBag()
 
-    private lazy var naviBackTap: Driver<Void> = naviBar.backButtonTapped
+    private let maxCharCount = 250
+    private let textChangedSubject = PassthroughSubject<String, Never>()
+    private let submitTapSubject = PassthroughSubject<Void, Never>()
+    private var isSettingAttributedText = false
 
-    // MARK: - UI Components
+    private lazy var naviBackTap: Driver<Void> = backButton
+        .publisher(for: .touchUpInside)
+        .mapVoid()
+        .asDriver()
 
-    private lazy var naviBar = OPNavigationBar(self, type: .bothButtons)
-        .addMiddleLabel(title: I18N.Soptletter.navigationTitle)
+    // MARK: - UI Components (NavBar)
+
+    private let navBarView = UIView()
+
+    private let backButton = UIButton(type: .custom).then {
+        $0.setImage(DSKitAsset.Assets.opArrowWhite.image, for: .normal)
+    }
+
+    private let navTitleLabel = UILabel().then {
+        $0.text = I18N.Soptletter.navigationTitle
+        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.font = DSKitFontFamily.Pretendard.bold.font(size: 18)
+    }
+
+    // MARK: - UI Components (Description)
+
+    private let descriptionStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = 14
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = UIEdgeInsets(top: 0, left: 20, bottom: 4, right: 20)
+    }
+
+    private let mailBoxImageView = UIImageView().then {
+        $0.image = DSKitAsset.Assets.icMailBox.image
+        $0.contentMode = .scaleAspectFit
+    }
+
+    private let descriptionLabel = UILabel().then {
+        $0.text = I18N.Soptletter.descriptionText
+        $0.textColor = DSKitAsset.Colors.gray300.color
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
+        $0.numberOfLines = 0
+    }
+
+    // MARK: - UI Components (Input Container)
+
+    private let inputContainerView = UIView().then {
+        $0.backgroundColor = DSKitAsset.Colors.gray700.color
+        $0.layer.cornerRadius = 10
+        $0.layer.borderWidth = 0
+    }
+
+    private let recipientLabel = UILabel().then {
+        $0.text = I18N.Soptletter.recipient
+        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 16)
+    }
+
+    private let textView = UITextView().then {
+        $0.backgroundColor = .clear
+        $0.textColor = DSKitAsset.Colors.gray200.color
+        $0.font = DSKitFontFamily.Suit.regular.font(size: 16)
+        $0.textContainerInset = .zero
+        $0.textContainer.lineFragmentPadding = 0
+        $0.isScrollEnabled = false
+        $0.autocorrectionType = .no
+        $0.autocapitalizationType = .none
+    }
+
+    private let placeholderLabel = UILabel().then {
+        $0.text = I18N.Soptletter.placeholder
+        $0.textColor = DSKitAsset.Colors.gray500.color
+        $0.font = DSKitFontFamily.Suit.regular.font(size: 16)
+        $0.numberOfLines = 0
+    }
+
+    private let charCountLabel = UILabel().then {
+        $0.text = I18N.Soptletter.charLimit
+        $0.textColor = DSKitAsset.Colors.gray300.color
+        $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
+    }
+
+    // MARK: - UI Components (Submit Button)
+
+    private let submitButton = AppCustomButton(title: I18N.Soptletter.submitButton)
+        .setEnabled(false)
+        .setConfigForState(
+            bgColor: DSKitAsset.Colors.gray100.color,
+            disabledColor: DSKitAsset.Colors.gray600.color,
+            disabledTextColor: DSKitAsset.Colors.white.color,
+            disabledFont: DSKitFontFamily.Suit.semiBold.font(size: 16),
+            enabledTextColor: DSKitAsset.Colors.gray300.color,
+            enabledFont: DSKitFontFamily.Suit.semiBold.font(size: 16)
+        )
 
     // MARK: - Init
 
@@ -59,14 +149,74 @@ private extension SoptletterWritingVC {
     func setUI() {
         view.backgroundColor = DSKitAsset.Colors.semanticBackground.color
         navigationController?.navigationBar.isHidden = true
+        textView.delegate = self
+        submitButton.addTarget(self, action: #selector(submitButtonTapped), for: .touchUpInside)
     }
 
     func setLayout() {
-        view.addSubview(naviBar)
+        descriptionStackView.addArrangedSubview(mailBoxImageView)
+        descriptionStackView.addArrangedSubview(descriptionLabel)
 
-        naviBar.snp.makeConstraints { make in
+        view.addSubviews(navBarView, descriptionStackView, inputContainerView, submitButton)
+        navBarView.addSubviews(backButton, navTitleLabel)
+        inputContainerView.addSubviews(recipientLabel, textView, placeholderLabel, charCountLabel)
+
+        navBarView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide)
             make.leading.trailing.equalToSuperview()
+            make.height.equalTo(56)
+        }
+
+        backButton.snp.makeConstraints { make in
+            make.top.bottom.equalToSuperview().inset(12)
+            make.leading.equalToSuperview().inset(20)
+            make.width.height.equalTo(32)
+        }
+
+        navTitleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(backButton.snp.trailing).offset(12)
+            make.centerY.equalTo(backButton)
+        }
+
+        descriptionStackView.snp.makeConstraints { make in
+            make.top.equalTo(navBarView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+        }
+
+        mailBoxImageView.snp.makeConstraints { make in
+            make.width.equalTo(96)
+            make.height.equalTo(80)
+        }
+
+        inputContainerView.snp.makeConstraints { make in
+            make.top.equalTo(descriptionStackView.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(19)
+        }
+
+        recipientLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(28)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+
+        textView.snp.makeConstraints { make in
+            make.top.equalTo(recipientLabel.snp.bottom).offset(14)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalTo(charCountLabel.snp.top).offset(-16)
+            make.height.greaterThanOrEqualTo(120)
+        }
+
+        placeholderLabel.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(textView)
+        }
+
+        charCountLabel.snp.makeConstraints { make in
+            make.trailing.bottom.equalToSuperview().inset(20)
+        }
+
+        submitButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(34)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(56)
         }
     }
 
@@ -77,5 +227,60 @@ private extension SoptletterWritingVC {
         )
 
         let _ = self.viewModel.transform(from: input, cancelBag: cancelBag)
+    }
+
+    @objc func submitButtonTapped() {
+        submitTapSubject.send(())
+    }
+}
+
+// MARK: - UITextViewDelegate
+
+extension SoptletterWritingVC: UITextViewDelegate {
+    public func textViewDidChange(_ textView: UITextView) {
+        guard !isSettingAttributedText else { return }
+
+        let text = textView.text ?? ""
+        placeholderLabel.isHidden = !text.isEmpty
+        updateCharCount(text.count)
+        updateErrorState(text: text)
+        textChangedSubject.send(text)
+    }
+
+    private func updateCharCount(_ count: Int) {
+        charCountLabel.text = "\(count)/250자"
+        charCountLabel.textColor = count > maxCharCount
+            ? DSKitAsset.Colors.error.color
+            : DSKitAsset.Colors.gray300.color
+    }
+
+    private func updateErrorState(text: String) {
+        let isOver = text.count > maxCharCount
+        inputContainerView.layer.borderWidth = isOver ? 1 : 0
+        inputContainerView.layer.borderColor = isOver ? DSKitAsset.Colors.error.color.cgColor : nil
+
+        guard isOver else {
+            if textView.textColor != DSKitAsset.Colors.gray200.color {
+                textView.textColor = DSKitAsset.Colors.gray200.color
+            }
+            return
+        }
+
+        let attributed = NSMutableAttributedString(string: text)
+        let normalFont = DSKitFontFamily.Suit.regular.font(size: 16)
+        attributed.addAttributes([
+            .foregroundColor: DSKitAsset.Colors.gray200.color,
+            .font: normalFont
+        ], range: NSRange(location: 0, length: maxCharCount))
+        attributed.addAttributes([
+            .foregroundColor: DSKitAsset.Colors.error.color,
+            .font: normalFont
+        ], range: NSRange(location: maxCharCount, length: text.count - maxCharCount))
+
+        let selectedRange = textView.selectedRange
+        isSettingAttributedText = true
+        textView.attributedText = attributed
+        textView.selectedRange = selectedRange
+        isSettingAttributedText = false
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/VC/SoptletterWritingVC.swift
@@ -140,6 +140,7 @@ public final class SoptletterWritingVC: UIViewController, SoptletterViewControll
         setUI()
         setLayout()
         bindViewModels()
+        hideKeyboard()
     }
 }
 

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
@@ -32,6 +32,7 @@ public final class SoptletterWritingViewModel: SoptletterWritingViewModelType {
         let viewDidLoad: Driver<Void>
         let naviBackTap: Driver<Void>
         let textChanged: Driver<String>
+        let submitTap: Driver<Void>
     }
 
     // MARK: - Outputs
@@ -61,6 +62,13 @@ extension SoptletterWritingViewModel {
             .withUnretained(self)
             .sink { owner, text in
                 output.isSubmitEnabled.send(!text.isEmpty && text.count <= owner.maxCharCount)
+            }.store(in: cancelBag)
+
+        input.submitTap
+            .withUnretained(self)
+            .sink { owner, _ in
+                // TODO: 실제 서버 연동 시 교체
+                owner.onSubmitSuccess?()
             }.store(in: cancelBag)
 
         return output

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
@@ -24,17 +24,21 @@ public final class SoptletterWritingViewModel: SoptletterWritingViewModelType {
 
     private let coordinator: AnyCoordinatorObject
     private var cancelBag = CancelBag()
+    private let maxCharCount = 250
 
     // MARK: - Inputs
 
     public struct Input {
         let viewDidLoad: Driver<Void>
         let naviBackTap: Driver<Void>
+        let textChanged: Driver<String>
     }
 
     // MARK: - Outputs
 
-    public struct Output {}
+    public struct Output {
+        let isSubmitEnabled = CurrentValueSubject<Bool, Never>(false)
+    }
 
     // MARK: - Init
 
@@ -51,6 +55,12 @@ extension SoptletterWritingViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.onNaviBackTap?()
+            }.store(in: cancelBag)
+
+        input.textChanged
+            .withUnretained(self)
+            .sink { owner, text in
+                output.isSubmitEnabled.send(!text.isEmpty && text.count <= owner.maxCharCount)
             }.store(in: cancelBag)
 
         return output

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
@@ -15,9 +15,10 @@ import SoptletterFeatureInterface
 
 public final class SoptletterWritingViewModel: SoptletterWritingViewModelType {
 
-    // MARK: - Coordinatable
+    // MARK: - SoptletterCoordinatable
 
     public var onNaviBackTap: (() -> Void)?
+    public var onSubmitSuccess: (() -> Void)?
 
     // MARK: - Properties
 


### PR DESCRIPTION
## 🌴 PR 요약
- 솝레터 작성 뷰 UI를 구현했습니다.

🌱 작업한 브랜치
- feature/#874

## 🌱 PR Point
### 글자수 초과 처리
- 250자 초과 시 초과 글자를 빨간색으로 표시
- 컨테이너 테두리 활성화
- 토스트 메시지 노출
글자수만큼 작성하지 않고 한 글자 더 작성이 가능하되, 빨간색으로 처리했습니다(피그마 참고)

## 📌 참고 사항
- 솝레터 목록 뷰 완성 후 진입 경로 및 제출 후 이동 로직 구현이 필요합니다.
- 서버 연동 미구현 상태입니다. (submitTap 시 `onSubmitSuccess` 직접 호출)
   - 또한 서버 에러로 인한 작성 실패 시 토스트 UI를 요청해둔 상태라 API 연결 시 반영이 필요합니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/08511b8f-f6d9-4de2-b77a-f9c53d75e52b



## 📮 관련 이슈
- Resolved: #874