### PR TITLE
[Feat] #949 - SOPT-iOS-MDS 의존성 추가 및 폰트 등록

### DIFF
--- a/SOPT-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/SOPT-iOS/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -25,5 +25,6 @@ public extension TargetDependency.SPM {
     static let FirebaseCore = TargetDependency.external(name: "FirebaseCore")
     static let FirebaseCrashlytics = TargetDependency.external(name: "FirebaseCrashlytics")
     static let FirebaseAnalytics = TargetDependency.external(name: "FirebaseAnalytics")
-    static let GoogleSignIn = TargetDependency.external(name: "GoogleSignIn")    
+    static let GoogleSignIn = TargetDependency.external(name: "GoogleSignIn")
+    static let MDS = TargetDependency.external(name: "MDS")
 }

--- a/SOPT-iOS/Projects/Modules/ThirdPartyLibs/Project.swift
+++ b/SOPT-iOS/Projects/Modules/ThirdPartyLibs/Project.swift
@@ -24,6 +24,7 @@ let project = Project.makeModule(
         .SPM.GoogleSignIn,
         .SPM.FirebaseCore,
         .SPM.FirebaseRemoteConfig,
-        .SPM.FirebaseCrashlytics,        
+        .SPM.FirebaseCrashlytics,
+        .SPM.MDS,
     ]
 )

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import BaseFeatureDependency
 import Core
+import MDS
 import Networks
 
 @main
@@ -22,6 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //
         registerDependencies()
         configureAppLifecycleAdapter()
+        FontLoader.registerIfNeeded()
         Firebase.configure()
         Firebase.configureCrashlytics()
         application.registerForRemoteNotifications()

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -45,5 +45,6 @@ let package = Package(
         .package(url: "https://github.com/amplitude/Amplitude-Swift", from: "1.11.10"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "9.0.0"),
+        .package(url: "https://github.com/sopt-makers/SOPT-iOS-MDS", from: "1.0.1"),
     ]
 )


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feat/#949

## 🌱 PR Point
- 솝레터 화면을 새 디자인 시스템 라이브러리(`SOPT-iOS-MDS`)로 마이그레이션하기 위한 선행 작업입니다.
- `Tuist/Package.swift`에 `SOPT-iOS-MDS`(from 1.0.1) 의존성을 추가했습니다.
- `Dependency+SPM.swift`에 `.SPM.MDS`를 추가하고, `ThirdPartyLibs`를 통해 `Core → DSKit → Feature`로 전이되도록 연결했습니다(기존 Kingfisher 등과 동일한 컨벤션).
- `AppDelegate`에서 앱 시작 시 `FontLoader.registerIfNeeded()`를 호출해 SUIT 폰트를 등록하도록 했습니다.
- UI 변경은 없고, 이후 솝레터 화면별 토큰 마이그레이션 PR에서 실제로 `import MDS`를 사용하게 됩니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `tuist install`로 패키지가 정상적으로 1.0.1로 resolve되는 것까지는 확인했으나, 이 환경에는 `xcconfigs/targets/iOS-Framework.xcconfig`가 없어 `tuist generate`/빌드까지는 확인하지 못했습니다. 로컬 빌드 확인 후 머지하겠습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|-|UI 변경 없음 (의존성 추가만 포함)|

## 📮 관련 이슈
- Resolved: #949