### PR TITLE
[Fix] #906 - 한마디 편집 뷰 Figma 스펙 반영

### DIFF
--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
@@ -155,7 +155,7 @@ extension SentenceEditVC {
 
 extension SentenceEditVC: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        return text != "\n"
+        return !text.contains("\n")
     }
 
     public func textViewDidBeginEditing(_ textView: UITextView) {

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageSubScene/SentenceEditScene/SentenceEditVC.swift
@@ -37,17 +37,18 @@ public class SentenceEditVC: UIViewController, LegacySentenceEditViewControllabl
     private lazy var textView: UITextView = {
         let tv = UITextView()
         tv.backgroundColor = DSKitAsset.Colors.black80.color
-        tv.textColor = DSKitAsset.Colors.white.color
+        tv.textColor = DSKitAsset.Colors.gray60.color
         tv.font = DSKitFontFamily.Pretendard.medium.font(size: 16)
-        tv.layer.cornerRadius = 9.adjustedH
+        tv.layer.cornerRadius = 12.adjustedH
         tv.layer.borderWidth = 1.adjustedH
         tv.isEditable = true
-        tv.textContainerInset = UIEdgeInsets(top: 13, left: 16, bottom: 13, right: 16)
+        tv.textContainerInset = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
         tv.delegate = self
         return tv
     }()
-    
+
     private let saveButton = AppCustomButton(title: I18N.Setting.SentenceEdit.save)
+        .setConfigForState(disabledColor: DSKitAsset.Colors.black40.color)
         .setEnabled(false)
     
     // MARK: - View Life Cycle
@@ -137,13 +138,13 @@ extension SentenceEditVC {
         }
         
         textView.snp.makeConstraints { make in
-            make.top.equalTo(naviBar.snp.bottom).offset(8.adjustedH)
+            make.top.equalTo(naviBar.snp.bottom).offset(16.adjustedH)
             make.leading.trailing.equalToSuperview().inset(20.adjusted)
-            make.height.equalTo(64.adjustedH)
+            make.height.equalTo(72.adjustedH)
         }
-        
+
         saveButton.snp.makeConstraints { make in
-            make.top.equalTo(textView.snp.bottom).offset(32.adjustedH)
+            make.top.equalTo(textView.snp.bottom).offset(44.adjustedH)
             make.leading.trailing.equalToSuperview().inset(20.adjusted)
             make.height.equalTo(56.adjustedH)
         }
@@ -154,19 +155,18 @@ extension SentenceEditVC {
 
 extension SentenceEditVC: UITextViewDelegate {
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        guard text != "\n" else { return false }
-        guard let str = textView.text else { return true }
-        let newLength = str.count + text.count - range.length
-        return newLength <= 42
+        return text != "\n"
     }
-    
+
     public func textViewDidBeginEditing(_ textView: UITextView) {
         textView.layer.borderColor = DSKitAsset.Colors.white.color.cgColor
         textView.backgroundColor = DSKitAsset.Colors.black100.color
+        textView.textColor = DSKitAsset.Colors.white.color
     }
-    
+
     public func textViewDidEndEditing(_ textView: UITextView) {
         textView.backgroundColor = DSKitAsset.Colors.black80.color
         textView.layer.borderColor = nil
+        textView.textColor = DSKitAsset.Colors.gray60.color
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
한 마디 편집 화면의 변경된 UI를 반영했습니다.

🌱 작업한 브랜치
- fix/#906

## 🌱 PR Point
- 텍스트뷰 글자수 제한 제거 (42자   글자수 제한 없음)
- 텍스트 색상이 focus 상태와 무관하게 항상 흰색으로 고정되어 있던 버그 수정 → `active(흰색)`/`inactive(gray60)`로 토글되도록 변경
- 텍스트뷰 높이(64→72), cornerRadius(9→12), textContainerInset(13/16→16/20), 네비바와의 간격(8→16), 저장 버튼과의 간격(32→44)을 Figma 수치에 맞게 보정
- 저장 버튼 비활성 배경색을 스펙에 맞는 black40으로 변경 (기존 gray600)

## 📌 참고 사항
`shouldChangeTextIn`에서 `text != "\n"` → `!text.contains("\n")`으로 수정했습니다.

기존 코드는 입력된 텍스트가 정확히 개행 한 글자일 때만 차단해서, 클립보드 붙여넣기와 같이 여러 줄이 포함된 문자열은 조건을 통과해 개행이 그대로 삽입되는 문제가 있었습니다. 따라서 `contains` 검사로 변경해 한 줄 입력을 보장하도록 했습니다.

## 📸 스크린샷

https://github.com/user-attachments/assets/61299427-8668-4fad-a865-5d0af40790b2


## 📮 관련 이슈
- Resolved: #906