### PR TITLE
[Feat] #902 - 마이페이지 프로필/솝트로그 API 연동

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -411,6 +411,8 @@ public struct I18N {
             public static let login = "로그인"
         }
         
+        public static let fetchErrorToast = "잠시 문제가 발생했습니다. 다시 시도해주세요"
+
         public static let resetMissionTitle = "미션을 초기화 하실건가요?"
         public static let resetMissionDescription = "사진, 메모가 삭제되고\n 전체 미션이 미완료상태로 초기화됩니다."
         public static let reset = "초기화"

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
@@ -11,7 +11,10 @@ import Combine
 import Core
 import Domain
 import Networks
- 
+
+import SafariServices
+import WebKit
+
 public final class AppMyPageRepository {
     private let stampService: StampService
     private let userService: UserService
@@ -51,5 +54,11 @@ extension AppMyPageRepository: AppMyPageRepositoryInterface {
 
     public func fetchSoptlogPreview() async throws -> SoptlogModel {
         try await userService.fetchSoptlogInfo().toDomain()
+    }
+
+    public func logout() {
+        UserDefaultKeyList.clearUserData()
+        SFSafariViewController.DataStore.default.clearWebsiteData()
+        WKWebsiteDataStore.default().httpCookieStore.getAllCookies({ _ in })
     }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/AppMyPageRepository.swift
@@ -40,4 +40,16 @@ extension AppMyPageRepository: AppMyPageRepositoryInterface {
             }
             .eraseToAnyPublisher()
     }
+
+    public func fetchUserMainInfo() async throws -> UserMainInfoModel {
+        let entity = try await userService.getUserMainInfoAsync()
+        guard let model = entity.toDomain() else {
+            throw MainError.networkError(message: "프로필 정보를 불러올 수 없습니다")
+        }
+        return model
+    }
+
+    public func fetchSoptlogPreview() async throws -> SoptlogModel {
+        try await userService.fetchSoptlogInfo().toDomain()
+    }
 }

--- a/SOPT-iOS/Projects/Data/Sources/Transform/MainTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/MainTransform.swift
@@ -14,6 +14,6 @@ import Networks
 extension MainEntity {
     public func toDomain() -> UserMainInfoModel? {
         guard let user = user, !user.name.isEmpty else { return nil }
-        return UserMainInfoModel.init(status: user.status, name: user.name, profileImage: user.profileImage, historyList: user.historyList, attendanceScore: operation?.attendanceScore, announcement: operation?.announcement, isAllConfirm: isAllConfirm)
+        return UserMainInfoModel.init(status: user.status, name: user.name, part: user.part, profileImage: user.profileImage, historyList: user.historyList, attendanceScore: operation?.attendanceScore, announcement: operation?.announcement, isAllConfirm: isAllConfirm)
     }
 }

--- a/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/UserMainInfoModel.swift
@@ -11,13 +11,13 @@ import Foundation
 import Core
 
 public struct UserMainInfoModel: Equatable {
-    public let status, name: String
+    public let status, name, part: String
     public let profileImage: String?
     public let historyList: [Int]
     public let attendanceScore: Float?
     public let announcement: String?
     public let isAllConfirm: Bool?
-    
+
     public var userType: UserType {
         switch status {
         case UserType.active.rawValue:
@@ -28,10 +28,11 @@ public struct UserMainInfoModel: Equatable {
             return .visitor
         }
     }
-    
-    public init(status: String, name: String, profileImage: String?, historyList: [Int], attendanceScore: Float?, announcement: String?, isAllConfirm: Bool?) {
+
+    public init(status: String, name: String, part: String, profileImage: String?, historyList: [Int], attendanceScore: Float?, announcement: String?, isAllConfirm: Bool?) {
         self.status = status
         self.name = name
+        self.part = part
         self.profileImage = profileImage
         self.historyList = historyList
         self.attendanceScore = attendanceScore

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
@@ -13,4 +13,6 @@ import Core
 public protocol AppMyPageRepositoryInterface {
     func resetStamp() -> Driver<Bool>
     func deregisterPushToken(with token: String) -> AnyPublisher<Bool, Error>
+    func fetchUserMainInfo() async throws -> UserMainInfoModel
+    func fetchSoptlogPreview() async throws -> SoptlogModel
 }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/AppMyPageRepositoryInterface.swift
@@ -15,4 +15,5 @@ public protocol AppMyPageRepositoryInterface {
     func deregisterPushToken(with token: String) -> AnyPublisher<Bool, Error>
     func fetchUserMainInfo() async throws -> UserMainInfoModel
     func fetchSoptlogPreview() async throws -> SoptlogModel
+    func logout()
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
@@ -13,7 +13,9 @@ import Combine
 public protocol AppMyPageUseCase {
     func resetStamp()
     func deregisterPushToken()
-    
+    func fetchUserMainInfo() async throws -> UserMainInfoModel
+    func fetchSoptlogPreview() async throws -> SoptlogModel
+
     var resetSuccess: PassthroughSubject<Bool, Error> { get }
     var deregisterPushTokenSuccess: PassthroughSubject<Bool, Never> { get }
 }
@@ -32,6 +34,14 @@ public final class DefaultAppMyPageUseCase {
 }
 
 extension DefaultAppMyPageUseCase: AppMyPageUseCase {
+    public func fetchUserMainInfo() async throws -> UserMainInfoModel {
+        try await repository.fetchUserMainInfo()
+    }
+
+    public func fetchSoptlogPreview() async throws -> SoptlogModel {
+        try await repository.fetchSoptlogPreview()
+    }
+
     public func resetStamp() {
         self.repository
             .resetStamp()

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/AppMyPageUseCase.swift
@@ -15,6 +15,7 @@ public protocol AppMyPageUseCase {
     func deregisterPushToken()
     func fetchUserMainInfo() async throws -> UserMainInfoModel
     func fetchSoptlogPreview() async throws -> SoptlogModel
+    func logout()
 
     var resetSuccess: PassthroughSubject<Bool, Error> { get }
     var deregisterPushTokenSuccess: PassthroughSubject<Bool, Never> { get }
@@ -60,5 +61,9 @@ extension DefaultAppMyPageUseCase: AppMyPageUseCase {
             }.sink { [weak self] didSucceed in
                 self?.deregisterPushTokenSuccess.send(didSucceed)
             }.store(in: self.cancelBag)
+    }
+
+    public func logout() {
+        repository.logout()
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Interface/Sources/MyPage/MyPagePresentable.swift
@@ -21,7 +21,8 @@ public protocol MyPageRoutingTrigger {
     var onShowLogin: (() -> Void)? { get set }
     var onShowLogout: (() -> Void)? { get set }
     var onAlertButtonTap: ((String) -> Void)? { get set }
-    var onResetSoptampTap: (() -> Void)? { get set }
+    var onResetSoptampTap: ((@escaping () -> Void) -> Void)? { get set }
+    var onLogoutTap: ((@escaping () -> Void) -> Void)? { get set }
     var onShowSoptlog: (() -> Void)? { get set }
     var onEditProfileTap: (() -> Void)? { get set }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
@@ -27,6 +27,7 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     private let isAppjamtampOpen: Bool = false
     private var dataSource: UICollectionViewDiffableDataSource<MyPageSectionLayoutKind, MyPageItem>! = nil
     private var cellTapped = PassthroughSubject<MyPageItem, Never>()
+    private var refreshTriggered = PassthroughSubject<Void, Never>()
     private let cancelBag = CancelBag()
 
     private var userProfileData: MyPageProfilePresentationModel?
@@ -51,6 +52,8 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
         $0.contentInset.bottom = 36 // 마지막 섹션 자체 bottom inset(32) + 36 = 탭바까지 68pt
     }
 
+    private let refreshControl = UIRefreshControl()
+
     // MARK: - Life Cycle
 
     public override func viewDidLoad() {
@@ -62,6 +65,8 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
         setDataSource()
         applySnapshot()
         bindViewModels()
+        refreshControl.addTarget(self, action: #selector(handleRefresh), for: .valueChanged)
+        collectionView.refreshControl = refreshControl
     }
 
     public init(userType: UserType, viewModel: AppMyPageViewModel) {
@@ -198,8 +203,10 @@ extension AppMyPageVC: UICollectionViewDelegate {
 extension AppMyPageVC {
     private func bindViewModels() {
         let input = AppMyPageViewModel.Input(
+            viewDidLoad: Driver.just(()),
             naviBackButtonTapped: navigationBar.leftButtonTapped.asDriver(),
-            cellTapped: cellTapped.asDriver()
+            cellTapped: cellTapped.asDriver(),
+            refreshTriggered: refreshTriggered.asDriver()
         )
 
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
@@ -226,6 +233,24 @@ extension AppMyPageVC {
                 owner.soptlogData = soptlog
                 owner.reconfigureItems(in: .soptlogPreview)
             }.store(in: cancelBag)
+
+        output.fetchError
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, _ in
+                Toast.show(message: I18N.MyPage.fetchErrorToast, view: owner.view)
+            }.store(in: cancelBag)
+
+        output.fetchCompleted
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, _ in
+                owner.refreshControl.endRefreshing()
+            }.store(in: cancelBag)
+    }
+
+    @objc private func handleRefresh() {
+        refreshTriggered.send()
     }
 
     private func reconfigureItems(in section: MyPageSectionLayoutKind) {

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/AppMyPageVC.swift
@@ -29,6 +29,9 @@ public final class AppMyPageVC: UIViewController, MyPageViewControllable {
     private var cellTapped = PassthroughSubject<MyPageItem, Never>()
     private let cancelBag = CancelBag()
 
+    private var userProfileData: MyPageProfilePresentationModel?
+    private var soptlogData: MyPageSoptlogPreviewPresentationModel?
+
     // MARK: - UI Components
 
     private lazy var navigationBar = OPNavigationBar(
@@ -104,18 +107,24 @@ extension AppMyPageVC {
         let myPageMenuRegistration = createMyPageeCellRegistration()
 
         let profileRegistration: MyPageProfileCellRegistration = collectionView.createCellRegistration { [weak self] cell, _, item in
-            cell.configure(name: "홍길동", part: "iOS파트", profileImageURL: nil)
+            guard let self else { return }
+            cell.configure(
+                name: self.userProfileData?.name ?? "",
+                part: self.userProfileData?.part ?? "",
+                profileImageURL: self.userProfileData?.profileImageURL
+            )
             cell.onEditProfileTap = { [weak self] in
                 self?.cellTapped.send(item)
             }
         }
 
-        let soptlogStatRegistration: MyPageSoptlogStatCellRegistration = collectionView.createCellRegistration { cell, _, item in
+        let soptlogStatRegistration: MyPageSoptlogStatCellRegistration = collectionView.createCellRegistration { [weak self] cell, _, item in
+            guard let self else { return }
             switch item.type {
             case .soptlogSoptampPreview:
-                cell.configure(icon: DSKitAsset.Assets.icThumb.image, iconSize: 21, title: I18N.Soptlog.soptamp, count: 0)
+                cell.configure(icon: DSKitAsset.Assets.icThumb.image, iconSize: 21, title: I18N.Soptlog.soptamp, count: self.soptlogData?.soptampCount ?? 0)
             case .soptlogPokePreview:
-                cell.configure(icon: DSKitAsset.Assets.icPokeFilled.image.withRenderingMode(.alwaysTemplate), iconSize: 24, title: I18N.Soptlog.poke, count: 0)
+                cell.configure(icon: DSKitAsset.Assets.icPokeFilled.image.withRenderingMode(.alwaysTemplate), iconSize: 24, title: I18N.Soptlog.poke, count: self.soptlogData?.totalPokeCount ?? 0)
             default:
                 break
             }
@@ -201,5 +210,28 @@ extension AppMyPageVC {
             .sink { owner, _ in
                 Toast.show(message: I18N.MyPage.resetSuccess, view: owner.view)
             }.store(in: self.cancelBag)
+
+        output.userProfile
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, profile in
+                owner.userProfileData = profile
+                owner.reconfigureItems(in: .profile)
+            }.store(in: cancelBag)
+
+        output.soptlogPreview
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, soptlog in
+                owner.soptlogData = soptlog
+                owner.reconfigureItems(in: .soptlogPreview)
+            }.store(in: cancelBag)
+    }
+
+    private func reconfigureItems(in section: MyPageSectionLayoutKind) {
+        var snapshot = dataSource.snapshot()
+        guard snapshot.sectionIdentifiers.contains(section) else { return }
+        snapshot.reconfigureItems(snapshot.itemIdentifiers(inSection: section))
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Cells/MyPageProfileCVC.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Cells/MyPageProfileCVC.swift
@@ -117,7 +117,10 @@ extension MyPageProfileCVC {
         nameLabel.attributedText = name.applyMDSFont(mdsFont: .heading5, color: DSKitAsset.Colors.white.color)
         partLabel.attributedText = part.applyMDSFont(mdsFont: .label4, color: DSKitAsset.Colors.gray100.color)
 
-        // TODO: 이미지 로딩 라이브러리 연동 시 profileImageURL로 실제 프로필 이미지 로드하도록 교체
-        profileImageView.image = DSKitAsset.Assets.icDefaultProfile.image
+        guard let profileImageURL else {
+            profileImageView.image = DSKitAsset.Assets.icDefaultProfile.image
+            return
+        }
+        profileImageView.setImage(with: profileImageURL, placeholder: DSKitAsset.Assets.icDefaultProfile.image)
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
@@ -1,0 +1,35 @@
+//
+//  MyPagePresentationModel.swift
+//  AppMyPageFeature
+//
+//  Created by 강윤서 on 2026/07/04.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Foundation
+
+import Domain
+
+struct MyPageProfilePresentationModel {
+    let name: String
+    let part: String
+    let profileImageURL: String?
+}
+
+struct MyPageSoptlogPreviewPresentationModel {
+    let soptampCount: Int
+    let totalPokeCount: Int
+}
+
+extension UserMainInfoModel {
+    func toPresentation() -> MyPageProfilePresentationModel {
+        let generation = historyList.last.map { "\($0)기" } ?? ""
+        return MyPageProfilePresentationModel(name: name, part: generation, profileImageURL: profileImage)
+    }
+}
+
+extension SoptlogModel {
+    func toPresentation() -> MyPageSoptlogPreviewPresentationModel {
+        MyPageSoptlogPreviewPresentationModel(soptampCount: soptampCount ?? 0, totalPokeCount: totalPokeCount)
+    }
+}

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
@@ -23,8 +23,7 @@ struct MyPageSoptlogPreviewPresentationModel {
 
 extension UserMainInfoModel {
     func toPresentation() -> MyPageProfilePresentationModel {
-        // part는 API 미제공 필드라 우선 숨김 처리 (별도 이슈에서 연동 예정)
-        MyPageProfilePresentationModel(name: name, part: "", profileImageURL: profileImage)
+        MyPageProfilePresentationModel(name: name, part: part, profileImageURL: profileImage)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/Model/MyPagePresentationModel.swift
@@ -23,8 +23,8 @@ struct MyPageSoptlogPreviewPresentationModel {
 
 extension UserMainInfoModel {
     func toPresentation() -> MyPageProfilePresentationModel {
-        let generation = historyList.last.map { "\($0)기" } ?? ""
-        return MyPageProfilePresentationModel(name: name, part: generation, profileImageURL: profileImage)
+        // part는 API 미제공 필드라 우선 숨김 처리 (별도 이슈에서 연동 예정)
+        MyPageProfilePresentationModel(name: name, part: "", profileImageURL: profileImage)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -41,10 +41,12 @@ public final class AppMyPageViewModel: MyPageViewModelType {
     // MARK: - Inputs
     
     public struct Input {
+        let viewDidLoad: Driver<Void>
         let naviBackButtonTapped: Driver<Void>
         let cellTapped: Driver<MyPageItem>
+        let refreshTriggered: Driver<Void>
     }
-    
+
     // MARK: - Outputs
 
     public struct Output {
@@ -52,6 +54,8 @@ public final class AppMyPageViewModel: MyPageViewModelType {
         let deregisterPushTokenSuccess = PassthroughSubject<Bool, Never>()
         let userProfile = PassthroughSubject<MyPageProfilePresentationModel, Never>()
         let soptlogPreview = PassthroughSubject<MyPageSoptlogPreviewPresentationModel, Never>()
+        let fetchError = PassthroughSubject<Void, Never>()
+        let fetchCompleted = PassthroughSubject<Void, Never>()
     }
     
     // MARK: - init
@@ -67,15 +71,12 @@ extension AppMyPageViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
-        if userType != .visitor {
-            Task { [weak self] in
-                guard let self else { return }
-                async let profileResult = self.useCase.fetchUserMainInfo()
-                async let soptlogResult = self.useCase.fetchSoptlogPreview()
-                if let profile = try? await profileResult { output.userProfile.send(profile.toPresentation()) }
-                if let soptlog = try? await soptlogResult { output.soptlogPreview.send(soptlog.toPresentation()) }
-            }
-        }
+        Publishers.Merge(input.viewDidLoad, input.refreshTriggered)
+            .withUnretained(self)
+            .sink { owner, _ in
+                guard owner.userType != .visitor else { return }
+                owner.fetchProfileData(output: output)
+            }.store(in: cancelBag)
 
         input.naviBackButtonTapped
             .withUnretained(self)
@@ -180,5 +181,18 @@ extension AppMyPageViewModel {
             },
             animated: true
         )
+    }
+
+    private func fetchProfileData(output: Output) {
+        Task { [weak self] in
+            guard let self else { return }
+            defer { output.fetchCompleted.send(()) }
+            async let profileTask = useCase.fetchUserMainInfo()
+            async let soptlogTask = useCase.fetchSoptlogPreview()
+            var hasError = false
+            if let profile = try? await profileTask { output.userProfile.send(profile.toPresentation()) } else { hasError = true }
+            if let soptlog = try? await soptlogTask { output.soptlogPreview.send(soptlog.toPresentation()) } else { hasError = true }
+            if hasError { output.fetchError.send(()) }
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -9,7 +9,6 @@
 import UIKit
 import Foundation
 import Combine
-import SafariServices
 
 import Core
 import Domain
@@ -28,7 +27,8 @@ public final class AppMyPageViewModel: MyPageViewModelType {
     public var onShowLogin: (() -> Void)?
     public var onShowLogout: (() -> Void)?
     public var onAlertButtonTap: ((String) -> Void)?
-    public var onResetSoptampTap: (() -> Void)?
+    public var onResetSoptampTap: ((@escaping () -> Void) -> Void)?
+    public var onLogoutTap: ((@escaping () -> Void) -> Void)?
     public var onShowSoptlog: (() -> Void)?
     public var onEditProfileTap: (() -> Void)?
     
@@ -111,7 +111,7 @@ extension AppMyPageViewModel {
             .withUnretained(self)
             .sink { owner, success in
                 if success {
-                    owner.logout()
+                    owner.useCase.logout()
                     owner.onShowLogin?()
                 }
             }.store(in: cancelBag)
@@ -136,53 +136,23 @@ extension AppMyPageViewModel {
         case .editOnelineSentence:
             self.onEditOnelineSentenceItemTap?()
         case .resetStamp:
-            self.showResetSoptampAlert()
+            self.onResetSoptampTap?({ [weak self] in
+                self?.useCase.resetStamp()
+            })
         case .withdrawal:
             self.onWithdrawalItemTap?(userType)
         case .logout:
-            self.showLogoutAlert()
+            self.onLogoutTap?({ [weak self] in
+                self?.useCase.deregisterPushToken()
+                self?.onShowLogout?()
+            })
         case .login:
             self.onShowLogin?()
         }
     }
 }
-import WebKit
-extension AppMyPageViewModel {
-    private func logout() {
-        UserDefaultKeyList.clearUserData()
-        SFSafariViewController.DataStore.default.clearWebsiteData()
-        WKWebsiteDataStore.default().httpCookieStore.getAllCookies({_ in  })
-    }
-    
-    private func showResetSoptampAlert() {
-        AlertUtils.presentAlertVC(
-            type: .titleDescription,
-            theme: .main,
-            title: I18N.MyPage.resetMissionTitle,
-            description: I18N.MyPage.resetMissionDescription,
-            customButtonTitle: I18N.MyPage.reset,
-            customAction: { [weak self] in
-                self?.useCase.resetStamp()
-            },
-            animated: true
-        )
-    }
-    
-    private func showLogoutAlert() {
-        AlertUtils.presentAlertVC(
-            type: .titleDescription,
-            theme: .main,
-            title: I18N.MyPage.logoutDialogTitle,
-            description: I18N.MyPage.logoutDialogDescription,
-            customButtonTitle: I18N.MyPage.logoutDialogGrantButtonTitle,
-            customAction: { [weak self] in
-                self?.useCase.deregisterPushToken()
-                self?.onShowLogout?()
-            },
-            animated: true
-        )
-    }
 
+extension AppMyPageViewModel {
     private func fetchProfileData(output: Output) {
         Task { [weak self] in
             guard let self else { return }

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/AppMypageScene/ViewModel/AppMyPageViewModel.swift
@@ -46,10 +46,12 @@ public final class AppMyPageViewModel: MyPageViewModelType {
     }
     
     // MARK: - Outputs
-    
+
     public struct Output {
         let resetSuccessed = PassthroughSubject<Bool, Never>()
         let deregisterPushTokenSuccess = PassthroughSubject<Bool, Never>()
+        let userProfile = PassthroughSubject<MyPageProfilePresentationModel, Never>()
+        let soptlogPreview = PassthroughSubject<MyPageSoptlogPreviewPresentationModel, Never>()
     }
     
     // MARK: - init
@@ -65,6 +67,16 @@ extension AppMyPageViewModel {
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
+        if userType != .visitor {
+            Task { [weak self] in
+                guard let self else { return }
+                async let profileResult = self.useCase.fetchUserMainInfo()
+                async let soptlogResult = self.useCase.fetchSoptlogPreview()
+                if let profile = try? await profileResult { output.userProfile.send(profile.toPresentation()) }
+                if let soptlog = try? await soptlogResult { output.soptlogPreview.send(soptlog.toPresentation()) }
+            }
+        }
+
         input.naviBackButtonTapped
             .withUnretained(self)
             .sink { owner, _ in

--- a/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/AppMyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -68,6 +68,30 @@ public final class MyPageCoordinator: BaseCoordinator {
             self.delegate?.myPageCoordinator(self, to: .signIn)
         }
 
+        myPage.vm.onLogoutTap = { confirmed in
+            AlertUtils.presentAlertVC(
+                type: .titleDescription,
+                theme: .main,
+                title: I18N.MyPage.logoutDialogTitle,
+                description: I18N.MyPage.logoutDialogDescription,
+                customButtonTitle: I18N.MyPage.logoutDialogGrantButtonTitle,
+                customAction: confirmed,
+                animated: true
+            )
+        }
+
+        myPage.vm.onResetSoptampTap = { confirmed in
+            AlertUtils.presentAlertVC(
+                type: .titleDescription,
+                theme: .main,
+                title: I18N.MyPage.resetMissionTitle,
+                description: I18N.MyPage.resetMissionDescription,
+                customButtonTitle: I18N.MyPage.reset,
+                customAction: confirmed,
+                animated: true
+            )
+        }
+
         myPage.vm.onEditProfileTap = { [weak self] in
             guard let self, let url = URL(string: ExternalURL.Playground.editProfile) else { return }
             let webView = SOPTWebView(startWith: url)

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/MainEntity.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/MainEntity.swift
@@ -17,13 +17,13 @@ public struct MainEntity: Codable {
 // MARK: - UserInfo
 
 public struct UserInfo: Codable {
-    public let status, name: String
+    public let status, name, part: String
     public let profileImage: String?
     public let historyList: [Int]
-    
+
     enum CodingKeys: String, CodingKey {
         case historyList = "generationList"
-        case status, name, profileImage
+        case status, name, profileImage, part
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

마이페이지 프로필/솝트로그 미리보기 섹션에 실제 API를 연동했습니다.
- 두 API 병렬 패칭 및 에러 발생 시 Toast 안내, pull-to-refresh 지원
- `/user/main` 응답에 실제로 내려오던 `part` 필드가 iOS 모델에 누락되어 있던 것을 발견해 함께 수정
- Domain 모델을 View가 직접 참조하지 않도록 Presentation 모델 분리
- 스탬프 초기화/로그아웃 확인 얼럿을 ViewModel → Coordinator로 이동

🌱 작업한 브랜치
- feat/#902

## 🌱 PR Point

### 병렬 패칭 + 부분 실패 허용
- `AppMyPageViewModel.fetchProfileData()`에서 `async let`으로 두 API를 동시에 호출하고, 한쪽이 실패해도 성공한 쪽의 데이터는 그대로 반영되도록 `try?`로 개별 처리했습니다.
- 대신 하나라도 실패하면 공통 Toast 문구를 띄웁니다(어떤 API가 실패했는지는 구분하지 않음. 마이페이지 프리뷰 섹션이라 블로킹 알림보다는 가벼운 Toast가 적합하다고 판단했습니다).

### part 필드 누락 발견 및 수정
- `/user/main` 응답에 `part` 필드가 실제로 내려오고 있었는데, 기존 `UserInfo`(`MainEntity`) 구조체에 해당 필드가 없어 `Codable`이 무시하고 있어 추가했습니다.

### Presentation 모델 분리
- `AppMyPageVC`가 `UserMainInfoModel`/`SoptlogModel`(Domain)을 그대로 들고 `import Domain`까지 하던 상태였습니다.
- `MyPageProfilePresentationModel`/`MyPageSoptlogPreviewPresentationModel`을 추가해, ViewModel의 Output이 Presentation 모델을 방출하도록 바꿨습니다. VC는 더 이상 Domain을 몰라도 됩니다.

### Alert을 ViewModel에서 Coordinator로 이동
- 스탬프 초기화/로그아웃 확인 얼럿을 `AppMyPageViewModel`이 `AlertUtils.presentAlertVC`로 직접 띄우고 있었는데, 이 코드베이스는 대부분 Coordinator가 얼럿 프레젠테이션을 담당하는 컨벤션이라(`HomeCoordinator`, `SoptlogCoordinator`, `TabBarCoordinator` 등) 그에 맞췄습니다. 
- 또한 `onResetSoptampTap` 트리거가 프로토콜에 선언만 되어 있고 실제로는 아무 데서도 호출되지 않고 있어 수정했습니다.
- `onResetSoptampTap`/`onLogoutTap`을 completion 클로저를 받는 형태로 바꿔 ViewModel은 "탭됨 + 확인 시 실행할 동작"만 넘기고, Alert 표시는 Coordinator가 담당합니다.

### WebKit 관련 로직을 Repository로 이동
- 로그아웃 시 쿠키/웹뷰 데이터를 지우는 `SFSafariViewController.DataStore`/`WKWebsiteDataStore` 코드가 `AppMyPageViewModel`(Presentation 레이어)에 있었습니다. ViewModel은 `useCase.logout()`만 호출하면 되므로 `import WebKit`/`SafariServices`를 제거했습니다.

## 📌 참고 사항
- 에러 메시지는 두 API 중 어떤 것이 실패했는지 구분하지 않는 공용 Toast입니다. 필요하면 세분화할 예정입니다.

## 📸 스크린샷
<!-- 스크린샷을 추가해주세요 -->
https://github.com/user-attachments/assets/9bbb7d61-9e4f-4b6d-a017-e8194a3c8c26


## 📮 관련 이슈
- Resolved: #902
