### PR TITLE
[Feat] #944 - 솝레터 익명 신고 폼 주소 조회 API 연동

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/SoptletterRepository.swift
@@ -26,6 +26,10 @@ extension SoptletterRepository: SoptletterRepositoryInterface {
     public func fetchCTA() async throws -> Domain.SoptletterCTAModel {
         try await soptletterService.fetchCTA().toDomain()
     }
+
+    public func fetchReportForm() async throws -> Domain.SoptletterReportFormModel {
+        try await soptletterService.fetchReportForm().toDomain()
+    }
     
     public func likeMessage(messageId: Int, topicId: Int) async throws {
         try await soptletterService.likeMessage(messageId: messageId, topicId: topicId)

--- a/SOPT-iOS/Projects/Data/Sources/Transform/SoptletterReportFormTransform.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Transform/SoptletterReportFormTransform.swift
@@ -1,0 +1,16 @@
+//
+//  SoptletterReportFormTransform.swift
+//  Data
+//
+//  Created by 강윤서 on 7/29/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import Networks
+import Domain
+
+extension SoptletterReportFormResponse {
+    func toDomain() -> SoptletterReportFormModel {
+        SoptletterReportFormModel(reportFormUrl: reportFormUrl)
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/Model/SoptletterReportFormModel.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/Model/SoptletterReportFormModel.swift
@@ -1,0 +1,15 @@
+//
+//  SoptletterReportFormModel.swift
+//  Domain
+//
+//  Created by 강윤서 on 7/29/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+public struct SoptletterReportFormModel {
+    public let reportFormUrl: String
+
+    public init(reportFormUrl: String) {
+        self.reportFormUrl = reportFormUrl
+    }
+}

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptletterRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/SoptletterRepositoryInterface.swift
@@ -20,4 +20,5 @@ public protocol SoptletterRepositoryInterface {
     func unlikeMessage(messageId: Int, topicId: Int) async throws
     func fetchCTA() async throws -> SoptletterCTAModel
     func fetchDefaultTopic() async throws -> SoptletterItemModel
+    func fetchReportForm() async throws -> SoptletterReportFormModel
 }

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/SoptletterUseCase.swift
@@ -20,7 +20,8 @@ public protocol SoptletterUseCase {
     func deleteMessage(messageId: Int, topicId: Int) async throws
     func likeMessage(messageId: Int, topicId: Int) async throws
     func unlikeMessage(messageId: Int, topicId: Int) async throws
-    func fetchCTA() async throws -> SoptletterCTAModel    
+    func fetchCTA() async throws -> SoptletterCTAModel
+    func fetchReportForm() async throws -> SoptletterReportFormModel
 }
 
 public final class DefaultSoptletterUseCase: SoptletterUseCase {
@@ -96,5 +97,9 @@ public final class DefaultSoptletterUseCase: SoptletterUseCase {
     
     public func fetchCTA() async throws -> SoptletterCTAModel {
         return try await repository.fetchCTA()
+    }
+
+    public func fetchReportForm() async throws -> SoptletterReportFormModel {
+        return try await repository.fetchReportForm()
     }
 }

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Interface/Sources/SoptletterMainPresentable.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Interface/Sources/SoptletterMainPresentable.swift
@@ -17,7 +17,7 @@ public protocol SoptletterMainRoutingTrigger {
     var onPostItTap: (() -> Void)? { get set }
     var onWriteTap: (() -> Void)? { get set }
     var onDownloadTap: ((String, UIImage, URL) -> Void)? { get set }
-    var onReportTap: (() -> Void)? { get set }
+    var onReportTap: (@MainActor (URL) -> Void)? { get set }
     var onMenuTap: (() -> Void)? { get set }
     var onCellTap: ((Int, Int) -> Void)? { get set }
     var onError: (@MainActor () -> Void)? { get set }

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/Coordinator/SoptletterCoordinator.swift
@@ -115,8 +115,9 @@ public final class SoptletterCoordinator: BaseCoordinator {
             self?.showSelectTopic()
         }
         
-        soptletterMain.vm.onReportTap = { [weak self] in
-            self?.showReportForm()
+        soptletterMain.vm.onReportTap = { [weak self] url in
+            let webView = SOPTWebView(startWith: url)
+            self?.soptletterRootController?.pushViewController(webView, animated: true)
         }
         
         soptletterMain.vm.onDownloadTap = { [weak self] fileName, image, pdfURL in
@@ -145,14 +146,6 @@ public final class SoptletterCoordinator: BaseCoordinator {
             self.soptletterRootController = navController
             navigationController?.present(navController, animated: true)
         }
-    }
-    
-    // MARK: - sopt-letter/report-form API 연결 필요
-    
-    private func showReportForm() {
-        guard let url = URL(string: "https://forms.gle/jkQWs2e6YMkg7HSg8") else { return }
-        let webView = SOPTWebView(startWith: url)
-        soptletterRootController?.pushViewController(webView, animated: true)
     }
     
     private func showSoptletterPrint(_ fileName: String, _ uiImage: UIImage, _ pdfURL: URL) {

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterMainScene/ViewModel/SoptletterMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterMainScene/ViewModel/SoptletterMainViewModel.swift
@@ -157,6 +157,7 @@ extension SoptletterMainViewModel {
         fetchMessageTask = Task {
             do {                
                 let result = try await useCase.fetchSoptletterMessages(topicId: topicId, cursor: nil, size: nil)
+                try Task.checkCancellation()
                 await MainActor.run {
                     output.soptletterMessages.send(result)
                 }
@@ -178,6 +179,7 @@ extension SoptletterMainViewModel {
         fetchCTATask = Task {
             do {
                 let result = try await useCase.fetchCTA()
+                try Task.checkCancellation()
                 await MainActor.run {
                     output.ctaInfo.send(result)
                 }
@@ -196,10 +198,19 @@ extension SoptletterMainViewModel {
         fetchReportFormTask = Task {
             do {
                 let result = try await useCase.fetchReportForm()
-                guard let url = URL(string: result.reportFormUrl) else {
+                try Task.checkCancellation()
+
+                guard
+                    let url = URL(string: result.reportFormUrl),
+                    url.scheme?.lowercased() == "https",
+                    let host = url.host,
+                    !host.isEmpty
+                else {
                     await onError?()
                     return
                 }
+
+                try Task.checkCancellation()
                 await onReportTap?(url)
             } catch is CancellationError {
                 return

--- a/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterMainScene/ViewModel/SoptletterMainViewModel.swift
+++ b/SOPT-iOS/Projects/Features/SoptletterFeature/Sources/SoptletterMainScene/ViewModel/SoptletterMainViewModel.swift
@@ -45,6 +45,7 @@ public final class SoptletterMainViewModel: SoptletterMainViewModelType {
     private var soptletterTitle: String = ""
     private var fetchMessageTask: Task<Void, Never>?
     private var fetchCTATask: Task<Void, Never>?
+    private var fetchReportFormTask: Task<Void, Never>?
     private var topicId: Int?
     
     private var cancelBag = CancelBag()
@@ -53,7 +54,7 @@ public final class SoptletterMainViewModel: SoptletterMainViewModelType {
     public var onWriteTap: (() -> Void)?
     public var onPostItTap: (() -> Void)?
     public var onDownloadTap: ((String, UIImage, URL) -> Void)?
-    public var onReportTap: (() -> Void)?
+    public var onReportTap: (@MainActor (URL) -> Void)?
     public var onMenuTap: (() -> Void)?
     public var onCellTap: ((Int, Int) -> Void)?
     public var onError: (@MainActor () -> Void)?
@@ -131,7 +132,7 @@ extension SoptletterMainViewModel {
         input.reportButtonTap
             .withUnretained(self)
             .sink { owner, _ in
-                owner.onReportTap?()
+                owner.fetchReportForm()
             }.store(in: cancelBag)
         
         input.postItCellTap
@@ -190,6 +191,24 @@ extension SoptletterMainViewModel {
         }
     }
     
+    public func fetchReportForm() {
+        fetchReportFormTask?.cancel()
+        fetchReportFormTask = Task {
+            do {
+                let result = try await useCase.fetchReportForm()
+                guard let url = URL(string: result.reportFormUrl) else {
+                    await onError?()
+                    return
+                }
+                await onReportTap?(url)
+            } catch is CancellationError {
+                return
+            } catch {
+                await onError?()
+            }
+        }
+    }
+
     public func refreshMessagesTrigger() {
         refreshTriggerSubject.send()
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/API/SoptletterAPI.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/API/SoptletterAPI.swift
@@ -24,6 +24,7 @@ public enum SoptletterAPI {
     case unlikeMessage(messageId: Int, topicId: Int)
     case fetchCTA
     case fetchDefaultTopic
+    case fetchReportForm
 }
 
 extension SoptletterAPI: BaseAPI {
@@ -49,14 +50,16 @@ extension SoptletterAPI: BaseAPI {
             return "/cta"
         case .fetchDefaultTopic:
             return "/topics/default/messages"
+        case .fetchReportForm:
+            return "/report-form"
         }
     }
-    
+
     public var method: Moya.Method {
         switch self {
         case .writeMessage, .completeOnboarding, .likeMessage:
             return .post
-        case .fetchTopics, .fetchTopic, .fetchProfile, .soptletterMessages, .soptletterMessage, .fetchCTA, .fetchDefaultTopic:
+        case .fetchTopics, .fetchTopic, .fetchProfile, .soptletterMessages, .soptletterMessage, .fetchCTA, .fetchDefaultTopic, .fetchReportForm:
             return .get
         case .editMessage:
             return .patch
@@ -64,14 +67,14 @@ extension SoptletterAPI: BaseAPI {
             return .delete
         }
     }
-    
+
     public var task: Moya.Task {
         switch self {
         case .writeMessage(_, let content):
                 return .requestParameters(parameters: ["content": content], encoding: JSONEncoding.default)
         case let .editMessage(_, _, content):
                 return .requestParameters(parameters: ["content": content], encoding: JSONEncoding.default)
-        case .fetchTopics, .fetchTopic, .completeOnboarding, .fetchProfile, .soptletterMessages, .soptletterMessage, .deleteMessage, .likeMessage, .unlikeMessage, .fetchCTA, .fetchDefaultTopic:
+        case .fetchTopics, .fetchTopic, .completeOnboarding, .fetchProfile, .soptletterMessages, .soptletterMessage, .deleteMessage, .likeMessage, .unlikeMessage, .fetchCTA, .fetchDefaultTopic, .fetchReportForm:
                 return .requestPlain
         }
     }

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptletterReportFormResponse.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Entity/ResponseEntity/SoptletterReportFormResponse.swift
@@ -1,0 +1,15 @@
+//
+//  SoptletterReportFormResponse.swift
+//  Networks
+//
+//  Created by 강윤서 on 7/29/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+public struct SoptletterReportFormResponse: Codable {
+    public let reportFormUrl: String
+
+    public init(reportFormUrl: String) {
+        self.reportFormUrl = reportFormUrl
+    }
+}

--- a/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
+++ b/SOPT-iOS/Projects/Modules/Networks/Sources/Service/SoptletterService.swift
@@ -26,6 +26,7 @@ public protocol SoptletterService {
     func unlikeMessage(messageId: Int, topicId: Int) async throws
     func fetchCTA() async throws -> SoptletterCTAResponse
     func fetchDefaultTopic() async throws -> SoptletterItemResponseEntity
+    func fetchReportForm() async throws -> SoptletterReportFormResponse
 }
 
 extension DefaultSoptletterService: SoptletterService {
@@ -35,6 +36,10 @@ extension DefaultSoptletterService: SoptletterService {
     
     public func fetchCTA() async throws -> SoptletterCTAResponse {
         return try await requestObjectAsync(.fetchCTA)
+    }
+
+    public func fetchReportForm() async throws -> SoptletterReportFormResponse {
+        return try await requestObjectAsync(.fetchReportForm)
     }
     
     public func likeMessage(messageId: Int, topicId: Int) async throws {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#944

## 🌱 PR Point
- 솝레터 익명 신고 폼으로 이동할 때 리터럴 값으로 하드코딩되어 있던 구글폼 URL을  API 응답으로 대체했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 빌드할 수 없는 환경이라 개인 노트북으로 빌드 확인 후 머지하겠습니다.

## 📸 스크린샷
| 설명 | 스크린샷 |
| :--: | :--: |
| 구글폼 API 연동 | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-29 at 22 25 06" src="https://github.com/user-attachments/assets/3f3f0afe-0293-4078-9820-3609339cfcd6" /> |

## 📮 관련 이슈
- Resolved: #944