### PR TITLE
[Feat] #898 - 솝레터 작성 API 연동

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -503,7 +503,7 @@ public struct I18N {
         public static let charLimitError = "공백 포함 250자 이하로만 작성할 수 있어요."
         public static let submitButton = "작성 완료"
         public static let submitSuccess = "메시지 작성을 완료했어요."
-        public static let submitFailure = "실패했습니다"
+        public static let submitFailure = "일시적인 오류가 발생했어요."
         
         public static let topicTitle = "솝레터 주제"
     }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
@@ -20,6 +20,6 @@ public final class SoptletterRepository {
 
 extension SoptletterRepository: SoptletterRepositoryInterface {
     public func writeMessage(topicId: Int, content: String) async throws {
-        for try await _ in soptletterService.writeMessage(topicId: topicId, content: content).values { break }
+        try await soptletterService.writeMessage(topicId: topicId, content: content)
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
@@ -1,0 +1,25 @@
+//
+//  SoptletterRepository.swift
+//  Data
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Core
+import Domain
+import Networks
+
+public final class SoptletterRepository {
+    private let soptletterService: SoptletterService
+
+    public init(soptletterService: SoptletterService) {
+        self.soptletterService = soptletterService
+    }
+}
+
+extension SoptletterRepository: SoptletterRepositoryInterface {
+    public func writeMessage(topicId: Int, content: String) async throws {
+        for try await _ in soptletterService.writeMessage(topicId: topicId, content: content).values { break }
+    }
+}

--- a/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Dependency/RegisterDependencies.swift
@@ -248,5 +248,11 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: SoptletterRepositoryInterface.self,
+            implement: {
+                SoptletterRepository(soptletterService: DefaultSoptletterService.standard)
+            }
+        )
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Error/SoptletterError.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Error/SoptletterError.swift
@@ -1,0 +1,13 @@
+//
+//  SoptletterError.swift
+//  Domain
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+public enum SoptletterError: Error {
+    case invalidContent
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptletterRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptletterRepositoryInterface.swift
@@ -1,0 +1,11 @@
+//
+//  SoptletterRepositoryInterface.swift
+//  Domain
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+public protocol SoptletterRepositoryInterface {
+    func writeMessage(topicId: Int, content: String) async throws
+}

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
@@ -20,6 +20,9 @@ public final class DefaultSoptletterUseCase: SoptletterUseCase {
     }
 
     public func writeMessage(topicId: Int, content: String) async throws {
+        guard isWritable(content: content) else {
+            throw SoptletterError.invalidContent
+        }
         try await repository.writeMessage(topicId: topicId, content: content)
     }
 

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  SoptletterUseCase.swift
+//  Domain
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+public protocol SoptletterUseCase {
+    func writeMessage(topicId: Int, content: String) async throws
+    func isWritable(content: String) -> Bool
+}
+
+public final class DefaultSoptletterUseCase: SoptletterUseCase {
+    private let repository: SoptletterRepositoryInterface
+    private let maxCharCount = 250
+
+    public init(repository: SoptletterRepositoryInterface) {
+        self.repository = repository
+    }
+
+    public func writeMessage(topicId: Int, content: String) async throws {
+        try await repository.writeMessage(topicId: topicId, content: content)
+    }
+
+    public func isWritable(content: String) -> Bool {
+        return !content.isEmpty && content.count <= maxCharCount
+    }
+}

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterBuilder.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterBuilder.swift
@@ -7,20 +7,24 @@
 //
 
 import Core
+import Domain
 import BaseFeatureDependency
 @_exported import SoptletterFeatureInterface
 
 public final class SoptletterBuilder {
+    @Injected public var soptletterRepository: SoptletterRepositoryInterface
+
     public init() {}
 }
 
 extension SoptletterBuilder: SoptletterFeatureBuildable {
     public func makeSoptletterWritingVC(coordinator: Coordinator) -> SoptletterWritingPresentable {
-        let viewModel = SoptletterWritingViewModel(coordinator: coordinator)
+        let useCase = DefaultSoptletterUseCase(repository: soptletterRepository)
+        let viewModel = SoptletterWritingViewModel(coordinator: coordinator, useCase: useCase)
         let soptletterWritingVC = SoptletterWritingVC(viewModel: viewModel)
         return (soptletterWritingVC, viewModel)
     }
-    
+
     public func makeSelectTopicVC(coordinator: Coordinator) -> SelectTopicPresentable {
         let vc = SelectTopicVC()
         return vc

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
@@ -79,12 +79,17 @@ extension SoptletterWritingViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.submitTask?.cancel()
+                let submittedText = currentText
+                output.isSubmitEnabled.send(false)
                 owner.submitTask = Task {
                     do {
-                        try await owner.useCase.writeMessage(topicId: owner.topicId, content: currentText)
+                        try await owner.useCase.writeMessage(topicId: owner.topicId, content: submittedText)
                         await MainActor.run { owner.onSubmitSuccess?() }
+                    } catch is CancellationError {
+                        return
                     } catch {
                         await MainActor.run {
+                            output.isSubmitEnabled.send(owner.useCase.isWritable(content: currentText))
                             ToastUtils.showMDSToast(type: .alert, text: I18N.Soptletter.submitFailure)
                         }
                     }

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterScene/ViewModel/SoptletterWritingViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import Combine
 
 import Core
+import Domain
 import BaseFeatureDependency
 import SoptletterFeatureInterface
 
@@ -23,8 +24,11 @@ public final class SoptletterWritingViewModel: SoptletterWritingViewModelType {
     // MARK: - Properties
 
     private let coordinator: AnyCoordinatorObject
+    private let useCase: SoptletterUseCase
     private var cancelBag = CancelBag()
-    private let maxCharCount = 250
+    private var submitTask: Task<Void, Never>?
+    // TODO: 주제 선정 화면 연동 시 실제 topicId로 교체
+    private let topicId = 1
 
     // MARK: - Inputs
 
@@ -43,14 +47,20 @@ public final class SoptletterWritingViewModel: SoptletterWritingViewModelType {
 
     // MARK: - Init
 
-    public init(coordinator: Coordinator) {
+    public init(coordinator: Coordinator, useCase: SoptletterUseCase) {
         self.coordinator = coordinator
+        self.useCase = useCase
+    }
+
+    deinit {
+        submitTask?.cancel()
     }
 }
 
 extension SoptletterWritingViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
         let output = Output()
+        var currentText = ""
 
         input.naviBackTap
             .withUnretained(self)
@@ -61,14 +71,24 @@ extension SoptletterWritingViewModel {
         input.textChanged
             .withUnretained(self)
             .sink { owner, text in
-                output.isSubmitEnabled.send(!text.isEmpty && text.count <= owner.maxCharCount)
+                currentText = text
+                output.isSubmitEnabled.send(owner.useCase.isWritable(content: text))
             }.store(in: cancelBag)
 
         input.submitTap
             .withUnretained(self)
             .sink { owner, _ in
-                // TODO: 실제 서버 연동 시 교체
-                owner.onSubmitSuccess?()
+                owner.submitTask?.cancel()
+                owner.submitTask = Task {
+                    do {
+                        try await owner.useCase.writeMessage(topicId: owner.topicId, content: currentText)
+                        await MainActor.run { owner.onSubmitSuccess?() }
+                    } catch {
+                        await MainActor.run {
+                            ToastUtils.showMDSToast(type: .alert, text: I18N.Soptletter.submitFailure)
+                        }
+                    }
+                }
             }.store(in: cancelBag)
 
         return output

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/SoptletterAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/SoptletterAPI.swift
@@ -1,0 +1,40 @@
+//
+//  SoptletterAPI.swift
+//  Networks
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Moya
+
+public enum SoptletterAPI {
+    case writeMessage(topicId: Int, content: String)
+}
+
+extension SoptletterAPI: BaseAPI {
+    public static var apiType: APIType = .soptletter
+
+    public var path: String {
+        switch self {
+        case .writeMessage(let topicId, _):
+            return "/topics/\(topicId)/messages"
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .writeMessage:
+            return .post
+        }
+    }
+
+    public var task: Moya.Task {
+        switch self {
+        case .writeMessage(_, let content):
+            return .requestParameters(parameters: ["content": content], encoding: JSONEncoding.default)
+        }
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseAPI.swift
@@ -30,6 +30,7 @@ public enum APIType {
     case home
     case calendar
     case appjamRank
+    case soptletter
 }
 
 public protocol BaseAPI: TargetType, AccessTokenAuthorizable {
@@ -88,6 +89,8 @@ extension BaseAPI {
             base += "/calendar"
         case .appjamRank:
             base += "/appjamrank"
+        case .soptletter:
+            base += "/sopt-letter"
         }
         
         guard let url = URL(string: base) else {

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Foundation/BaseService.swift
@@ -341,4 +341,32 @@ extension BaseService {
             self.cancellable = cancellable
         }
     }
+
+    func requestObjectAsyncNoResult(_ target: API) async throws -> Int {
+        try await withUnsafeThrowingContinuation { [weak self] continuation in
+            guard let self else {
+                continuation.resume(throwing: CancellationError())
+                return
+            }
+            let cancellable = self.provider.request(target) { response in
+                defer { self.cancellable = nil }
+
+                switch response {
+                case .success(let value):
+                    continuation.resume(returning: value.statusCode)
+                case .failure(let error):
+                    if case MoyaError.underlying(let error, _) = error,
+                       case AFError.requestRetryFailed(let retryError, _) = error,
+                       let retryError = retryError as? APIError,
+                       retryError == APIError.tokenReissuanceFailed {
+                        continuation.resume(throwing: retryError)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+
+            self.cancellable = cancellable
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
@@ -7,18 +7,17 @@
 //
 
 import Foundation
-import Combine
 
 import Moya
 
 public typealias DefaultSoptletterService = BaseService<SoptletterAPI>
 
 public protocol SoptletterService {
-    func writeMessage(topicId: Int, content: String) -> AnyPublisher<Int, Error>
+    func writeMessage(topicId: Int, content: String) async throws
 }
 
 extension DefaultSoptletterService: SoptletterService {
-    public func writeMessage(topicId: Int, content: String) -> AnyPublisher<Int, Error> {
-        requestObjectInCombineNoResult(.writeMessage(topicId: topicId, content: content))
+    public func writeMessage(topicId: Int, content: String) async throws {
+        _ = try await requestObjectAsyncNoResult(.writeMessage(topicId: topicId, content: content))
     }
 }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
@@ -1,0 +1,24 @@
+//
+//  SoptletterService.swift
+//  Networks
+//
+//  Created by 강윤서 on 6/28/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Moya
+
+public typealias DefaultSoptletterService = BaseService<SoptletterAPI>
+
+public protocol SoptletterService {
+    func writeMessage(topicId: Int, content: String) -> AnyPublisher<Int, Error>
+}
+
+extension DefaultSoptletterService: SoptletterService {
+    public func writeMessage(topicId: Int, content: String) -> AnyPublisher<Int, Error> {
+        requestObjectInCombineNoResult(.writeMessage(topicId: topicId, content: content))
+    }
+}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Dependency/RegisterDependencies.swift
@@ -247,5 +247,11 @@ extension AppDelegate {
                 )
             }
         )
+        container.register(
+            interface: SoptletterRepositoryInterface.self,
+            implement: {
+                SoptletterRepository(soptletterService: DefaultSoptletterService.standard)
+            }
+        )
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
솝레터 작성 API(`POST /sopt-letter/topics/{topicId}/messages`)를 연동했습니다.

🌱 작업한 브랜치
- feat/#898

## 🌱 PR Point

### **isWritable을 UseCase로 옮긴 이유**
처음엔 250자 초과 시 버튼 비활성화 처리를 ViewModel에서 하고 있었는데, 이건 UI 로직이 아니라 비즈니스 규칙이라고 판단했어요. `"솝레터는 250자까지만 작성 가능하다"`는 도메인 규칙이기 때문에, UseCase가 이 기준을 단일 진실 공급원으로 관리하도록 옮겼습니다. `ViewModel`은 `UseCase`에 물어보기만 하면 되고, 나중에 **글자 수 제한이 바뀌어도 UseCase 한 곳만 수정하면 됩니다.**
(리뷰 반영: `writeMessage` 내부에서도 `isWritable`을 다시 검증해, UseCase가 검증의 최종 방어선이 되도록 했습니다. 실패 시 `SoptletterError.invalidContent`를 던집니다.)

### **response를 디코딩하지 않은 이유**
API 응답 body(`{ messageId, topicId, ... }`)가 있긴 하지만, 작성 완료 후에는 솝레터 메인뷰로 돌아가면서 목록을 새로 fetch할 예정이라 당장 사용할 데이터가 없어요. 그래서 status code만 확인하고 Entity/DTO 없이 처리했습니다.
(리뷰 반영: 기존엔 `requestObjectInCombineNoResult`(Combine)로 처리했는데, `BaseService`에 기존 `requestObjectAsync`와 동일한 패턴의 `requestObjectAsyncNoResult`(async/await, 디코딩 없이 status code만 반환)를 추가해 이걸 쓰도록 교체했습니다.)

### **async/await + Task 패턴**
`Combine flatMap` 대신 `async-await`를 사용했습니다. ~~`Repository`에서 `Combine Publisher`를 `for try await _ in publisher.values { break }` 로 브릿징해서 상위 레이어는 전부 `async/await`로 통일했고~~ → 리뷰 반영 후 `Service`/`Repository` 모두 async/await 기반 `requestObjectAsyncNoResult`를 직접 호출하도록 바꿔서, Combine 브릿징 자체가 필요 없어졌습니다. 에러 핸들링도 `do-catch`로 명확하게 처리했습니다.

## ✅ 코드리뷰 반영 (04130689)
### **도메인 계층 검증 강제**
`SoptletterUseCase.writeMessage`에서 `isWritable(content:)`를 확인하고, 실패 시 `SoptletterError.invalidContent`를 던지도록 수정했습니다.
### **취소된 요청 처리**
`catch is CancellationError { return }`을 추가해 의도된 취소(중복 탭, 화면 이탈)에는 실패 토스트가 뜨지 않도록 했습니다.
### **submit 시점 텍스트 고정**
`Task` 생성 전에 `let submittedText = currentText`로 스냅샷해서 넘기도록 수정했습니다.
### **중복 제출 방지**
제출 버튼이 텍스트 유효성만 반영하고 요청 중에는 비활성화되지 않아 연속 탭 시 중복 전송 위험이 있었습니다. 제출 시작 시 `isSubmitEnabled`를 `false`로 내리고, 실패 시에만 다시 활성화하도록 했습니다.
### **`for try await ... { break }` 개선**
`requestObjectInCombineNoResult`(Combine) 대신 async/await 기반 `requestObjectAsyncNoResult`를 추가해 `SoptletterService`/`SoptletterRepository`가 Combine 없이 동작하도록 전환했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### **topicId 하드코딩**
주제 선정 화면 및 메인 화면 연동 전이라 임시로 1로 고정해뒀습니다. `// TODO` 주석으로 표시해뒀어요.

### 화면전환
솝트로그에서 이동하는 로직은 스크린샷을 위한 코드로 PR에 포함하지 않았습니다.

## 📸 스크린샷
https://github.com/user-attachments/assets/98266ba7-d256-42d0-9367-a3addcce20a9



## 📮 관련 이슈
- Resolved: #898
