### PR TITLE
[Refactor] #956 - Splash/Auth MDS 디자인 토큰 마이그레이션

### DIFF
--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -64,6 +64,7 @@ public struct I18N {
             
             public static let codePlaceholder = "인증번호를 입력해주세요."
             public static let defaultTimerText = "03:00"
+            public static let keyboardDoneButtonTitle = "완료"
             
             public static let helpDescription = "번호가 바뀌었거나, 인증이 어려우신 경우 추가 정보 인증을 통해 가입을 도와드리고 있어요!"
             public static let inquireButtonTitle = "문의하기"

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -57,7 +57,7 @@ public struct I18N {
             public static let description = "이곳은 SOPT 회원만을 위한 공간이에요.\nSOPT 회원인증을 위해 전화번호를 입력해 주세요."
             
             public static let phoneLabel = "전화번호"
-            public static let phonePlaceholder = "01012345678"
+            public static let phonePlaceholder = "010XXXXXXXX"
             public static let sendButtonTitle = "전송하기"
             public static let resendButtonTitle = "재전송하기"
             public static let sendSuccessToast = "인증번호가 전송되었어요."
@@ -65,9 +65,14 @@ public struct I18N {
             public static let codePlaceholder = "인증번호를 입력해주세요."
             public static let defaultTimerText = "03:00"
             
-            public static let helpTitle = "SOPT 회원인증에 실패하셨나요?"
             public static let helpDescription = "번호가 바뀌었거나, 인증이 어려우신 경우 추가 정보 인증을 통해 가입을 도와드리고 있어요!"
+            public static let inquireButtonTitle = "문의하기"
             public static let doneButtonTitle = "SOPT 회원 인증 완료"
+        }
+
+        public struct SocialLink {
+            public static let title = "소셜 계정 연동"
+            public static let description = "반갑습니다 회원님\n소셜로그인을 진행하여 회원가입을 완료해주세요"
         }
     }
     

--- a/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
+++ b/SOPT-iOS/Projects/Core/Sources/Literals/StringLiterals.swift
@@ -74,6 +74,12 @@ public struct I18N {
             public static let title = "소셜 계정 연동"
             public static let description = "반갑습니다 회원님\n소셜로그인을 진행하여 회원가입을 완료해주세요"
         }
+
+        public struct SocialReset {
+            public static let title = "소셜 계정 재설정"
+            public static let description = "반갑습니다 회원님\n재설정할 소셜 계정을 선택해주세요"
+            public static let changeSuccessToast = "소셜 계정 변경에 성공했습니다."
+        }
     }
     
     public struct SignIn {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/Demo.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/Demo.swift
@@ -27,8 +27,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             interface: SignInRepositoryInterface.self,
             implement: { StubSignInRepository() }
         )
-        
-        
+        DIContainer.shared.register(
+            interface: CoreOAuthRepositoryInterface.self,
+            implement: { StubCoreOAuthRepository() }
+        )
+        DIContainer.shared.register(
+            interface: CoreAuthRepositoryInterface.self,
+            implement: { StubCoreAuthRepository() }
+        )
+        DIContainer.shared.register(
+            interface: PhoneVerifyRepositoryInterface.self,
+            implement: { StubPhoneVerifyRepository() }
+        )
+        DIContainer.shared.register(
+            interface: AuthTokensRepositoryInterface.self,
+            implement: { StubAuthTokensRepository() }
+        )
+
+
         return true
     }
     
@@ -54,7 +70,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         return self.window!.rootViewController as? UINavigationController ?? UINavigationController(rootViewController: UIViewController())
     }
     
-    lazy var authCoordinator: AuthCoordinator = AuthCoordinator(router: LegacyRouter(rootController: rootController), factory: AuthBuilder())
+    lazy var authCoordinator: AuthCoordinator = AuthCoordinator(navigationController: rootController, factory: AuthBuilder())
     
     func scene(_ scene: UIScene,
                willConnectTo session: UISceneSession,

--- a/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/StubSignInRepository.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Demo/Sources/StubSignInRepository.swift
@@ -9,11 +9,68 @@
 import Combine
 import Foundation
 
+import Core
 import Domain
 import AuthFeatureInterface
 
 struct StubSignInRepository: SignInRepositoryInterface {
-    func requestSignIn(token: String) -> AnyPublisher<Bool, Error> {
-        Just(true).setFailureType(to: Error.self).eraseToAnyPublisher()
+    func requestSignIn(token: String) -> AnyPublisher<SignInModel, Error> {
+        let model = SignInModel(
+            tokens: LegacyAuthTokensModel(accessToken: "stub", refreshToken: "stub", playgroundToken: "stub"),
+            status: .active
+        )
+        return Just(model).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
+
+    func fetchSoptampUser() -> AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+}
+
+struct StubCoreOAuthRepository: CoreOAuthRepositoryInterface {
+    func getIdentityToken(from provider: OAuthProvider) -> AnyPublisher<String, CoreAuthError> {
+        Just("stub-identity-token").setFailureType(to: CoreAuthError.self).eraseToAnyPublisher()
+    }
+}
+
+struct StubCoreAuthRepository: CoreAuthRepositoryInterface {
+    func login(for provider: OAuthProvider, with identityToken: String) -> AnyPublisher<AuthTokens, CoreAuthError> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func changeSocialAccount(_ model: SignUpModel) -> AnyPublisher<Void, CoreAuthError> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func searchSocialAccount(_ phone: String) -> AnyPublisher<OAuthProvider, CoreAuthError> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func signUp(_ model: SignUpModel) -> AnyPublisher<Void, CoreAuthError> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func getRecentLogin() -> OAuthProvider? { nil }
+    func saveRecentLogin(_ provider: OAuthProvider) {}
+    func deleteRecentLogin() {}
+}
+
+struct StubPhoneVerifyRepository: PhoneVerifyRepositoryInterface {
+    func send(_ model: PhoneSendModel) -> AnyPublisher<Void, PhoneVerifyError> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    func verify(_ model: PhoneVerifyModel) -> AnyPublisher<Void, PhoneVerifyError> {
+        Empty().eraseToAnyPublisher()
+    }
+}
+
+struct StubAuthTokensRepository: AuthTokensRepositoryInterface {
+    func refresh(completion: @escaping (Result<Void, ReissueError>) -> Void) {
+        completion(.success(()))
+    }
+
+    func fetch() -> AuthTokens? { nil }
+    func save(_ tokens: AuthTokens) {}
+    func delete() {}
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
@@ -39,6 +39,10 @@ public class ChangeSocialAccountVC: UIViewController, ChangeSocialAccountViewCon
         type: .oneLeftButton,
         backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
+    ).setLeftButtonImage(
+        MDSIcon.chevronLeftOutlined.image
+            .withRenderingMode(.alwaysTemplate)
+            .withTintColor(SemanticColor.Fg.Neutral.bold, renderingMode: .alwaysOriginal)
     )
 
     private let lineView = UIView().then {
@@ -55,7 +59,7 @@ public class ChangeSocialAccountVC: UIViewController, ChangeSocialAccountViewCon
 
     private let secondStepIndicator = StepIndicatorView(
         number: "2",
-        title: "소셜 계정 재설정",
+        title: I18N.Auth.SocialReset.title,
         circleTextColor: SemanticColor.Fg.Neutral.ghost,
         circleBackgroundColor: SemanticColor.Bg.Neutral.default,
         titleTextColor: SemanticColor.Fg.Neutral.ghost
@@ -125,9 +129,9 @@ extension ChangeSocialAccountVC {
         }
 
         lineView.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(35)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(123)
+            $0.width.equalTo(136)
             $0.height.equalTo(1)
         }
 
@@ -146,7 +150,7 @@ extension ChangeSocialAccountVC {
         }
 
         phoneVerifyView.snp.makeConstraints {
-            $0.top.equalTo(firstStepIndicator.titleLabel.snp.bottom)
+            $0.top.equalTo(firstStepIndicator.titleLabel.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
@@ -191,7 +195,7 @@ extension ChangeSocialAccountVC {
             .withUnretained(self)
             .delay(for: .seconds(0.5), scheduler: RunLoop.main)
             .sink { owner, _ in
-                Toast.showMDSToast(type: .success, text: "소셜 계정 변경에 성공했습니다.")
+                Toast.showMDSToast(type: .success, text: I18N.Auth.SocialReset.changeSuccessToast)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialAccountVC.swift
@@ -11,6 +11,7 @@ import Combine
 
 import DSKit
 import Core
+import MDS
 
 import AuthFeatureInterface
 import BaseFeatureDependency
@@ -36,56 +37,41 @@ public class ChangeSocialAccountVC: UIViewController, ChangeSocialAccountViewCon
     private lazy var navigationBar = OPNavigationBar(
         self,
         type: .oneLeftButton,
-        backgroundColor: DSKitAsset.Colors.black100.color,
+        backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
     )
-    
+
     private let lineView = UIView().then {
-        $0.backgroundColor = DSKitAsset.Colors.black40.color
+        $0.backgroundColor = SemanticColor.Bg.Neutral.default
     }
-    
-    private let firstCircle = UILabel().then {
-        $0.text = "1"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.backgroundColor = DSKitAsset.Colors.blue400.color
-        $0.layer.cornerRadius = 11
-        $0.layer.masksToBounds = true
-        $0.textAlignment = .center
-    }
-    
+
+    private let firstStepIndicator = StepIndicatorView(
+        number: "1",
+        title: I18N.Auth.PhoneVerify.title,
+        circleTextColor: SemanticColor.Fg.Neutral.bold,
+        circleBackgroundColor: SemanticColor.Bg.Secondary.default,
+        titleTextColor: SemanticColor.Fg.Neutral.bold
+    )
+
+    private let secondStepIndicator = StepIndicatorView(
+        number: "2",
+        title: "소셜 계정 재설정",
+        circleTextColor: SemanticColor.Fg.Neutral.ghost,
+        circleBackgroundColor: SemanticColor.Bg.Neutral.default,
+        titleTextColor: SemanticColor.Fg.Neutral.ghost
+    )
+
     private let checkImageView = UIImageView().then {
-        $0.image = DSKitAsset.Assets.check.image.withAlignmentRectInsets(.init(top: -4, left: -4, bottom: -4, right: -4))
+        $0.image = MDSIcon.checkOutlined.image.withRenderingMode(.alwaysTemplate).withAlignmentRectInsets(.init(top: -4, left: -4, bottom: -4, right: -4))
+        $0.tintColor = SemanticColor.Fg.Neutral.bold
         $0.contentMode = .scaleAspectFit
-        $0.backgroundColor = DSKitAsset.Colors.blue400.color
-        $0.layer.cornerRadius = 11
+        $0.backgroundColor = SemanticColor.Bg.Secondary.default
+        $0.layer.cornerRadius = BaseRadius.Base.full
         $0.layer.masksToBounds = true
         $0.isHidden = true
     }
-    
-    private let secondCircle = UILabel().then {
-        $0.text = "2"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.backgroundColor = DSKitAsset.Colors.black40.color
-        $0.layer.cornerRadius = 11
-        $0.layer.masksToBounds = true
-        $0.textAlignment = .center
-    }
-    
-    private let firstLabel = UILabel().then {
-        $0.text = "SOPT 회원인증"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.white.color
-        $0.textAlignment = .center
-    }
-    
-    private let secondLabel = UILabel().then {
-        $0.text = "소셜 계정 재설정"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.white.color
-        $0.textAlignment = .center
-    }
-   
-    
+
+
     // MARK: - View Life Cycle
     
     public init(
@@ -117,7 +103,7 @@ public class ChangeSocialAccountVC: UIViewController, ChangeSocialAccountViewCon
 extension ChangeSocialAccountVC {
     
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.black100.color
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
         self.phoneVerifyView.helpViewHidden = true
     }
     
@@ -126,55 +112,41 @@ extension ChangeSocialAccountVC {
         self.view.addSubviews(
             navigationBar,
             lineView,
-            firstCircle,
+            firstStepIndicator,
             checkImageView,
-            secondCircle,
-            firstLabel,
-            secondLabel,
+            secondStepIndicator,
             phoneVerifyView,
             oAuthView
         )
-        
+
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.leading.trailing.equalToSuperview()
         }
-        
+
         lineView.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(123)
             $0.height.equalTo(1)
         }
-        
-        firstCircle.snp.makeConstraints {
+
+        firstStepIndicator.snp.makeConstraints {
             $0.centerX.equalTo(lineView.snp.leading)
-            $0.centerY.equalTo(lineView)
-            $0.size.equalTo(22)
+            $0.top.equalTo(lineView.snp.centerY).offset(-11)
         }
-        
+
         checkImageView.snp.makeConstraints {
-            $0.edges.equalTo(firstCircle)
+            $0.edges.equalTo(firstStepIndicator.circleView)
         }
-        
-        secondCircle.snp.makeConstraints {
+
+        secondStepIndicator.snp.makeConstraints {
             $0.centerX.equalTo(lineView.snp.trailing)
-            $0.centerY.equalTo(lineView)
-            $0.size.equalTo(22)
+            $0.top.equalTo(lineView.snp.centerY).offset(-11)
         }
-        
-        firstLabel.snp.makeConstraints {
-            $0.top.equalTo(firstCircle.snp.bottom).offset(12)
-            $0.centerX.equalTo(firstCircle)
-        }
-        
-        secondLabel.snp.makeConstraints {
-            $0.top.equalTo(secondCircle.snp.bottom).offset(12)
-            $0.centerX.equalTo(secondCircle)
-        }
-        
+
         phoneVerifyView.snp.makeConstraints {
-            $0.top.equalTo(firstLabel.snp.bottom)
+            $0.top.equalTo(firstStepIndicator.titleLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
@@ -202,13 +174,16 @@ extension ChangeSocialAccountVC {
         output.currentStep
             .withUnretained(self)
             .sink { owner, step in
-                let bg = step == .phoneVerify ? DSKitAsset.Colors.black40.color : DSKitAsset.Colors.blue400.color
+                let bg = step == .phoneVerify ? SemanticColor.Bg.Neutral.default : SemanticColor.Bg.Secondary.default
                 owner.phoneVerifyView.isHidden = step != .phoneVerify
                 owner.oAuthView.isHidden = step != .oAuth
                 owner.checkImageView.isHidden = step == .phoneVerify
                 owner.lineView.backgroundColor = bg
-                owner.secondCircle.backgroundColor = bg
+                owner.secondStepIndicator.setCircleBackgroundColor(bg)
                 owner.navigationBar.isHidden = step != .phoneVerify
+
+                owner.firstStepIndicator.setTitleActive(step == .phoneVerify)
+                owner.secondStepIndicator.setTitleActive(step != .phoneVerify)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
@@ -13,7 +13,7 @@ import MDS
 
 public final class ChangeSocialOAuthView: UIView {
     
-    private static let i18n = I18N.SignIn.Refactor.self
+    private static let i18n = I18N.Auth.SocialReset.self
     
     public var viewModelInput: ChangeSocialAccountViewModel.Input.OAuth {
         .init(
@@ -25,13 +25,13 @@ public final class ChangeSocialOAuthView: UIView {
     //MARK: - Properties
 
     private let titleLabel = UILabel().then {
-        $0.text = "소셜 계정 재설정"
+        $0.text = i18n.title
         $0.setTypography(Typography.heading2, textColor: SemanticColor.Fg.Neutral.bold)
         $0.textAlignment = .center
     }
 
     private let descriptionLabel = UILabel().then {
-        $0.text = "반갑습니다 회원님\n재설정할 소셜 계정을 선택해주세요"
+        $0.text = i18n.description
         $0.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.subtle)
         $0.textAlignment = .center
         $0.numberOfLines = 2
@@ -63,7 +63,7 @@ public final class ChangeSocialOAuthView: UIView {
         )
 
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(54)
+            $0.top.equalToSuperview()
             $0.centerX.equalToSuperview()
         }
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/ChangeSocialAccountScene/ChangeSocialOAuthView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 import Core
-import DSKit
+import MDS
 
 public final class ChangeSocialOAuthView: UIView {
     
@@ -26,15 +26,13 @@ public final class ChangeSocialOAuthView: UIView {
 
     private let titleLabel = UILabel().then {
         $0.text = "소셜 계정 재설정"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 24)
-        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.setTypography(Typography.heading2, textColor: SemanticColor.Fg.Neutral.bold)
         $0.textAlignment = .center
     }
-    
+
     private let descriptionLabel = UILabel().then {
         $0.text = "반갑습니다 회원님\n재설정할 소셜 계정을 선택해주세요"
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.gray60.color
+        $0.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.subtle)
         $0.textAlignment = .center
         $0.numberOfLines = 2
     }
@@ -54,28 +52,28 @@ public final class ChangeSocialOAuthView: UIView {
     
     
     private func setUI() {
-        self.backgroundColor = DSKitAsset.Colors.black100.color
+        self.backgroundColor = SemanticColor.Bg.Layer.basement
     }
-    
+
     private func setLayout() {
         self.addSubviews(
             titleLabel,
             descriptionLabel,
             oAuthView
         )
-        
+
         titleLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(54)
             $0.centerX.equalToSuperview()
         }
-        
+
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(14)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(BaseSpacing.Base.s8)
             $0.centerX.equalToSuperview()
         }
-        
+
         oAuthView.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(66)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(BaseSpacing.Base.s64)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.lessThanOrEqualToSuperview()
         }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
@@ -11,59 +11,59 @@ import UIKit
 import Core
 import Combine
 import DSKit
+import MDS
 
 public final class OAuthView: UIView {
-    
+
     private static let i18n = I18N.Auth.OAuth.self
-    
+
     //MARK: - Properties
-    
-    let googleLoginButton = AppImageTextButton(
+
+    let googleLoginButton = MDSActionButton(
+        variant: .primary,
+        size: .medium,
         title: i18n.googleLogin,
-        image: DSKitAsset.Assets.logoGoogle.image
+        prefixIcon: MDSIcon.googleColorFilled.image
     )
-    
-    let appleLoginButton = AppImageTextButton(
+
+    let appleLoginButton = MDSActionButton(
+        variant: .primary,
+        size: .medium,
         title: i18n.appleLogin,
-        image: DSKitAsset.Assets.logoApple.image
+        prefixIcon: MDSIcon.appleFilled.image
     )
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         setUI()
         setLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    
+
+
     private func setUI() {
-        self.backgroundColor = DSKitAsset.Colors.black100.color
+        self.backgroundColor = SemanticColor.Bg.Layer.basement
     }
-    
+
     private func setLayout() {
         self.addSubviews(
             googleLoginButton,
             appleLoginButton
         )
 
-        
         googleLoginButton.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(48)
-            
         }
-        
+
         appleLoginButton.snp.makeConstraints {
-            $0.top.equalTo(googleLoginButton.snp.bottom).offset(20)
+            $0.top.equalTo(googleLoginButton.snp.bottom).offset(BaseSpacing.Base.s10)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(48)
             $0.bottom.equalToSuperview()
         }
-       
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
@@ -23,14 +23,14 @@ public final class OAuthView: UIView {
         variant: .primary,
         size: .medium,
         title: i18n.googleLogin,
-        prefixIcon: MDSIcon.googleColorFilled.image
+        prefixIcon: .googleColorFilled
     )
 
     let appleLoginButton = MDSActionButton(
         variant: .primary,
         size: .medium,
         title: i18n.appleLogin,
-        prefixIcon: MDSIcon.appleFilled.image
+        prefixIcon: .appleFilled
     )
 
     override init(frame: CGRect) {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/Components/OAuthView.swift
@@ -23,14 +23,16 @@ public final class OAuthView: UIView {
         variant: .primary,
         size: .medium,
         title: i18n.googleLogin,
-        prefixIcon: .googleColorFilled
+        prefixIcon: .googleColorFilled,
+        prefixIconTint: .original
     )
 
     let appleLoginButton = MDSActionButton(
         variant: .primary,
         size: .medium,
         title: i18n.appleLogin,
-        prefixIcon: .appleFilled
+        prefixIcon: .appleFilled,
+        prefixIconTint: .automatic
     )
 
     override init(frame: CGRect) {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 SOPT-iOS. All rights reserved.
 //
 
+import Combine
 import UIKit
 
 import BaseFeatureDependency
@@ -16,6 +17,10 @@ final class PhoneVerifyView: UIView {
 
     private var isTimeLeftError = false
 
+    private let phoneTextChanged = PassthroughSubject<String, Never>()
+    private let codeTextChanged = PassthroughSubject<String, Never>()
+    private let loginHelpButtonTappedSubject = PassthroughSubject<Void, Never>()
+
     public var helpViewHidden: Bool {
         get { helpCallout.isHidden }
         set { helpCallout.isHidden = newValue }
@@ -25,14 +30,13 @@ final class PhoneVerifyView: UIView {
         return .init(
             sendButtonTapped: sendButton.publisher(for: .touchUpInside).mapVoid().asDriver(),
             doneButtonTapped: doneButton.publisher(for: .touchUpInside).mapVoid().asDriver(),
-            phoneTextFieldText: phoneTextField.publisher(for: .editingChanged).compactMap { $0.text }.asDriver(),
-            codeTextFieldText: codeTextField.publisher(for: .editingChanged).compactMap { $0.text }.asDriver()
+            phoneTextFieldText: phoneTextChanged.asDriver(),
+            codeTextFieldText: codeTextChanged.asDriver()
         )
     }
     
-    // TODO: 터치 영역 문의 필요 - MDSCallout이 내부 버튼에 외부 탭 클로저를 제공하지 않아 배너 전체 탭으로 유지, 추후 문의 후 수정
     public var loginHelpButtonTapped: Driver<Void> {
-        helpCallout.gesture().mapVoid().asDriver()
+        loginHelpButtonTappedSubject.asDriver()
     }
     
     private static let i18N = I18N.Auth.PhoneVerify.self
@@ -57,16 +61,6 @@ final class PhoneVerifyView: UIView {
         isRequired: true
     )
 
-    // TODO: MDSTextField가 텍스트 변경 Combine publisher(예: textDidChangePublisher)를 공개 API로 노출해야함
-    private lazy var phoneTextField: UITextField = {
-        guard let textField = phoneField.firstSubview(ofType: UITextField.self) else {
-            fatalError("phoneField 내부에서 UITextField를 찾을 수 없습니다.")
-        }
-        textField.keyboardType = .numberPad
-        textField.addToolbar()
-        return textField
-    }()
-
     private let sendButton = UIButton().then {
         $0.layer.cornerRadius = BaseRadius.Base.r8
         $0.layer.masksToBounds = true
@@ -79,17 +73,6 @@ final class PhoneVerifyView: UIView {
     ).then {
         $0.isHidden = true
     }
-
-    // TODO: MDSTextField가 textDidChangePublisher/keyboardType API를 노출하면 phoneTextField와 함께 대체
-    private lazy var codeTextField: UITextField = {
-        guard let textField = codeField.firstSubview(ofType: UITextField.self) else {
-            fatalError("codeField 내부에서 UITextField를 찾을 수 없습니다.")
-        }
-        textField.keyboardType = .numberPad
-        textField.addToolbar()
-        textField.addRightPadding(width: 68)
-        return textField
-    }()
 
     private let timeLeftLabel = UILabel().then {
         $0.text = i18N.defaultTimerText
@@ -110,6 +93,7 @@ final class PhoneVerifyView: UIView {
         
         setUI()
         setLayout()
+        setBinding()
     }
     
     required init?(coder: NSCoder) {
@@ -127,9 +111,34 @@ final class PhoneVerifyView: UIView {
             doneButton
         )
 
-        codeTextField.addSubview(timeLeftLabel)
+        codeField.addSubview(timeLeftLabel)
 
         setSendButtonTitle(Self.i18N.sendButtonTitle)
+    }
+
+    private func setBinding() {
+        [phoneField, codeField].forEach {
+            $0.keyboardType = .numberPad
+            $0.keyboardAccessoryView = makeKeyboardToolbar()
+        }
+
+        phoneField.onTextChanged = { [weak self] in self?.phoneTextChanged.send($0) }
+        codeField.onTextChanged = { [weak self] in self?.codeTextChanged.send($0) }
+        helpCallout.onButtonTap = { [weak self] in self?.loginHelpButtonTappedSubject.send() }
+    }
+
+    private func makeKeyboardToolbar() -> UIToolbar {
+        let toolbar = UIToolbar()
+        toolbar.sizeToFit()
+        toolbar.items = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: I18N.Auth.PhoneVerify.keyboardDoneButtonTitle, style: .done, target: self, action: #selector(dismissKeyboard))
+        ]
+        return toolbar
+    }
+
+    @objc private func dismissKeyboard() {
+        endEditing(true)
     }
     
     private func setLayout() {
@@ -144,7 +153,7 @@ final class PhoneVerifyView: UIView {
         }
 
         sendButton.snp.makeConstraints {
-            $0.centerY.equalTo(phoneTextField)
+            $0.top.equalTo(phoneField).offset(36)
             $0.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(46)
             $0.width.equalTo(109)
@@ -163,12 +172,12 @@ final class PhoneVerifyView: UIView {
         }
 
         timeLeftLabel.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
+            $0.top.equalTo(codeField.snp.top).inset(10)
             $0.trailing.equalToSuperview().inset(BaseSpacing.Base.s16)
         }
 
         helpCallout.snp.makeConstraints {
-            $0.leading.trailing.equalTo(codeTextField)
+            $0.leading.trailing.equalTo(codeField)
             $0.bottom.equalTo(doneButton.snp.top).offset(-BaseSpacing.Base.s24)
         }
 
@@ -200,7 +209,7 @@ extension PhoneVerifyView {
             .asDriver()
             .withUnretained(self)
             .sink { owner, text in
-                owner.phoneTextField.text = text
+                owner.phoneField.text = text
             }
             .store(in: cancelBag)
         
@@ -208,15 +217,16 @@ extension PhoneVerifyView {
             .asDriver()
             .withUnretained(self)
             .sink { owner, text in
-                owner.codeTextField.text = text
+                owner.codeField.text = text
             }
             .store(in: cancelBag)
         
         output.timerIsRunning
             .withUnretained(self)
             .sink { owner, active in
-                self.endEditing(!active)
-                self.codeTextField.isEnabled = active
+                owner.endEditing(!active)
+                // state = .disabled로 두면 MDSTextField가 에러 메시지를 감추므로 입력만 막는다.
+                owner.codeField.isUserInteractionEnabled = active
             }
             .store(in: cancelBag)
         
@@ -295,19 +305,5 @@ extension PhoneVerifyView {
             ),
             for: .disabled
         )
-    }
-}
-
-private extension UIView {
-    func firstSubview<T: UIView>(ofType type: T.Type) -> T? {
-        for subview in subviews {
-            if let matched = subview as? T {
-                return matched
-            }
-            if let matched = subview.firstSubview(ofType: type) {
-                return matched
-            }
-        }
-        return nil
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/PhoneVerifyScene/PhoneVerifyView.swift
@@ -9,15 +9,16 @@
 import UIKit
 
 import BaseFeatureDependency
-import DSKit
 import Core
-
+import MDS
 
 final class PhoneVerifyView: UIView {
-    
+
+    private var isTimeLeftError = false
+
     public var helpViewHidden: Bool {
-        get { helpView.isHidden }
-        set { helpView.isHidden = newValue }
+        get { helpCallout.isHidden }
+        set { helpCallout.isHidden = newValue }
     }
     
     public var viewModelInput: PhoneVerifyViewModel.Input {
@@ -29,142 +30,86 @@ final class PhoneVerifyView: UIView {
         )
     }
     
+    // TODO: 터치 영역 문의 필요 - MDSCallout이 내부 버튼에 외부 탭 클로저를 제공하지 않아 배너 전체 탭으로 유지, 추후 문의 후 수정
     public var loginHelpButtonTapped: Driver<Void> {
-        helpView.gesture().mapVoid().asDriver()
+        helpCallout.gesture().mapVoid().asDriver()
     }
     
     private static let i18N = I18N.Auth.PhoneVerify.self
     
     private let titleLabel = UILabel().then {
         $0.text = i18N.title
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 24)
-        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.setTypography(Typography.heading2, textColor: SemanticColor.Fg.Neutral.bold)
         $0.textAlignment = .center
     }
-    
+
     private let descriptionLabel = UILabel().then {
         $0.text = i18N.description
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.gray60.color
+        $0.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.subtle)
         $0.textAlignment = .center
         $0.numberOfLines = 2
     }
-    
-    private let phoneLabel = UILabel().then {
-        $0.text = i18N.phoneLabel
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
-        $0.textColor = DSKitAsset.Colors.gray80.color
-    }
-    
-    private let phoneTextField = UITextField().then {
-        $0.placeholder = i18N.phonePlaceholder
-        $0.font = DSKitFontFamily.Suit.medium.font(size: 16)
-        $0.keyboardType = .numberPad
-        $0.backgroundColor = DSKitAsset.Colors.gray800.color
-        $0.textColor = DSKitAsset.Colors.gray10.color
-        $0.layer.cornerRadius = 10
+
+    private let phoneField = MDSTextField(
+        variant: .default,
+        placeholder: i18N.phonePlaceholder,
+        label: i18N.phoneLabel,
+        isRequired: true
+    )
+
+    // TODO: MDSTextField가 텍스트 변경 Combine publisher(예: textDidChangePublisher)를 공개 API로 노출해야함
+    private lazy var phoneTextField: UITextField = {
+        guard let textField = phoneField.firstSubview(ofType: UITextField.self) else {
+            fatalError("phoneField 내부에서 UITextField를 찾을 수 없습니다.")
+        }
+        textField.keyboardType = .numberPad
+        textField.addToolbar()
+        return textField
+    }()
+
+    private let sendButton = UIButton().then {
+        $0.layer.cornerRadius = BaseRadius.Base.r8
         $0.layer.masksToBounds = true
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = UIColor.clear.cgColor
-        $0.addToolbar()
-        $0.addLeftPadding(width: 20)
+        $0.backgroundColor = SemanticColor.Bg.Neutral.inverse
     }
-    
-    private let phoneFailIcon = UIImageView().then {
-        $0.image = DSKitAsset.Assets.alertCircle.image.withTintColor(DSKitAsset.Colors.error.color)
-        $0.contentMode = .scaleAspectFit
+
+    private let codeField = MDSTextField(
+        variant: .default,
+        placeholder: i18N.codePlaceholder
+    ).then {
         $0.isHidden = true
     }
-    
-    private let phoneFailLabel = UILabel().then {
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.error.color
-        $0.isHidden = true
-    }
-    
-    private let sendButton = AppImageTextButton(title: i18N.sendButtonTitle).then {
-        $0.layer.cornerRadius = 10
-        $0.layer.masksToBounds = true
-    }
-    
-    private let codeTextField = UITextField().then {
-        $0.placeholder = i18N.codePlaceholder
-        $0.font = DSKitFontFamily.Suit.medium.font(size: 16)
-        $0.keyboardType = .numberPad
-        $0.backgroundColor = DSKitAsset.Colors.gray800.color
-        $0.layer.cornerRadius = 10
-        $0.layer.masksToBounds = true
-        $0.layer.borderWidth = 1
-        $0.layer.borderColor = UIColor.clear.cgColor
-        $0.isHidden = true
-        $0.addToolbar()
-        $0.addLeftPadding(width: 20)
-        $0.addRightPadding(width: 63)
-    }
-    
+
+    // TODO: MDSTextField가 textDidChangePublisher/keyboardType API를 노출하면 phoneTextField와 함께 대체
+    private lazy var codeTextField: UITextField = {
+        guard let textField = codeField.firstSubview(ofType: UITextField.self) else {
+            fatalError("codeField 내부에서 UITextField를 찾을 수 없습니다.")
+        }
+        textField.keyboardType = .numberPad
+        textField.addToolbar()
+        textField.addRightPadding(width: 68)
+        return textField
+    }()
+
     private let timeLeftLabel = UILabel().then {
-        $0.font = DSKitFontFamily.Suit.medium.font(size: 14)
-        $0.textColor = DSKitAsset.Colors.white.color
         $0.text = i18N.defaultTimerText
+        $0.setTypography(Typography.body1, textColor: SemanticColor.Fg.Neutral.bold)
     }
-    
-    private let codeFailIcon = UIImageView().then {
-        $0.image = DSKitAsset.Assets.alertCircle.image.withTintColor(DSKitAsset.Colors.error.color)
-        $0.contentMode = .scaleAspectFit
-        $0.isHidden = true
-    }
-    
-    private let codeFailLabel = UILabel().then {
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.error.color
-        $0.isHidden = true
-    }
-    
-    private let helpView = UIView().then {
-        $0.backgroundColor = DSKitAsset.Colors.blue400.color.withAlphaComponent(0.1)
-        $0.layer.borderColor = DSKitAsset.Colors.blue400.color.withAlphaComponent(0.6).cgColor
-        $0.layer.borderWidth = 1
-        $0.layer.cornerRadius = 10
-        $0.layer.masksToBounds = true
-    }
-    
-    private let infoIcon = UIImageView().then {
-        $0.image = DSKitAsset.Assets.infoCircle.image.withTintColor(
-            DSKitAsset.Colors.blue500.color
-        )
-        $0.contentMode = .scaleAspectFit
-    }
-    
-    private let helpTitleLabel = UILabel().then {
-        $0.text = i18N.helpTitle
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
-        $0.textColor = DSKitAsset.Colors.gray30.color
-    }
-    
-    private let chevronRightIcon = UIImageView().then {
-        $0.image = DSKitAsset.Assets.chevronRight.image.withTintColor(
-            DSKitAsset.Colors.gray30.color
-        )
-        $0.contentMode = .scaleAspectFit
-    }
-    
-    private let helpDescriptionLabel = UILabel().then {
-        $0.text = i18N.helpDescription
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.gray200.color
-        $0.numberOfLines = 0
-    }
-    
-    private let doneButton = AppImageTextButton(title: i18N.doneButtonTitle).then {
-        $0.configuration?.attributedTitle?.font = DSKitFontFamily.Suit.semiBold.font(size: 18)
-    }
+
+    private let helpCallout = MDSCallout(
+        style: .information,
+        text: i18N.helpDescription,
+        icon: .alertCircleOutlined,
+        buttonTitle: i18N.inquireButtonTitle
+    )
+
+    private let doneButton = MDSActionButton(variant: .primary, size: .large, title: i18N.doneButtonTitle)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setUI()
         setLayout()
-        
     }
     
     required init?(coder: NSCoder) {
@@ -175,127 +120,61 @@ final class PhoneVerifyView: UIView {
         self.addSubviews(
             titleLabel,
             descriptionLabel,
-            phoneLabel,
-            phoneTextField,
-            phoneFailIcon,
-            phoneFailLabel,
+            phoneField,
             sendButton,
-            codeTextField,
-            codeFailIcon,
-            codeFailLabel,
-            helpView,
+            codeField,
+            helpCallout,
             doneButton
         )
-        
+
         codeTextField.addSubview(timeLeftLabel)
-        
-        helpView.addSubviews(
-            infoIcon,
-            helpTitleLabel,
-            chevronRightIcon,
-            helpDescriptionLabel
-        )
+
+        setSendButtonTitle(Self.i18N.sendButtonTitle)
     }
     
     private func setLayout() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(54)
+            $0.top.equalToSuperview()
             $0.centerX.equalToSuperview()
         }
-        
+
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(14)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(BaseSpacing.Base.s8)
             $0.centerX.equalToSuperview()
         }
-        
-        phoneLabel.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(40)
-            $0.leading.trailing.equalToSuperview().inset(24)
-        }
-        
-        phoneTextField.snp.makeConstraints {
-            $0.top.equalTo(phoneLabel.snp.bottom).offset(6)
-            $0.leading.equalToSuperview().inset(24)
-            $0.height.equalTo(48)
-        }
-        
-        phoneFailIcon.snp.makeConstraints {
-            $0.top.equalTo(phoneTextField.snp.bottom).offset(8)
-            $0.leading.equalTo(phoneTextField)
-            $0.size.equalTo(14)
-        }
-        
-        phoneFailLabel.snp.makeConstraints {
-            $0.centerY.equalTo(phoneFailIcon)
-            $0.leading.equalTo(phoneFailIcon.snp.trailing).offset(4)
-            $0.trailing.equalTo(codeTextField)
-        }
-        
+
         sendButton.snp.makeConstraints {
             $0.centerY.equalTo(phoneTextField)
-            $0.leading.equalTo(phoneTextField.snp.trailing).offset(7)
-            $0.trailing.equalToSuperview().inset(24)
-            $0.width.equalTo(110)
-            $0.height.equalTo(phoneTextField)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(46)
+            $0.width.equalTo(109)
         }
-        
-        codeTextField.snp.makeConstraints {
-            $0.top.equalTo(phoneFailLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(phoneTextField)
+
+        phoneField.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(BaseSpacing.Base.s48)
+            $0.leading.equalToSuperview().inset(20)
+            $0.trailing.equalTo(sendButton.snp.leading).offset(-BaseSpacing.Base.s8)
+        }
+
+        codeField.snp.makeConstraints {
+            $0.top.equalTo(phoneField.snp.bottom).offset(BaseSpacing.Base.s10)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.lessThanOrEqualToSuperview()
         }
-        
+
         timeLeftLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(BaseSpacing.Base.s16)
         }
-        
-        codeFailIcon.snp.makeConstraints {
-            $0.top.equalTo(codeTextField.snp.bottom).offset(8)
-            $0.leading.equalTo(codeTextField)
-            $0.size.equalTo(14)
-        }
-        
-        codeFailLabel.snp.makeConstraints {
-            $0.centerY.equalTo(codeFailIcon)
-            $0.leading.equalTo(codeFailIcon.snp.trailing).offset(4)
-            $0.trailing.equalTo(codeTextField)
-        }
-        
-        helpView.snp.makeConstraints {
-            $0.top.equalTo(codeFailLabel.snp.bottom).offset(20)
+
+        helpCallout.snp.makeConstraints {
             $0.leading.trailing.equalTo(codeTextField)
+            $0.bottom.equalTo(doneButton.snp.top).offset(-BaseSpacing.Base.s24)
         }
-        
-        infoIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14)
-            $0.leading.equalToSuperview().inset(18)
-            $0.size.equalTo(20)
-        }
-        
-        helpTitleLabel.snp.makeConstraints {
-            $0.centerY.equalTo(infoIcon)
-            $0.leading.equalTo(infoIcon.snp.trailing).offset(10)
-        }
-        
-        chevronRightIcon.snp.makeConstraints {
-            $0.centerY.equalTo(helpTitleLabel)
-            $0.leading.equalTo(helpTitleLabel.snp.trailing)
-            $0.size.equalTo(16)
-        }
-        
-        helpDescriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(helpTitleLabel.snp.bottom).offset(10)
-            $0.leading.equalTo(helpTitleLabel)
-            $0.trailing.equalToSuperview().inset(18)
-            $0.bottom.equalToSuperview().inset(14)
-        }
-        
+
         doneButton.snp.makeConstraints {
             $0.bottom.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(56)
+            $0.leading.trailing.equalToSuperview().inset(20)
         }
     }
 }
@@ -312,8 +191,8 @@ extension PhoneVerifyView {
             .sink { owner, isSent in
                 let text = isSent ? Self.i18N.resendButtonTitle : Self.i18N.sendButtonTitle
                 ToastUtils.showMDSToast(type: .success, text: Self.i18N.sendSuccessToast)
-                owner.sendButton.updateTitle(text)
-                owner.codeTextField.isHidden = !isSent
+                owner.setSendButtonTitle(text)
+                owner.codeField.isHidden = !isSent
             }
             .store(in: cancelBag)
         
@@ -359,6 +238,7 @@ extension PhoneVerifyView {
             .withUnretained(self)
             .sink { owner, isEnabled in
                 owner.sendButton.isEnabled = isEnabled
+                owner.sendButton.backgroundColor = isEnabled ? SemanticColor.Bg.Neutral.inverse : SemanticColor.Bg.Neutral.Default.disabled
             }
             .store(in: cancelBag)
         
@@ -373,6 +253,7 @@ extension PhoneVerifyView {
             .withUnretained(self)
             .sink { owner, timeLeft in
                 owner.timeLeftLabel.text = timeLeft.to_mmss
+                owner.refreshTimeLeftLabel()
             }
             .store(in: cancelBag)
         
@@ -385,16 +266,48 @@ extension PhoneVerifyView {
     }
     
     private func updateFailLabelUI(isCode: Bool, _ description: String?) {
-        let failLabel = isCode ? codeFailLabel : phoneFailLabel
-        let failIcon = isCode ? codeFailIcon : phoneFailIcon
-        let textfield = isCode ? codeTextField : phoneTextField
-        failLabel.text = description
-        failIcon.isHidden = description == nil
-        failLabel.isHidden = description == nil
-        textfield.layer.borderColor = description == nil ? UIColor.clear.cgColor : DSKitAsset.Colors.error.color.cgColor
-        
+        let field = isCode ? codeField : phoneField
+        field.errorMessage = description
+
         if isCode {
-            timeLeftLabel.textColor = description == nil ? DSKitAsset.Colors.white.color : DSKitAsset.Colors.error.color
+            isTimeLeftError = description != nil
+            refreshTimeLeftLabel()
         }
+    }
+
+    private func refreshTimeLeftLabel() {
+        let color = isTimeLeftError ? SemanticColor.Fg.Danger.default : SemanticColor.Fg.Neutral.bold
+        timeLeftLabel.setTypography(Typography.body1, textColor: color)
+    }
+
+    private func setSendButtonTitle(_ text: String) {
+        sendButton.setAttributedTitle(
+            NSAttributedString(
+                string: text,
+                attributes: Typography.label3.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.inverse)
+            ),
+            for: .normal
+        )
+        sendButton.setAttributedTitle(
+            NSAttributedString(
+                string: text,
+                attributes: Typography.label3.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.Default.disabled)
+            ),
+            for: .disabled
+        )
+    }
+}
+
+private extension UIView {
+    func firstSubview<T: UIView>(ofType type: T.Type) -> T? {
+        for subview in subviews {
+            if let matched = subview as? T {
+                return matched
+            }
+            if let matched = subview.firstSubview(ofType: type) {
+                return matched
+            }
+        }
+        return nil
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SearchSocialAccountScene/SearchSocialVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SearchSocialAccountScene/SearchSocialVC.swift
@@ -53,6 +53,10 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
         type: .oneLeftButton,
         backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
+    ).setLeftButtonImage(
+        MDSIcon.chevronLeftOutlined.image
+            .withRenderingMode(.alwaysTemplate)
+            .withTintColor(SemanticColor.Fg.Neutral.bold, renderingMode: .alwaysOriginal)
     )
    
     
@@ -85,7 +89,7 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
         }
 
         phoneVerifyView.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom).offset(54)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(BaseSpacing.Base.s24)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
@@ -101,6 +105,6 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
             verifySuccess: pvOutput.verifySuccess.asDriver()
         )
         
-        let output = viewModel.transform(from: input, cancelBag: cancelBag)
+        let _ = viewModel.transform(from: input, cancelBag: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SearchSocialAccountScene/SearchSocialVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SearchSocialAccountScene/SearchSocialVC.swift
@@ -11,6 +11,7 @@ import Combine
 
 import DSKit
 import Core
+import MDS
 
 import AuthFeatureInterface
 import BaseFeatureDependency
@@ -50,7 +51,7 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
     private lazy var navigationBar = OPNavigationBar(
         self,
         type: .oneLeftButton,
-        backgroundColor: DSKitAsset.Colors.black100.color,
+        backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
     )
    
@@ -68,7 +69,7 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
     // MARK: - UI & Layout
     
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.black100.color
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
         self.phoneVerifyView.helpViewHidden = true
     }
     
@@ -91,7 +92,6 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
     }
     
     private func bind() {
-        
         let pvInput = phoneVerifyView.viewModelInput
         let pvOutput = phoneVerifyViewModel.transform(from: pvInput, cancelBag: cancelBag)
         phoneVerifyView.bindOutput(pvOutput, cancelBag: cancelBag)
@@ -102,8 +102,5 @@ public class SearchSocialAccountVC: UIViewController, SearchSocialAccountViewCon
         )
         
         let output = viewModel.transform(from: input, cancelBag: cancelBag)
-        
-        
     }
-    
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
@@ -11,8 +11,8 @@ import Combine
 
 import BaseFeatureDependency
 import Core
-import DSKit
 import Domain
+import MDS
 
 public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomSheetRoutingTrigger {
     
@@ -23,62 +23,37 @@ public final class LoginHelpBottomSheetVC: UIViewController, LoginHelpBottomShee
     private let cancelBag = CancelBag()
     
     public var minimumContentHeight: CGFloat {
-        return 202.adjustedH
+        return 206.adjusted
     }
     
     // MARK: - Views
     
     private let warnImageView = UIImageView().then {
-        $0.image = DSKitAsset.Assets.alertCircle.image
+        $0.image = MDSIcon.alertCircleOutlined.image.withRenderingMode(.alwaysTemplate)
+        $0.tintColor = SemanticColor.Fg.Neutral.bold
     }
-    
+
     private let titleLabel = UILabel().then {
         $0.text = i18n.helpLogin
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 20)
-        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.setTypography(Typography.title3, textColor: SemanticColor.Fg.Neutral.bold)
     }
-    
-    private let wantToKnowAccountButton = UIButton().then {
-        $0.setTitleColor(DSKitAsset.Colors.gray10.color, for: .normal)
-        $0.setTitle(i18n.wantToKnowAccount, for: .normal)
-        $0.contentHorizontalAlignment = .leading
-        $0.titleEdgeInsets = .init(top: 0, left: 10, bottom: 0, right: 0)
-        $0.titleLabel?.font = DSKitFontFamily.Suit.regular.font(size: 16)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray700.color, for: .highlighted)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray800.color, for: .normal)
-        $0.layer.cornerRadius = 8
-        $0.layer.masksToBounds = true
+
+    private let wantToKnowAccountButton = LoginHelpOptionButton(title: i18n.wantToKnowAccount)
+    private let resetSocialAccountButton = LoginHelpOptionButton(title: i18n.resetSocialAccount)
+    private let inquireToKakaoTalkButton = LoginHelpOptionButton(title: i18n.inquireToKakaoTalk)
+
+    private lazy var optionButtonStackView = UIStackView(
+        arrangedSubviews: [wantToKnowAccountButton, resetSocialAccountButton, inquireToKakaoTalkButton]
+    ).then {
+        $0.axis = .vertical
+        $0.spacing = BaseSpacing.Base.s4
     }
-    
-    private let resetSocialAccountButton = UIButton().then {
-        $0.setTitleColor(DSKitAsset.Colors.gray10.color, for: .normal)
-        $0.setTitle(i18n.resetSocialAccount, for: .normal)
-        $0.titleLabel?.font = DSKitFontFamily.Suit.regular.font(size: 16)
-        $0.contentHorizontalAlignment = .leading
-        $0.titleEdgeInsets = .init(top: 0, left: 10, bottom: 0, right: 0)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray700.color, for: .highlighted)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray800.color, for: .normal)
-        $0.layer.cornerRadius = 8
-        $0.layer.masksToBounds = true
-    }
-    
-    private let inquireToKakaoTalkButton = UIButton().then {
-        $0.setTitleColor(DSKitAsset.Colors.gray10.color, for: .normal)
-        $0.setTitle(i18n.inquireToKakaoTalk, for: .normal)
-        $0.titleLabel?.font = DSKitFontFamily.Suit.regular.font(size: 16)
-        $0.contentHorizontalAlignment = .leading
-        $0.titleEdgeInsets = .init(top: 0, left: 10, bottom: 0, right: 0)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray700.color, for: .highlighted)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray800.color, for: .normal)
-        $0.layer.cornerRadius = 8
-        $0.layer.masksToBounds = true
-    }
-    
+
     public init() {
         super.init(nibName: nil, bundle: nil)
-        
-        self.view.backgroundColor = DSKitAsset.Colors.gray800.color
-        
+
+        self.view.backgroundColor = SemanticColor.Bg.Neutral.ghost
+
         self.setLayout()
         self.bindAction()
     }
@@ -95,39 +70,29 @@ extension LoginHelpBottomSheetVC {
         self.view.addSubviews(
             warnImageView,
             titleLabel,
-            wantToKnowAccountButton,
-            resetSocialAccountButton,
-            inquireToKakaoTalkButton
+            optionButtonStackView
         )
-        
+
         self.warnImageView.snp.makeConstraints {
             $0.size.equalTo(24)
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(24)
-            $0.leading.equalToSuperview().inset(20)
-            
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(19)
+            $0.leading.equalToSuperview().inset(12)
         }
-        
+
         self.titleLabel.snp.makeConstraints {
             $0.centerY.equalTo(warnImageView)
-            $0.leading.equalTo(warnImageView.snp.trailing).offset(4)
+            $0.leading.equalTo(warnImageView.snp.trailing).offset(BaseSpacing.Base.s4)
         }
-        
-        self.wantToKnowAccountButton.snp.makeConstraints {
-            $0.top.equalTo(warnImageView.snp.bottom).offset(12)
-            $0.horizontalEdges.equalToSuperview().inset(14)
-            $0.height.equalTo(44)
+
+        [wantToKnowAccountButton, resetSocialAccountButton, inquireToKakaoTalkButton].forEach {
+            $0.snp.makeConstraints {
+                $0.height.equalTo(44)
+            }
         }
-        
-        self.resetSocialAccountButton.snp.makeConstraints {
-            $0.top.equalTo(wantToKnowAccountButton.snp.bottom).offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(14)
-            $0.height.equalTo(wantToKnowAccountButton.snp.height)
-        }
-        
-        self.inquireToKakaoTalkButton.snp.makeConstraints {
-            $0.top.equalTo(resetSocialAccountButton.snp.bottom).offset(4)
-            $0.horizontalEdges.equalToSuperview().inset(14)
-            $0.height.equalTo(wantToKnowAccountButton.snp.height)
+
+        self.optionButtonStackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(BaseSpacing.Base.s12)
+            $0.horizontalEdges.equalToSuperview().inset(BaseSpacing.Base.s8)
             $0.bottom.lessThanOrEqualTo(view.safeAreaLayoutGuide).inset(8)
         }
     }
@@ -163,3 +128,29 @@ extension LoginHelpBottomSheetVC {
     }
 }
 
+private final class LoginHelpOptionButton: UIButton {
+
+    init(title: String) {
+        super.init(frame: .zero)
+
+        self.configureUI(title: title)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureUI(title: String) {
+        self.setAttributedTitle(
+            NSAttributedString(string: title,
+                               attributes: Typography.body2.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.bold)),
+            for: .normal
+        )
+        self.contentHorizontalAlignment = .leading
+        self.titleEdgeInsets = .init(top: BaseSpacing.Base.s10, left: BaseSpacing.Base.s10, bottom: BaseSpacing.Base.s10, right: 0)
+        self.setBackgroundColor(SemanticColor.Bg.Neutral.Ghost.hover, for: .highlighted)
+        self.setBackgroundColor(.clear, for: .normal)
+        self.layer.cornerRadius = BaseRadius.Base.r8
+        self.layer.masksToBounds = true
+    }
+}

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/LoginHelpBottomSheetVC.swift
@@ -141,16 +141,23 @@ private final class LoginHelpOptionButton: UIButton {
     }
 
     private func configureUI(title: String) {
-        self.setAttributedTitle(
+        var configuration = UIButton.Configuration.plain()
+        configuration.attributedTitle = AttributedString(
             NSAttributedString(string: title,
-                               attributes: Typography.body2.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.bold)),
-            for: .normal
+                               attributes: Typography.body2.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.bold))
         )
+        configuration.contentInsets = .init(top: BaseSpacing.Base.s10,
+                                            leading: BaseSpacing.Base.s10,
+                                            bottom: BaseSpacing.Base.s10,
+                                            trailing: 0)
+        configuration.background.cornerRadius = BaseRadius.Base.r8
+        self.configuration = configuration
+
         self.contentHorizontalAlignment = .leading
-        self.titleEdgeInsets = .init(top: BaseSpacing.Base.s10, left: BaseSpacing.Base.s10, bottom: BaseSpacing.Base.s10, right: 0)
-        self.setBackgroundColor(SemanticColor.Bg.Neutral.Ghost.hover, for: .highlighted)
-        self.setBackgroundColor(.clear, for: .normal)
-        self.layer.cornerRadius = BaseRadius.Base.r8
-        self.layer.masksToBounds = true
+        self.configurationUpdateHandler = { button in
+            button.configuration?.background.backgroundColor = button.isHighlighted
+            ? SemanticColor.Bg.Neutral.Ghost.hover
+            : .clear
+        }
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
@@ -13,6 +13,7 @@ import SafariServices
 import DSKit
 import Core
 import Domain
+import MDS
 
 import AuthFeatureInterface
 import BaseFeatureDependency
@@ -47,78 +48,44 @@ public class SignInVC: UIViewController, SignInViewControllable {
         $0.alpha = 0
     }
     
-    private let loginHelpButton = UIButton(type: .system).then {
-        var config = UIButton.Configuration.plain()
-        config.baseForegroundColor = DSKitAsset.Colors.gray30.color
-        config.baseBackgroundColor = .clear
-        
-        var attributedTitle = AttributedString(i18n.helpLogin)
-        attributedTitle.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
-        config.attributedTitle = attributedTitle
-        
-        config.image = DSKitAsset.Assets.chevronRight.image.withTintColor(DSKitAsset.Colors.gray30.color).withRenderingMode(.alwaysTemplate)
-        config.imagePadding = 0
-        config.imagePlacement = .trailing
-        
-        $0.configuration = config
+    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin).then {
         $0.alpha = 0
     }
-    
+
     private let leftLine = UIView().then {
-        $0.backgroundColor = DSKitAsset.Colors.gray300.color
+        $0.backgroundColor = SemanticColor.Stroke.Neutral.subtle
     }
-    
+
     private let rightLine = UIView().then {
-        $0.backgroundColor = DSKitAsset.Colors.gray300.color
+        $0.backgroundColor = SemanticColor.Stroke.Neutral.subtle
     }
-    
+
     private let orLabel = UILabel().then {
         $0.text = i18n.or
-        $0.font = DSKitFontFamily.Suit.regular.font(size: 13)
+        $0.setTypography(Typography.label4, textColor: SemanticColor.Fg.Neutral.ghost)
     }
-    
+
     private lazy var orStackView = UIStackView().then {
         $0.axis = .horizontal
         $0.alignment = .center
         $0.distribution = .fill
-        $0.spacing = 8
+        $0.spacing = BaseSpacing.Base.s8
         $0.alpha = 0
     }
-    
-    private lazy var signUpButton = UIButton(type: .system).then {
-        $0.setTitle(Self.i18n.signUp, for: .normal)
-        $0.setTitleColor(DSKitAsset.Colors.white.color, for: .normal)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray700.color, for: .normal)
-        $0.setBackgroundColor(DSKitAsset.Colors.gray800.color, for: .highlighted)
-        $0.titleLabel?.font = DSKitFontFamily.Suit.semiBold.font(size: 16)
-        $0.layer.cornerRadius = 10
-        $0.layer.masksToBounds = true
+
+    private lazy var signUpButton = MDSActionButton(variant: .secondary, size: .medium, title: Self.i18n.signUp).then {
         $0.alpha = 0
     }
-    
-    
-    private let loginLaterButton = UIButton(type: .system).then {
-        var config = UIButton.Configuration.plain()
-        config.baseForegroundColor = DSKitAsset.Colors.gray30.color
-        config.baseBackgroundColor = .clear
-        
-        var attributedTitle = AttributedString(i18n.loginLater)
-        attributedTitle.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
-        config.attributedTitle = attributedTitle
-        
-        config.image = DSKitAsset.Assets.chevronRight.image.withTintColor(DSKitAsset.Colors.gray30.color)
-        config.imagePadding = 0
-        config.imagePlacement = .trailing
-        
-        $0.configuration = config
+
+
+    private let loginLaterButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.loginLater).then {
         $0.alpha = 0
     }
-    
+
     private let recentLoginLabel = UILabel().then {
-        $0.font = DSKitFontFamily.Suit.medium.font(size: 13)
-        $0.textColor = DSKitAsset.Colors.gray50.color
+        $0.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.bold)
     }
-    
+
     private let recentLoginToolTip = ToolTipView()
     
     
@@ -161,10 +128,10 @@ public class SignInVC: UIViewController, SignInViewControllable {
     }
     
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.soptampBlack.color
-        
-        self.recentLoginToolTip.layer.cornerRadius = 12
-        self.recentLoginToolTip.backgroundColor = DSKitAsset.Colors.success.color
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
+
+        self.recentLoginToolTip.layer.cornerRadius = BaseRadius.Base.r12
+        self.recentLoginToolTip.backgroundColor = SemanticColor.Bg.Secondary.default
         self.recentLoginToolTip.contentView.addSubview(recentLoginLabel)
         self.recentLoginToolTip.alpha = 0
     }
@@ -183,8 +150,8 @@ public class SignInVC: UIViewController, SignInViewControllable {
         recentLoginToolTip.addSubview(recentLoginLabel)
         
         recentLoginLabel.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(10)
-            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.verticalEdges.equalToSuperview().inset(BaseSpacing.Base.s10)
+            $0.horizontalEdges.equalToSuperview().inset(BaseSpacing.Base.s20)
         }
         
         orStackView.addArrangedSubviews(leftLine, orLabel, rightLine)
@@ -198,13 +165,12 @@ public class SignInVC: UIViewController, SignInViewControllable {
         
         oAuthView.snp.makeConstraints { make in
             make.horizontalEdges.equalToSuperview().inset(20)
-            make.bottom.equalTo(loginHelpButton.snp.top).offset(-20.adjustedH)
+            make.bottom.equalTo(loginHelpButton.snp.top).offset(-BaseSpacing.Base.s24)
         }
-        
+
         loginHelpButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.height.equalTo(20.adjustedH)
-            make.bottom.equalTo(orStackView.snp.top).offset(-44.adjustedH)
+            make.bottom.equalTo(orStackView.snp.top).offset(-BaseSpacing.Base.s40)
         }
         
         leftLine.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -223,18 +189,17 @@ public class SignInVC: UIViewController, SignInViewControllable {
         
         orStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
-            make.bottom.equalTo(signUpButton.snp.top).inset(-16.adjustedH)
+            make.bottom.equalTo(signUpButton.snp.top).inset(-BaseSpacing.Base.s16)
         }
-        
+
         signUpButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(48)
-            make.bottom.equalTo(loginLaterButton.snp.top).offset(-16.adjustedH)
+            make.bottom.equalTo(loginLaterButton.snp.top).offset(-BaseSpacing.Base.s24)
         }
         
         loginLaterButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(28.adjustedH)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(40.adjustedH)
         }
         
         recentLoginToolTip.snp.makeConstraints { make in
@@ -303,8 +268,9 @@ extension SignInVC {
                 owner.recentLoginToolTip.isHidden = oAuthProvider == nil
                 
                 guard let oAuthProvider else { return }
-                
+
                 owner.recentLoginLabel.text = "최근 로그인한 계정은 \(oAuthProvider.title)이에요."
+                owner.recentLoginLabel.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.bold)
             }
             .store(in: cancelBag)
         

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
@@ -48,7 +48,7 @@ public class SignInVC: UIViewController, SignInViewControllable {
         $0.alpha = 0
     }
     
-    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin).then {
+    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin, icon: .chevronRightOutlined).then {
         $0.alpha = 0
     }
 
@@ -78,7 +78,7 @@ public class SignInVC: UIViewController, SignInViewControllable {
     }
 
 
-    private let loginLaterButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.loginLater).then {
+    private let loginLaterButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.loginLater, icon: .chevronRightOutlined).then {
         $0.alpha = 0
     }
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/SignInVC.swift
@@ -88,7 +88,6 @@ public class SignInVC: UIViewController, SignInViewControllable {
 
     private let recentLoginToolTip = ToolTipView()
     
-    
     // MARK: - View Life Cycle
     
     init(viewModel: SignInViewModel) {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
@@ -47,7 +47,7 @@ public final class UserNotFoundVC: UIViewController, UserNotFoundRoutingTrigger 
 
     private let loginRetryButton = MDSActionButton(variant: .primary, size: .large, title: i18n.retryLogin)
 
-    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin)
+    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin, icon: .chevronRightOutlined)
 
     
     // MARK: - View Life Cycle

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignInScene/UserNotFoundVC.swift
@@ -11,6 +11,7 @@ import UIKit
 import BaseFeatureDependency
 import Core
 import DSKit
+import MDS
 
 public final class UserNotFoundVC: UIViewController, UserNotFoundRoutingTrigger {
 
@@ -29,38 +30,24 @@ public final class UserNotFoundVC: UIViewController, UserNotFoundRoutingTrigger 
     }
     
     private let titleLabel = UILabel().then {
-        $0.text = i18n.userNotFound
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 24)
-        $0.textColor = .white
-        $0.partColorChange(targetString: I18N.SignIn.Refactor.userInfo, textColor: DSKitAsset.Colors.secondary.color)
+        let fullText = i18n.userNotFound
+        let attributedString = NSMutableAttributedString(
+            string: fullText,
+            attributes: Typography.title2.attributedStringAttributes(foregroundColor: SemanticColor.Fg.Neutral.bold)
+        )
+        let range = (fullText as NSString).range(of: I18N.SignIn.Refactor.userInfo)
+        attributedString.addAttribute(.foregroundColor, value: SemanticColor.Fg.Brand.default, range: range)
+        $0.attributedText = attributedString
     }
 
-    
     private let descriptionLabel = UILabel().then {
         $0.text = i18n.signUpFirst
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 18)
-        $0.textColor = .white
+        $0.setTypography(Typography.label2, textColor: SemanticColor.Fg.Neutral.subtle)
     }
 
-    
-    private let loginRetryButton = AppCustomButton(title: i18n.retryLogin)
-        .setConfigForState(enabledFont: DSKitFontFamily.Suit.semiBold.font(size: 18))
-    
-    private let loginHelpButton = UIButton(type: .system).then {
-        var config = UIButton.Configuration.plain()
-        config.baseForegroundColor = DSKitAsset.Colors.gray30.color
-        config.baseBackgroundColor = .clear
-        
-        var attributedTitle = AttributedString(i18n.helpLogin)
-        attributedTitle.font = DSKitFontFamily.Suit.semiBold.font(size: 14)
-        config.attributedTitle = attributedTitle
-        
-        config.image = DSKitAsset.Assets.chevronRight.image.withTintColor(DSKitAsset.Colors.gray30.color).withRenderingMode(.alwaysTemplate)
-        config.imagePadding = 0
-        config.imagePlacement = .trailing
-        
-        $0.configuration = config
-    }
+    private let loginRetryButton = MDSActionButton(variant: .primary, size: .large, title: i18n.retryLogin)
+
+    private let loginHelpButton = MDSTextButton(variant: .emphasis, size: .medium, title: i18n.helpLogin)
 
     
     // MARK: - View Life Cycle
@@ -82,7 +69,7 @@ public final class UserNotFoundVC: UIViewController, UserNotFoundRoutingTrigger 
 extension UserNotFoundVC {
     
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.soptampBlack.color
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
     }
     
     private func setLayout() {
@@ -97,28 +84,27 @@ extension UserNotFoundVC {
         imageView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.size.equalTo(194.adjusted)
-            $0.bottom.equalTo(titleLabel.snp.top).offset(-8)
+            $0.bottom.equalTo(titleLabel.snp.top).offset(-BaseSpacing.Base.s8)
         }
-        
+
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.centerY.equalToSuperview().offset(12)
         }
-        
+
         descriptionLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(titleLabel.snp.bottom).offset(6)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(BaseSpacing.Base.s8)
         }
         
         loginRetryButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(48)
-            $0.bottom.equalTo(loginHelpButton.snp.top).offset(-16)
+            $0.bottom.equalTo(loginHelpButton.snp.top).offset(-BaseSpacing.Base.s24)
         }
         
         loginHelpButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(28.adjustedH)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(24.adjustedH)
         }
         
 

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpOAuthView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpOAuthView.swift
@@ -9,32 +9,30 @@
 import UIKit
 
 import Core
-import DSKit
+import MDS
 
 final class SignUpOAuthView: UIView {
     
-    private static let i18n = I18N.SignIn.Refactor.self
-    
+    private static let i18n = I18N.Auth.SocialLink.self
+
     public var viewModelInput: SignUpViewModel.Input.OAuth {
         .init(
             googleLoginTapped: oAuthView.googleLoginButton.publisher(for: .touchUpInside).mapVoid().asDriver(),
             appleLoginTapped: oAuthView.appleLoginButton.publisher(for: .touchUpInside).mapVoid().asDriver()
         )
     }
-    
+
     //MARK: - Properties
 
     private let titleLabel = UILabel().then {
-        $0.text = "소셜 계정 연동"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 24)
-        $0.textColor = DSKitAsset.Colors.gray10.color
+        $0.text = i18n.title
+        $0.setTypography(Typography.heading2, textColor: SemanticColor.Fg.Neutral.bold)
         $0.textAlignment = .center
     }
-    
+
     private let descriptionLabel = UILabel().then {
-        $0.text = "반갑습니다 회원님\n소셜로그인을 진행하여 회원가입을 완료해주세요"
-        $0.font = DSKitFontFamily.Suit.semiBold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.gray60.color
+        $0.text = i18n.description
+        $0.setTypography(Typography.body3, textColor: SemanticColor.Fg.Neutral.subtle)
         $0.textAlignment = .center
         $0.numberOfLines = 2
     }
@@ -54,28 +52,28 @@ final class SignUpOAuthView: UIView {
     
     
     private func setUI() {
-        self.backgroundColor = DSKitAsset.Colors.black100.color
+        self.backgroundColor = SemanticColor.Bg.Layer.basement
     }
-    
+
     private func setLayout() {
         self.addSubviews(
             titleLabel,
             descriptionLabel,
             oAuthView
         )
-        
+
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(54)
+            $0.top.equalToSuperview()
             $0.centerX.equalToSuperview()
         }
-        
+
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(14)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(BaseSpacing.Base.s8)
             $0.centerX.equalToSuperview()
         }
-        
+
         oAuthView.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).offset(66)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(BaseSpacing.Base.s64)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.lessThanOrEqualToSuperview()
         }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpVC.swift
@@ -11,6 +11,7 @@ import Combine
 
 import DSKit
 import Core
+import MDS
 
 import AuthFeatureInterface
 import BaseFeatureDependency
@@ -22,8 +23,8 @@ public class SignUpVC: UIViewController, SignUpViewControllable {
     
     //MARK: - Properties
     
-    private let phoneVerifyView = PhoneVerifyView()
-    private let oAuthView = SignUpOAuthView()
+    private let phoneVerifyView = PhoneVerifyView()         // SOPT 회원인증
+    private let oAuthView = SignUpOAuthView()               // 소셜 계정연동
     
     private let viewModel: SignUpViewModel
     private let phoneVerifyViewModel: PhoneVerifyViewModel
@@ -51,56 +52,40 @@ public class SignUpVC: UIViewController, SignUpViewControllable {
     private lazy var navigationBar = OPNavigationBar(
         self,
         type: .oneLeftButton,
-        backgroundColor: DSKitAsset.Colors.black100.color,
+        backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
     )
-    
+
     private let lineView = UIView().then {
-        $0.backgroundColor = DSKitAsset.Colors.black40.color
+        $0.backgroundColor = SemanticColor.Bg.Neutral.default
     }
-    
-    private let firstCircle = UILabel().then {
-        $0.text = "1"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.backgroundColor = DSKitAsset.Colors.blue400.color
-        $0.layer.cornerRadius = 11
-        $0.layer.masksToBounds = true
-        $0.textAlignment = .center
-    }
-    
+
+    private let firstStepIndicator = StepIndicatorView(
+        number: "1",
+        title: I18N.Auth.PhoneVerify.title,
+        circleTextColor: SemanticColor.Fg.Neutral.bold,
+        circleBackgroundColor: SemanticColor.Bg.Secondary.default,
+        titleTextColor: SemanticColor.Fg.Neutral.bold
+    )
+
+    private let secondStepIndicator = StepIndicatorView(
+        number: "2",
+        title: I18N.Auth.SocialLink.title,
+        circleTextColor: SemanticColor.Fg.Neutral.ghost,
+        circleBackgroundColor: SemanticColor.Bg.Neutral.default,
+        titleTextColor: SemanticColor.Fg.Neutral.ghost
+    )
+
     private let checkImageView = UIImageView().then {
-        $0.image = DSKitAsset.Assets.check.image.withAlignmentRectInsets(.init(top: -4, left: -4, bottom: -4, right: -4))
+        $0.image = MDSIcon.checkOutlined.image.withRenderingMode(.alwaysTemplate).withAlignmentRectInsets(.init(top: -4, left: -4, bottom: -4, right: -4))
+        $0.tintColor = SemanticColor.Fg.Neutral.bold
         $0.contentMode = .scaleAspectFit
-        $0.backgroundColor = DSKitAsset.Colors.blue400.color
-        $0.layer.cornerRadius = 11
+        $0.backgroundColor = SemanticColor.Bg.Secondary.default
+        $0.layer.cornerRadius = BaseRadius.Base.full
         $0.layer.masksToBounds = true
         $0.isHidden = true
     }
-    
-    private let secondCircle = UILabel().then {
-        $0.text = "2"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.backgroundColor = DSKitAsset.Colors.black40.color
-        $0.layer.cornerRadius = 11
-        $0.layer.masksToBounds = true
-        $0.textAlignment = .center
-    }
-    
-    private let firstLabel = UILabel().then {
-        $0.text = "SOPT 회원인증"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.white.color
-        $0.textAlignment = .center
-    }
-    
-    private let secondLabel = UILabel().then {
-        $0.text = "소셜 계정 연동"
-        $0.font = DSKitFontFamily.Suit.bold.font(size: 12)
-        $0.textColor = DSKitAsset.Colors.white.color
-        $0.textAlignment = .center
-    }
-   
-    
+
     // MARK: - View Life Cycle
     
     public override func viewDidLoad() {
@@ -110,24 +95,20 @@ public class SignUpVC: UIViewController, SignUpViewControllable {
         setLayout()
         bind()
     }
-    
 }
 
 // MARK: - UI & Layout
 
 extension SignUpVC {
-    
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.black100.color
-        
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
+
         self.view.addSubviews(
             navigationBar,
             lineView,
-            firstCircle,
+            firstStepIndicator,
             checkImageView,
-            secondCircle,
-            firstLabel,
-            secondLabel,
+            secondStepIndicator,
             phoneVerifyView,
             oAuthView
         )
@@ -140,40 +121,28 @@ extension SignUpVC {
         }
         
         lineView.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.top.equalTo(navigationBar.snp.bottom).offset(35)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(123)
+            $0.width.equalTo(136)
             $0.height.equalTo(1)
         }
         
-        firstCircle.snp.makeConstraints {
+        firstStepIndicator.snp.makeConstraints {
             $0.centerX.equalTo(lineView.snp.leading)
-            $0.centerY.equalTo(lineView)
-            $0.size.equalTo(22)
+            $0.top.equalTo(lineView.snp.centerY).offset(-11)
         }
-        
+
         checkImageView.snp.makeConstraints {
-            $0.edges.equalTo(firstCircle)
+            $0.edges.equalTo(firstStepIndicator.circleView)
         }
-        
-        secondCircle.snp.makeConstraints {
+
+        secondStepIndicator.snp.makeConstraints {
             $0.centerX.equalTo(lineView.snp.trailing)
-            $0.centerY.equalTo(lineView)
-            $0.size.equalTo(22)
+            $0.top.equalTo(lineView.snp.centerY).offset(-11)
         }
-        
-        firstLabel.snp.makeConstraints {
-            $0.top.equalTo(firstCircle.snp.bottom).offset(12)
-            $0.centerX.equalTo(firstCircle)
-        }
-        
-        secondLabel.snp.makeConstraints {
-            $0.top.equalTo(secondCircle.snp.bottom).offset(12)
-            $0.centerX.equalTo(secondCircle)
-        }
-        
+
         phoneVerifyView.snp.makeConstraints {
-            $0.top.equalTo(firstLabel.snp.bottom)
+            $0.top.equalTo(firstStepIndicator.titleLabel.snp.bottom).offset(32)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
@@ -181,11 +150,9 @@ extension SignUpVC {
         oAuthView.snp.makeConstraints {
             $0.edges.equalTo(phoneVerifyView)
         }
-        
     }
     
     private func bind() {
-
         let pvInput = phoneVerifyView.viewModelInput
         let pvOutput = phoneVerifyViewModel.transform(from: pvInput, cancelBag: cancelBag)
         phoneVerifyView.bindOutput(pvOutput, cancelBag: cancelBag)
@@ -202,13 +169,16 @@ extension SignUpVC {
         output.currentStep
             .withUnretained(self)
             .sink { owner, step in
-                let bg = step == .phoneVerify ? DSKitAsset.Colors.black40.color : DSKitAsset.Colors.blue400.color
+                let bg = step == .phoneVerify ? SemanticColor.Bg.Neutral.default : SemanticColor.Bg.Secondary.default
                 owner.phoneVerifyView.isHidden = step != .phoneVerify
                 owner.oAuthView.isHidden = step != .oAuth
                 owner.checkImageView.isHidden = step == .phoneVerify
                 owner.lineView.backgroundColor = bg
-                owner.secondCircle.backgroundColor = bg
+                owner.secondStepIndicator.setCircleBackgroundColor(bg)
                 owner.navigationBar.isHidden = step != .phoneVerify
+
+                owner.firstStepIndicator.setTitleActive(step == .phoneVerify)
+                owner.secondStepIndicator.setTitleActive(step != .phoneVerify)
             }
             .store(in: cancelBag)
         
@@ -218,5 +188,4 @@ extension SignUpVC {
                 Toast.showMDSToast(type: .success, text: "회원가입에 성공했습니다.")
             }.store(in: cancelBag)
     }
-    
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpVC.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/SignUpVC.swift
@@ -54,6 +54,10 @@ public class SignUpVC: UIViewController, SignUpViewControllable {
         type: .oneLeftButton,
         backgroundColor: SemanticColor.Bg.Layer.basement,
         ignoreLeftButtonAction: false
+    ).setLeftButtonImage(
+        MDSIcon.chevronLeftOutlined.image
+            .withRenderingMode(.alwaysTemplate)
+            .withTintColor(SemanticColor.Fg.Neutral.bold, renderingMode: .alwaysOriginal)
     )
 
     private let lineView = UIView().then {

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/StepIndicatorView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/StepIndicatorView.swift
@@ -58,9 +58,6 @@ extension StepIndicatorView {
         self.addSubviews(circleView, titleLabel)
         circleView.addSubview(numberLabel)
 
-        // circleView/titleLabel의 위치(top/centerX 등)는 여기서만 self(StepIndicatorView) 기준으로 고정한다.
-        // 호출부(SignUpVC 등)에서는 이 StepIndicatorView 자체(컨테이너)의 위치만 잡아야 한다.
-        // circleView에 호출부가 또 위치 제약을 걸면 여기 제약과 충돌한다.
         circleView.snp.makeConstraints {
             $0.top.centerX.equalToSuperview()
             $0.size.equalTo(22)
@@ -80,6 +77,7 @@ extension StepIndicatorView {
     }
 
     func setTitleActive(_ isActive: Bool) {
-        titleLabel.setTypography(Typography.label4, textColor: isActive ? SemanticColor.Fg.Neutral.bold : SemanticColor.Fg.Neutral.ghost)
+        titleLabel.setTypography(Typography.label4,
+                                 textColor: isActive ? SemanticColor.Fg.Neutral.bold : SemanticColor.Fg.Neutral.ghost)
     }
 }

--- a/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/StepIndicatorView.swift
+++ b/SOPT-iOS/Projects/Features/AuthFeature/Sources/SignUpScene/StepIndicatorView.swift
@@ -1,0 +1,85 @@
+//
+//  StepIndicatorView.swift
+//  AuthFeature
+//
+//  Created by yungu0010 on 8/7/26.
+//  Copyright © 2026 SOPT-iOS. All rights reserved.
+//
+
+import UIKit
+
+import Core
+import MDS
+
+import SnapKit
+import Then
+
+final class StepIndicatorView: UIView {
+
+    // MARK: - UI Components
+
+    let circleView = UIView().then {
+        $0.layer.cornerRadius = 11
+    }
+
+    private let numberLabel = UILabel().then {
+        $0.textAlignment = .center
+    }
+
+    let titleLabel = UILabel().then {
+        $0.textAlignment = .center
+    }
+
+    // MARK: - Init
+
+    init(
+        number: String,
+        title: String,
+        circleTextColor: UIColor,
+        circleBackgroundColor: UIColor,
+        titleTextColor: UIColor
+    ) {
+        super.init(frame: .zero)
+        numberLabel.text = number
+        numberLabel.setTypography(Typography.label4, textColor: circleTextColor)
+        circleView.backgroundColor = circleBackgroundColor
+        titleLabel.text = title
+        titleLabel.setTypography(Typography.label4, textColor: titleTextColor)
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+}
+
+// MARK: - Methods
+
+extension StepIndicatorView {
+    private func setLayout() {
+        self.addSubviews(circleView, titleLabel)
+        circleView.addSubview(numberLabel)
+
+        // circleView/titleLabel의 위치(top/centerX 등)는 여기서만 self(StepIndicatorView) 기준으로 고정한다.
+        // 호출부(SignUpVC 등)에서는 이 StepIndicatorView 자체(컨테이너)의 위치만 잡아야 한다.
+        // circleView에 호출부가 또 위치 제약을 걸면 여기 제약과 충돌한다.
+        circleView.snp.makeConstraints {
+            $0.top.centerX.equalToSuperview()
+            $0.size.equalTo(22)
+        }
+        numberLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(circleView.snp.bottom).offset(BaseSpacing.Base.s12)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
+    }
+
+    func setCircleBackgroundColor(_ color: UIColor) {
+        circleView.backgroundColor = color
+    }
+
+    func setTitleActive(_ isActive: Bool) {
+        titleLabel.setTypography(Typography.label4, textColor: isActive ? SemanticColor.Fg.Neutral.bold : SemanticColor.Fg.Neutral.ghost)
+    }
+}

--- a/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/SplashVC.swift
+++ b/SOPT-iOS/Projects/Features/SplashFeature/Sources/SplashScene/VC/SplashVC.swift
@@ -12,6 +12,7 @@ import Combine
 import Core
 import DSKit
 import Domain
+import MDS
 
 import SnapKit
 import Then
@@ -64,7 +65,7 @@ extension SplashVC {
     }
     
     private func setUI() {
-        self.view.backgroundColor = DSKitAsset.Colors.soptampBlack.color
+        self.view.backgroundColor = SemanticColor.Bg.Layer.basement
     }
     
     private func setLayout() {

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -45,6 +45,6 @@ let package = Package(
         .package(url: "https://github.com/amplitude/Amplitude-Swift", from: "1.11.10"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "9.0.0"),
-        .package(url: "https://github.com/sopt-makers/SOPT-iOS-MDS", from: "1.1.0"),
+        .package(url: "https://github.com/sopt-makers/SOPT-iOS-MDS.git", from: "1.1.1"),
     ]
 )

--- a/SOPT-iOS/Tuist/Package.swift
+++ b/SOPT-iOS/Tuist/Package.swift
@@ -45,6 +45,6 @@ let package = Package(
         .package(url: "https://github.com/amplitude/Amplitude-Swift", from: "1.11.10"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.12.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "9.0.0"),
-        .package(url: "https://github.com/sopt-makers/SOPT-iOS-MDS", from: "1.0.1"),
+        .package(url: "https://github.com/sopt-makers/SOPT-iOS-MDS", from: "1.1.0"),
     ]
 )


### PR DESCRIPTION
## 🌴 PR 요약

SplashFeature / AuthFeature를 MDS 토큰·컴포넌트로 마이그레이션했습니다.

🌱 작업한 브랜치
- refactor/#956

## 🌱 PR Point

### 스플래시/로그인 화면 MDS 마이그레이션
- 로그인 화면 전반에서 공용으로 쓰는 `OAuthView`의 구글/애플 로그인 버튼을 `AppImageTextButton` → `MDSActionButton`으로 교체하고, 배경색·아이콘도 MDS 토큰·아이콘으로 변경했습니다.
- `UserNotFoundVC`의 강조 텍스트를 `partColorChange` 대신 `NSAttributedString` + `SemanticColor` 조합으로 처리하도록 변경하고, 버튼도 `MDSActionButton`/`MDSTextButton`으로 교체했습니다.

### 회원가입 플로우 MDS 마이그레이션
- `SignUpVC`, `SignUpOAuthView`를 MDS 토큰 기반으로 마이그레이션했습니다.
- `StepIndicatorView`를 리팩토링했습니다. 기존에는 원형 배경이 배경과 텍스트를 함께 담당해 호출하는 쪽에서 내부 서브뷰에 직접 레이아웃 제약을 걸었는데, 배경과 숫자 라벨을 분리하고 위치 제약을 뷰 내부에서만 관리하도록 하여 호출부는 컨테이너 위치만 잡도록 했습니다.

### 휴대폰 인증/소셜 계정 연동 화면 MDS 마이그레이션
- `PhoneVerifyView`, `ChangeSocialAccountVC`, `ChangeSocialOAuthView`, `SearchSocialVC`를 MDS 컴포넌트/토큰 기반으로 마이그레이션했습니다.
- 관련 문구(`StringLiterals`)를 최신 디자인 스펙에 맞게 정리했습니다. 전화번호 placeholder를 `010XXXXXXXX`로 변경하고, 문의하기 버튼 문구를 추가했으며, 소셜 계정 연동 화면(`SocialLink`) 문구를 새로 추가했습니다.

### Demo 타겟 컴파일 에러 수정
- `AuthCoordinator` 생성자가 `LegacyRouter` 대신 `navigationController`를 직접 받도록 바뀌었는데 Demo 타겟이 반영되지 않아 빌드가 깨져 있던 것을 수정했습니다.
- `StubSignInRepository`도 `SignInRepositoryInterface` 변경사항(`SignInModel` 반환)에 맞춰 갱신하고, 새로 추가된 `CoreOAuth`/`CoreAuth`/`PhoneVerify`/`AuthTokens` Repository들에 대한 스텁을 등록해 Demo 앱이 다시 빌드·구동되도록 했습니다.

## 📌 참고 사항

### MDS 미적용 부분
- MDS에 대응되는 컴포넌트가 없는 부분은 기존 구조를 유지했습니다.
- 카운트다운 타이머 텍스트필드, bottom sheet 컨테이너는 기존 구조를 유지하되 색상·폰트·radius만 토큰 적용했습니다.

### ⚠️ 추후 확인/논의 필요
- [x] **전송/재전송 버튼 사이즈**: Figma상 `ActionButton(size: small, variant: primary)`인데, `MDSActionButton.Size.small`은 height가 38로 고정돼 있어 실제 높이와 맞지 않습니다. 지금은 우선 `MDSActionButton(size: .small)`로 그대로 사용해둔 상태입니다.
- [x] **문의하기 콜아웃 탭 영역**: `MDSCallout`이 내부 버튼에 외부 탭 클로저를 제공하지 않아 지금은 배너 전체가 탭 영역입니다. TextButton 부분만 터치영역이라면 수정이 필요합니다. (MDS 수정 후 추가 작업 필요)
- [x] **로그인 안내 bottom sheet 옵션 3개**: Figma 디자인에는 "로그인 방법 안내"/"계정 변경" 2개만 있고 "카카오톡 채널 문의"는 빠져있는데, 기존 기능 유지를 위해 3개 모두 남겨두고 스타일만 마이그레이션했습니다. 이 부분도 문의 남겼습니다.
- [x] 업데이트 뷰, 계정 재설정, 계정찾기 플로우는 figma 미반영으로 추가 작업 필요
- [x] textfield 이벤트를 외부에서 설정 가능하도록 MDS 수정 필요
- [x] 버튼 이미지 tintColor 선택할 수 있도록 MDS 수정 필요

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #956
