### PR TITLE
[Fix] 탭 타이틀 변경

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -124,6 +124,10 @@ public struct I18N {
         public static let start = "시작하기"
     }
     
+    public struct Soptamp {
+        public static let title = "솝탬프"
+    }
+    
     public struct MissionList {
         public static let noMission = "아직 완료한 미션이 없습니다!"
         public static let multipleTen = "x 10"
@@ -451,6 +455,7 @@ public struct I18N {
     }
     
     public struct Poke {
+        public static let title = "콕찌르기"
         public static let poke = "콕 찌르기"
         public static let someonePokedMe = "누가 나를 찔렀어요"
         public static let pokeMyFriends = "내 친구를 찔러보세요"

--- a/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Components/TabBarItem.swift
+++ b/SOPT-iOS/Projects/Features/TabBarFeature/Sources/Components/TabBarItem.swift
@@ -31,9 +31,9 @@ extension TabBarItemType {
         case .home:
             return I18N.Home.title
         case .soptamp:
-            return I18N.Soptlog.soptamp
+            return I18N.Soptamp.title
         case .poke:
-            return I18N.Soptlog.poke
+            return I18N.Poke.title
         case .mypage:
             return I18N.MyPage.title
         }


### PR DESCRIPTION
## 🌴 PR 요약
탭 타이틀 변경

🌱 작업한 브랜치
- feature/#

## 🌱 PR Point
string literal 사용처를 미처 확인하지 못했어서 탭 타이틀도 "솝탬프 로그", "콕찌르기 로그" 로 표기되어 있던 버그를 수정했습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #
