### PR TITLE
[Fix] #871 - 콕찌르기 천생연분 UX 변경사항 반영

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Transform/PokeUserTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/PokeUserTransform.swift
@@ -25,7 +25,7 @@ extension PokeUserEntity {
       mutualRelationMessage: mutualRelationMessage,
       isFirstMeet: isFirstMeet,
       isAlreadyPoke: isAlreadyPoke,
-      isAnonymous: isAnonymous,
+      isAnonymous: pokeNum >= 11 ? false :isAnonymous,
       anonymousName: anonymousName
     )
   }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/PokeMessageTemplateConfig.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/PokeMessageTemplateConfig.swift
@@ -1,0 +1,15 @@
+//
+//  PokeMessageTemplateConfig.swift
+//  Domain
+//
+//  Created by a on 5/13/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+public struct PokeMessageTemplateConfig {
+    public let isAnonymousSelectionAvailable: Bool
+    
+    public init(isAnonymousSelectionAvailable: Bool) {
+        self.isAnonymousSelectionAvailable = isAnonymousSelectionAvailable
+    }
+}

--- a/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/DailySoptuneFeature/Sources/Coordinator/DailySoptuneResultCoordinator.swift
@@ -97,9 +97,10 @@ public final class DailySoptuneResultCoordinator: BaseCoordinator {
     
     private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
         let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
+        let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
         
         guard let bottomSheet = self.pokeFactory
-            .makePokeMessageTemplateBottomSheet(messageType: messageType)
+            .makePokeMessageTemplateBottomSheet(messageType: messageType, config: messageTemplateConfig)
             .vc
             .viewController as? PokeMessageTemplatesViewControllable
         else { return .empty() }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Interface/Sources/PokeFeatureBuildable.swift
@@ -16,8 +16,9 @@ public protocol PokeFeatureBuildable {
     func makePokeMyFriends(coordinator: Coordinator) -> PokeMyFriendsPresentable
     func makePokeMyFriendsList(relation: PokeRelation) -> PokeMyFriendsListPresentable
     func makePokeOnboarding(coordinator: AnyCoordinatorObject) -> PokeOnboardingPresentable
-    func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> PokeMessageTemplatesPresentable
+    func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType, config: PokeMessageTemplateConfig) -> PokeMessageTemplatesPresentable
     func makePokeNotificationList(coordinator: Coordinator) -> PokeNotificationPresentable
     func makePokeMakingFriendCompleted(friendName: String) -> PokeMakingFriendCompletedPresentable
     func makePokeAnonymousFriendUpgrade(user: PokeUserModel) -> PokeAnonymousFriendUpgradePresentable
 }
+

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeNotificationListContentView.swift
@@ -162,7 +162,8 @@ extension PokeNotificationListContentView {
     self.userId = model.userId
     self.profileImageView.setImage(
         with: model.isAnonymous ? "" : model.profileImage,
-        relation: PokeRelation(rawValue: model.relationName) ?? .nonFriend
+        relation: PokeRelation(rawValue: model.relationName) ?? .nonFriend,
+        placeholder: model.isAnonymous ? DSKitAsset.Assets.icPokeDefaultProfile : DSKitAsset.Assets.icLineProfile
     )
     self.partInfoLabel.text = "\(model.generation)기 \(model.part)"
     self.descriptionLabel.attributedText = model.message.applyMDSFont()

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileImageView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileImageView.swift
@@ -10,8 +10,8 @@ import UIKit
 import DSKit
 
 extension CustomProfileImageView {
-    public func setImage(with url: String, relation: PokeRelation) {
-        self.setImage(with: url, placeholder: DSKitAsset.Assets.icPokeDefaultProfile.image)
+    public func setImage(with url: String, relation: PokeRelation, placeholder: DSKitImages) {
+        self.setImage(with: url, placeholder: placeholder.image)
         self.setBorderColor(for: relation)
     }
     

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Components/PokeProfileListView.swift
@@ -183,7 +183,8 @@ public final class PokeProfileListView: UIView, PokeCompatible {
         self.user = model
         self.profileImageView.setImage(
             with: model.isAnonymous ? "" : model.profileImage,
-            relation: model.pokeRelation
+            relation: model.pokeRelation,
+            placeholder: model.isAnonymous ? DSKitAsset.Assets.icPokeDefaultProfile : DSKitAsset.Assets.icLineProfile
         )
         self.partLabel.text = "\(model.generation)기 \(model.part)"
         self.kokCountLabel.text = "\(model.pokeNum)콕"

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/LegacyPokeBuilder.swift
@@ -48,7 +48,7 @@ extension LegacyPokeBuilder: LegacyPokeFeatureBuildable {
     
     public func makePokeMessageTemplateBottomSheet(messageType: PokeMessageType) -> LegacyPokeMessageTemplatesPresentable {
         let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
+        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase, config: .init(isAnonymousSelectionAvailable: false))
         let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeBuilder.swift
@@ -55,9 +55,9 @@ extension PokeBuilder: PokeFeatureBuildable {
         return (pokeMyFriendsListVC, viewModel)
     }
     
-    public func makePokeMessageTemplateBottomSheet(messageType: Domain.PokeMessageType) -> PokeFeatureInterface.PokeMessageTemplatesPresentable {
+    public func makePokeMessageTemplateBottomSheet(messageType: Domain.PokeMessageType, config: PokeMessageTemplateConfig) -> PokeFeatureInterface.PokeMessageTemplatesPresentable {
         let usecase = DefaultPokeMessageTemplateUsecase(repository: self.pokeOnboardingRepository)
-        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase)
+        let viewModel = PokeMessageTemplateViewModel(messageType: messageType, usecase: usecase, config: config)
         let viewController = PokeMessageTemplateBottomSheet(viewModel: viewModel)
         
         return (viewController, viewModel)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeCoordinator.swift
@@ -140,9 +140,10 @@ public final class PokeCoordinator: BaseCoordinator {
     
     private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
         let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
-
+        let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
+        
         guard let bottomSheet = self.factory
-            .makePokeMessageTemplateBottomSheet(messageType: messageType)
+            .makePokeMessageTemplateBottomSheet(messageType: messageType, config: messageTemplateConfig)
             .vc
             .viewController as? PokeMessageTemplateBottomSheet
         else { return .empty() }
@@ -157,3 +158,5 @@ public final class PokeCoordinator: BaseCoordinator {
             .asDriver()
     }
 }
+
+

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeMyFriendsCoordinator.swift
@@ -112,8 +112,10 @@ public final class PokeMyFriendsCoordinator: BaseCoordinator {
     }
     
     private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
+        let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
+        
         guard let bottomSheet = self.factory
-            .makePokeMessageTemplateBottomSheet(messageType: .pokeFriend)
+            .makePokeMessageTemplateBottomSheet(messageType: .pokeFriend, config: messageTemplateConfig)
             .vc
             .viewController as? PokeMessageTemplateBottomSheet
         else { return .empty() }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeNotificationListCoordinator.swift
@@ -46,8 +46,10 @@ public final class PokeNotificationListCoordinator: DefaultCoordinator {
         var pokeNotiListVC = factory.makePokeNotificationList(coordinator: self)
         
         pokeNotiListVC.vm.onPokeButtonTapped = { [weak self] userModel in
+            let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
+            
             guard let bottomSheet = self?.factory
-                .makePokeMessageTemplateBottomSheet(messageType: userModel.isFirstMeet ? .pokeSomeone : .pokeFriend)
+                .makePokeMessageTemplateBottomSheet(messageType: userModel.isFirstMeet ? .pokeSomeone : .pokeFriend, config: messageTemplateConfig)
                     .vc
                     .viewController as? PokeMessageTemplateBottomSheet
             else { return .empty() }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/Coordinator/PokeOnboardingCoordinator.swift
@@ -64,8 +64,10 @@ public final class PokeOnboardingCoordinator: DefaultCoordinator {
         }
         
         pokeOnboarding.vm.onPokeButtonTapped = { [weak self] userModel in
+            let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
+            
             guard let bottomSheet = self?.factory
-                .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone)
+                .makePokeMessageTemplateBottomSheet(messageType: .pokeSomeone, config: messageTemplateConfig)
                     .vc
                     .viewController as? PokeMessageTemplateBottomSheet
             else { return .empty() }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMainScene/ViewModel/PokeMainViewModel.swift
@@ -212,10 +212,12 @@ extension PokeMainViewModel {
             .sink { [weak self] user in
                 guard let self else { return }
                 ToastUtils.showMDSToast(type: .success, text: I18N.Poke.pokeSuccess)
-                if user.isAnonymous {
-                    if user.pokeNum == 5 || user.pokeNum == 6 || user.pokeNum == 11 || user.pokeNum == 12 {
-                        onAnonymousFriendUpgrade?(user)
-                    }
+                
+                let isUpgrade = (user.pokeNum == 11 || user.pokeNum == 12) ||
+                                (user.isAnonymous && (user.pokeNum == 5 || user.pokeNum == 6))
+                
+                if isUpgrade {
+                    onAnonymousFriendUpgrade?(user)
                 }
             }.store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMakingFriendCompletedScene/VC/PokeAnonymousFriendUpgradeVC.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMakingFriendCompletedScene/VC/PokeAnonymousFriendUpgradeVC.swift
@@ -113,7 +113,7 @@ public class PokeAnonymousFriendUpgradeVC: UIViewController, LegacyPokeAnonymous
   private func showRealIdentity() {
     titleLabel.text = "\(user.anonymousName)님의 정체는..."
     profileImageView.isHidden = false
-    profileImageView.setImage(with: user.profileImage, relation: user.pokeRelation)
+    profileImageView.setImage(with: user.profileImage, relation: user.pokeRelation, placeholder: user.isAnonymous ? DSKitAsset.Assets.icPokeDefaultProfile : DSKitAsset.Assets.icLineProfile)
     descriptionLabel.text = "\(user.generation)기 \(user.part)파트 \(user.name)"
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 4) {

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -208,7 +208,7 @@ extension PokeMessageTemplateBottomSheet {
                 guard isAnonymousAvailable else {
                     ToastUtils.showMDSToast(
                         type: .alert,
-                        text: "천생 연분은 실명만 남기실 수 있어요."
+                        text: "천생연분은 실명으로만 콕찌를 수 있어요."
                     )
                     return
                 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -16,196 +16,203 @@ import Domain
 
 public final class PokeMessageTemplateBottomSheet: UIViewController, LegacyPokeMessageTemplatesViewControllable, PokeMessageTemplatesViewControllable {
     
-  public var minimumContentHeight: CGFloat {
-     return PokeMessageTemplateBottomSheet.minimumContentHeight
-  }
+    public var minimumContentHeight: CGFloat {
+        return PokeMessageTemplateBottomSheet.minimumContentHeight
+    }
     
-  private enum Metric {
-    static let contentTop = 24.f
-    static let contentLeadingTrailng = 20.f
+    private enum Metric {
+        static let contentTop = 24.f
+        static let contentLeadingTrailng = 20.f
+        
+        static let scrollViewTop = 12.f
+        
+        static let anonymousStackViewSpacing = 8.f
+        static let anonymousCheckboxLength = 22.f
+        
+        static let contentStackViewSpacing = 4.f
+    }
     
-    static let scrollViewTop = 12.f
+    public static let minimumContentHeight = 366.f
     
-    static let anonymousStackViewSpacing = 8.f
-    static let anonymousCheckboxLength = 22.f
+    // MARK: - Views
+    private let scrollView = UIScrollView().then {
+        $0.alwaysBounceVertical = true
+        $0.showsVerticalScrollIndicator = false
+        $0.showsHorizontalScrollIndicator = false
+        
+        $0.isScrollEnabled = true
+    }
     
-    static let contentStackViewSpacing = 4.f
-  }
-  
-  public static let minimumContentHeight = 366.f
-
-  // MARK: - Views
-  private let scrollView = UIScrollView().then {
-    $0.alwaysBounceVertical = true
-    $0.showsVerticalScrollIndicator = false
-    $0.showsHorizontalScrollIndicator = false
+    private let scrollContainerStackView = UIStackView().then {
+        $0.alignment = .fill
+        $0.axis = .vertical
+        $0.spacing = Metric.contentStackViewSpacing
+    }
     
-    $0.isScrollEnabled = true
-  }
-  
-  private let scrollContainerStackView = UIStackView().then {
-    $0.alignment = .fill
-    $0.axis = .vertical
-    $0.spacing = Metric.contentStackViewSpacing
-  }
-  
-  private let messegeTemplateTitleLabel = UILabel().then {
-    $0.attributedText = "함께 보낼 메시지를 골라주세요".applyMDSFont(
-      mdsFont: .heading5,
-      color: DSKitAsset.Colors.gray30.color
-    )
-  }
-  
-  private let anonymousStackView = UIStackView().then {
-    $0.axis = .horizontal
-    $0.spacing = Metric.anonymousStackViewSpacing
-  }
-  
-  private let anonymousCheckboxButton = UIButton().then {
-    $0.layer.cornerRadius = 5
-    $0.setImage(DSKitAsset.Assets.check.image, for: .selected)
-    $0.setBackgroundColor(DSKitAsset.Colors.gray500.color, for: .normal)
-    $0.setBackgroundColor(DSKitAsset.Colors.blue40.color, for: .selected)
-    $0.isSelected = true
-  }
-  
-  private let anonymousDescription = UILabel().then {
-    $0.attributedText = "익명".applyMDSFont(
-      mdsFont: .title6,
-      color: DSKitAsset.Colors.gray10.color
-    )
-  }
-  
-  // MARK: - Variables
-  private let viewModel: PokeMessageTemplateViewModel
-  
-  // MARK: Combine
-  private let viewDidLoaded = PassthroughSubject<Void, Never>()
-  private let messageModelSubject = PassthroughSubject<(PokeMessageModel, isAnonymous: Bool), Error>()
-  private var cancelBag = CancelBag()
-  
-  public init(viewModel: PokeMessageTemplateViewModel) {
-    self.viewModel = viewModel
+    private let messegeTemplateTitleLabel = UILabel().then {
+        $0.attributedText = "함께 보낼 메시지를 골라주세요".applyMDSFont(
+            mdsFont: .heading5,
+            color: DSKitAsset.Colors.gray30.color
+        )
+    }
     
-    super.init(nibName: nil, bundle: nil)
+    private let anonymousStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = Metric.anonymousStackViewSpacing
+    }
     
-    self.view.backgroundColor = DSKitAsset.Colors.gray800.color
+    private let anonymousCheckboxButton = UIButton().then {
+        $0.layer.cornerRadius = 5
+        $0.setImage(DSKitAsset.Assets.check.image, for: .selected)
+        $0.setBackgroundColor(DSKitAsset.Colors.gray500.color, for: .normal)
+        $0.setBackgroundColor(DSKitAsset.Colors.blue40.color, for: .selected)
+    }
     
-    self.initializeViews()
-    self.setupConstraints()
-    self.bindViewModels()
-    self.initializeButtonActions()
+    private let anonymousDescription = UILabel().then {
+        $0.attributedText = "익명".applyMDSFont(
+            mdsFont: .title6,
+            color: DSKitAsset.Colors.gray10.color
+        )
+    }
     
-    self.viewDidLoaded.send(())
-  }
-  
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+    // MARK: - Variables
+    private let viewModel: PokeMessageTemplateViewModel
+    
+    // MARK: Combine
+    private let viewDidLoaded = PassthroughSubject<Void, Never>()
+    private let messageModelSubject = PassthroughSubject<(PokeMessageModel, isAnonymous: Bool), Error>()
+    private var cancelBag = CancelBag()
+    
+    public init(viewModel: PokeMessageTemplateViewModel) {
+        self.viewModel = viewModel
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        self.view.backgroundColor = DSKitAsset.Colors.gray800.color
+        
+        self.initializeViews()
+        self.setupConstraints()
+        self.bindViewModels()
+        self.initializeButtonActions()
+        
+        self.viewDidLoaded.send(())
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }
 
 extension PokeMessageTemplateBottomSheet {
-  private func initializeViews() {
-    self.view.addSubviews(
-      self.messegeTemplateTitleLabel,
-      self.anonymousStackView,
-      self.scrollView
-    )
-    
-    self.anonymousStackView.addArrangedSubviews(
-      self.anonymousCheckboxButton,
-      self.anonymousDescription
-    )
-    
-    self.scrollView.addSubview(self.scrollContainerStackView)
-  }
-  
-  private func setupConstraints() {
-    self.messegeTemplateTitleLabel.snp.makeConstraints {
-      $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(Metric.contentTop)
-      $0.leading.trailing.equalToSuperview().inset(Metric.contentLeadingTrailng)
+    private func initializeViews() {
+        self.view.addSubviews(
+            self.messegeTemplateTitleLabel,
+            self.anonymousStackView,
+            self.scrollView
+        )
+        
+        self.anonymousStackView.addArrangedSubviews(
+            self.anonymousCheckboxButton,
+            self.anonymousDescription
+        )
+        
+        self.scrollView.addSubview(self.scrollContainerStackView)
     }
     
-    self.anonymousStackView.snp.makeConstraints {
-      $0.trailing.equalToSuperview().inset(Metric.contentLeadingTrailng)
-      $0.centerY.equalTo(self.messegeTemplateTitleLabel.snp.centerY)
+    private func setupConstraints() {
+        self.messegeTemplateTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).inset(Metric.contentTop)
+            $0.leading.trailing.equalToSuperview().inset(Metric.contentLeadingTrailng)
+        }
+        
+        self.anonymousStackView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(Metric.contentLeadingTrailng)
+            $0.centerY.equalTo(self.messegeTemplateTitleLabel.snp.centerY)
+        }
+        
+        self.anonymousCheckboxButton.snp.makeConstraints { $0.size.equalTo(Metric.anonymousCheckboxLength) }
+        
+        self.scrollView.snp.makeConstraints {
+            $0.top.equalTo(self.messegeTemplateTitleLabel.snp.bottom).offset(Metric.scrollViewTop)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        
+        self.scrollContainerStackView.snp.makeConstraints {
+            $0.top.leading.trailing.width.equalToSuperview()
+            $0.bottom.lessThanOrEqualToSuperview()
+        }
     }
-    
-    self.anonymousCheckboxButton.snp.makeConstraints { $0.size.equalTo(Metric.anonymousCheckboxLength) }
-    
-    self.scrollView.snp.makeConstraints {
-      $0.top.equalTo(self.messegeTemplateTitleLabel.snp.bottom).offset(Metric.scrollViewTop)
-      $0.leading.trailing.bottom.equalToSuperview()
-    }
-    
-    self.scrollContainerStackView.snp.makeConstraints {
-      $0.top.leading.trailing.width.equalToSuperview()
-      $0.bottom.lessThanOrEqualToSuperview()
-    }
-  }
 }
 
 extension PokeMessageTemplateBottomSheet {
-  func configure(with messagesModel: PokeMessagesModel) {
-    self.messegeTemplateTitleLabel.text = messagesModel.header
-    messagesModel.messages.forEach {
-      let bottomsheetContentView = PokeBottomSheetMessageView(frame: self.view.frame)
-      bottomsheetContentView.configure(with: $0)
-      bottomsheetContentView
-        .signalForClick()
-        .sink(receiveValue: { [weak self] value in
-          
-          let isAnonymous = self?.anonymousCheckboxButton.isSelected ?? false
-          self?.messageModelSubject.send((value, isAnonymous: isAnonymous))
-          self?.dismiss(animated: true)
-        }).store(in: self.cancelBag)
-      
-      self.scrollContainerStackView.addArrangedSubview(bottomsheetContentView)
+    func configure(with messagesModel: PokeMessagesModel) {
+        self.messegeTemplateTitleLabel.text = messagesModel.header
+        messagesModel.messages.forEach {
+            let bottomsheetContentView = PokeBottomSheetMessageView(frame: self.view.frame)
+            bottomsheetContentView.configure(with: $0)
+            bottomsheetContentView
+                .signalForClick()
+                .sink(receiveValue: { [weak self] value in
+                    
+                    let isAnonymous = self?.anonymousCheckboxButton.isSelected ?? false
+                    self?.messageModelSubject.send((value, isAnonymous: isAnonymous))
+                    self?.dismiss(animated: true)
+                }).store(in: self.cancelBag)
+            
+            self.scrollContainerStackView.addArrangedSubview(bottomsheetContentView)
+        }
     }
-  }
-  
-  public func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)> {
-    return self.messageModelSubject.asDriver()
-  }
+    
+    public func signalForClick() -> Driver<(PokeMessageModel, isAnonymous: Bool)> {
+        return self.messageModelSubject.asDriver()
+    }
 }
 
 
 // MARK: - ViewModel Methods
 extension PokeMessageTemplateBottomSheet {
-  private func bindViewModels() {
-    let input = PokeMessageTemplateViewModel.Input(viewDidLoaded: self.viewDidLoaded.asDriver())
-    let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
-    
-    output
-      .messageTemplates
-      .asDriver()
-      .sink(receiveValue: { [weak self] values in
-        self?.configure(with: values)
-      }).store(in: self.cancelBag)
-  }
-  
-  private func initializeButtonActions() {
-    self.anonymousStackView
-      .gesture()
-      .map { _ in }
-      .merge(with: self.anonymousCheckboxButton.publisher(for: .touchUpInside).map { _ in })
-      .receive(on: RunLoop.main)
-      .sink(receiveValue: { [weak self] _ in
-        self?.anonymousCheckboxButton.isSelected.toggle()
-      }).store(in: self.cancelBag)
-    
-    self.anonymousCheckboxButton
-      .publisher(for: \.isSelected)
-      .dropFirst()
-      .receive(on: RunLoop.main)
-      .sink(receiveValue: { isSelected in
-        guard !isSelected else { return }
+    private func bindViewModels() {
+        let input = PokeMessageTemplateViewModel.Input(viewDidLoaded: self.viewDidLoaded.asDriver())
+        let output = self.viewModel.transform(from: input, cancelBag: self.cancelBag)
         
-        ToastUtils.showMDSToast(
-          type: .alert,
-          text: "익명 해제 시, 상대방이 나를 알 수 있어요."
-        )
+        output
+            .messageTemplates
+            .asDriver()
+            .sink(receiveValue: { [weak self] values in
+                self?.configure(with: values)
+            }).store(in: self.cancelBag)
         
-      }).store(in: self.cancelBag)
-  }
+        // messageTemplateConfig 상태에 따라서 체크박스 활성화 여부 설정
+        output
+            .messageTemplateConfig
+            .asDriver()
+            .sink { [weak self] messageTemplateConfig in
+                self?.anonymousCheckboxButton.isHidden = !messageTemplateConfig.isAnonymousSelectionAvailable
+                self?.anonymousDescription.isHidden = !messageTemplateConfig.isAnonymousSelectionAvailable
+                self?.anonymousCheckboxButton.isSelected = messageTemplateConfig.isAnonymousSelectionAvailable
+            }
+            .store(in: self.cancelBag)
+    }
+    
+    private func initializeButtonActions() {
+        self.anonymousStackView
+            .gesture()
+            .map { _ in }
+            .merge(with: self.anonymousCheckboxButton.publisher(for: .touchUpInside).map { _ in })
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] _ in
+                guard let self else { return }
+                
+                let isSelected = anonymousCheckboxButton.isSelected
+                
+                self.anonymousCheckboxButton.isSelected.toggle()
+                
+                if isSelected {
+                    ToastUtils.showMDSToast(
+                        type: .alert,
+                        text: "익명 해제 시, 상대방이 나를 알 수 있어요."
+                    )
+                }
+            }).store(in: self.cancelBag)
+    }
 }

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -81,6 +81,8 @@ public final class PokeMessageTemplateBottomSheet: UIViewController, LegacyPokeM
     // MARK: Combine
     private let viewDidLoaded = PassthroughSubject<Void, Never>()
     private let messageModelSubject = PassthroughSubject<(PokeMessageModel, isAnonymous: Bool), Error>()
+    private var isAnonymousAvailable = false
+    
     private var cancelBag = CancelBag()
     
     public init(viewModel: PokeMessageTemplateViewModel) {
@@ -187,8 +189,8 @@ extension PokeMessageTemplateBottomSheet {
             .messageTemplateConfig
             .asDriver()
             .sink { [weak self] messageTemplateConfig in
-                self?.anonymousCheckboxButton.isHidden = !messageTemplateConfig.isAnonymousSelectionAvailable
-                self?.anonymousDescription.isHidden = !messageTemplateConfig.isAnonymousSelectionAvailable
+                self?.isAnonymousAvailable = messageTemplateConfig.isAnonymousSelectionAvailable
+                self?.anonymousCheckboxButton.isEnabled = messageTemplateConfig.isAnonymousSelectionAvailable
                 self?.anonymousCheckboxButton.isSelected = messageTemplateConfig.isAnonymousSelectionAvailable
             }
             .store(in: self.cancelBag)
@@ -202,10 +204,17 @@ extension PokeMessageTemplateBottomSheet {
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] _ in
                 guard let self else { return }
+                guard isAnonymousAvailable else {
+                    ToastUtils.showMDSToast(
+                        type: .alert,
+                        text: "천생 연분은 실명만 남기실 수 있어요."
+                    )
+                    return
+                }
                 
                 let isSelected = anonymousCheckboxButton.isSelected
-                
-                self.anonymousCheckboxButton.isSelected.toggle()
+            
+                anonymousCheckboxButton.isSelected.toggle()
                 
                 if isSelected {
                     ToastUtils.showMDSToast(

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateBottomSheet.swift
@@ -157,6 +157,7 @@ extension PokeMessageTemplateBottomSheet {
                 .sink(receiveValue: { [weak self] value in
                     
                     let isAnonymous = self?.anonymousCheckboxButton.isSelected ?? false
+                    
                     self?.messageModelSubject.send((value, isAnonymous: isAnonymous))
                     self?.dismiss(animated: true)
                 }).store(in: self.cancelBag)

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMessageTemplatesScene/PokeMessageTemplateViewModel.swift
@@ -17,19 +17,23 @@ public final class PokeMessageTemplateViewModel: PokeMessageTemplatesViewModelTy
     
     public var messageType: PokeMessageType
     
+    private let messageTemplateConfig: PokeMessageTemplateConfig
+    
     public struct Input {
         let viewDidLoaded: Driver<Void>
     }
     
     public struct Output {
         let messageTemplates = PassthroughSubject<PokeMessagesModel, Never>()
+        let messageTemplateConfig = PassthroughSubject<PokeMessageTemplateConfig, Never>()
     }
     
     private let usecase: PokeMessageTemplateUsecase
     
-    public init(messageType: PokeMessageType, usecase: PokeMessageTemplateUsecase) {
+    public init(messageType: PokeMessageType, usecase: PokeMessageTemplateUsecase, config: PokeMessageTemplateConfig) {
         self.messageType = messageType
         self.usecase = usecase
+        self.messageTemplateConfig = config
     }
 }
 
@@ -42,6 +46,7 @@ extension PokeMessageTemplateViewModel {
             .withUnretained(self)
             .sink(receiveValue: { owner, _ in
                 owner.usecase.getPokeMessageTemplates(type: owner.messageType)
+                output.messageTemplateConfig.send(owner.messageTemplateConfig)
             }).store(in: cancelBag)
         
         return output

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
@@ -101,7 +101,7 @@ extension PokeMyFriendsViewModel {
             .store(in: cancelBag)
         
         useCase.myFriends
-            .sink { [weak self] myFriends in
+            .sink { [weak self] myFriends in                
                 self?.myFriends = myFriends
             }.store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeMyFriendsScene/ViewModel/PokeMyFriendsViewModel.swift
@@ -112,11 +112,12 @@ extension PokeMyFriendsViewModel {
               if let myFriends = owner.myFriends {
                 output.myFriends.send(myFriends)
               }
-              if user.isAnonymous {
-                if user.pokeNum == 5 || user.pokeNum == 6 || user.pokeNum == 11 || user.pokeNum == 12 {
-                  owner.onAnonymousFriendUpgrade?(user)
+                let isUpgrade = (user.pokeNum == 11 || user.pokeNum == 12) ||
+                                (user.isAnonymous && (user.pokeNum == 5 || user.pokeNum == 6))
+                
+                if isUpgrade {
+                    owner.onAnonymousFriendUpgrade?(user)
                 }
-              }
             }.store(in: cancelBag)
         
         useCase.pokedResponse

--- a/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
+++ b/SOPT-iOS/Projects/Features/PokeFeature/Sources/PokeNotificationScene/ViewModel/PokeNotificationViewModel.swift
@@ -107,10 +107,12 @@ extension PokeNotificationViewModel {
                   self?.onNewFriendAdded?(name)
                   return
                 }
-                if userModel.isAnonymous {
-                  if userModel.pokeNum == 5 || userModel.pokeNum == 6 || userModel.pokeNum == 11 || userModel.pokeNum == 12 {
+
+                let isUpgrade = (userModel.pokeNum == 11 || userModel.pokeNum == 12) ||
+                                (userModel.isAnonymous && (userModel.pokeNum == 5 || userModel.pokeNum == 6))
+                
+                if isUpgrade {
                     self?.onAnonymousFriendUpgrade?(userModel)
-                  }
                 }
             }).store(in: cancelBag)
         


### PR DESCRIPTION
## 🌴 PR 요약
콕찌르기 천생연분 맺어질 때 로띠가 나타나지 않는 문제와 UX 변경사항을 반영합니다.

🌱 작업한 브랜치
- feature/#871

## 🌱 PR Point
**변경 사항**
- 천생연분이 맺어진 후 상대의 프로필이 공개되는 애니메이션이 노출되는 경우는 상대방이 사용자에게 익명이나 실명으로 메세지를 보내왔을 경우 모두 해당 (기존에는 익명으로 보내왔을 시에만 노출되었음)
- 천생연분으로 넘어가는 찌르기 시(11~12번)에는 실명 콕찌르기 API 호출
- 천생연분이 맺어진 이후에는 익명 체크박스 UI 비활성화 및 토스트 노출
- 천생연분이 맺어지는 당시 로띠가 안 뜨는 문제 수정
- 익명 또는 프로필사진이 없는 경우 다른 프로필 이미지 적용

### 익명 체크박스 UI 비활성화
사용자가 **천생연분** 이거나 **단짝 -> 천생연분** 으로 넘어가는 단계(pokeNum >= 10)에서 PokeMessageBottomSheet 의 익명 체크박를 비활성화하고 토스트 메세지를 표시하도록 기획이 변경되었어요.
pokeNum 을 확인하려면 userModel 정보가 필요해서 PokeCoordinator 에서 pokeNum을 체크하고 `PokeBuilder->ViewModel`로 익명 체크 여부를 넘겨주도록 구현했습니다.

`PokeCoordinator`
```swift
    private func showMessageBottomSheet(userModel: PokeUserModel, on view: UIViewController?) -> AnyPublisher<(PokeUserModel, PokeMessageModel, isAnonymous: Bool), Never> {
        let messageType: PokeMessageType = userModel.isFirstMeet ? .pokeSomeone : .pokeFriend
        let messageTemplateConfig = PokeMessageTemplateConfig(isAnonymousSelectionAvailable: userModel.pokeNum < 10)
        
        guard let bottomSheet = self.factory
            .makePokeMessageTemplateBottomSheet(messageType: messageType, config: messageTemplateConfig)
            .vc
            .viewController as? PokeMessageTemplateBottomSheet
        else { return .empty() }
```

`PokeMessageTemplateBottomSheet`
```swift
        // messageTemplateConfig 상태에 따라서 체크박스 활성화 여부 설정
        output
            .messageTemplateConfig
            .asDriver()
            .sink { [weak self] messageTemplateConfig in
                self?.isAnonymousAvailable = messageTemplateConfig.isAnonymousSelectionAvailable
                self?.anonymousCheckboxButton.isEnabled = messageTemplateConfig.isAnonymousSelectionAvailable
                self?.anonymousCheckboxButton.isSelected = messageTemplateConfig.isAnonymousSelectionAvailable
            }
            .store(in: self.cancelBag)
```



## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #871 
