### PR TITLE
[Fix] #958 - Prod 빌드 시 FontLoader 참조 에러 수정

### DIFF
--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/AppDelegate.swift
@@ -9,7 +9,6 @@ import UIKit
 
 import BaseFeatureDependency
 import Core
-import MDS
 import Networks
 
 @main
@@ -23,7 +22,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         //
         registerDependencies()
         configureAppLifecycleAdapter()
-        FontLoader.registerIfNeeded()
         Firebase.configure()
         Firebase.configureCrashlytics()
         application.registerForRemoteNotifications()


### PR DESCRIPTION
## 🌴 PR 요약
- FontLoader 코드를 제거했습니다.

🌱 작업한 브랜치
- fix/#958

## 🌱 PR Point
### FontLoader 호출 이유
- 처음 `FontLoader.registerIfNeeded()`를 호출하려 했던 이유는 SUIT 폰트를 앱 실행 시점에 등록해주기 위해서였습니다.
- 이후 MDS 폰트 등록 방식을 프로덕트가 직접 등록하는 방식이 아니라 라이브러리가 `Typography` 프로퍼티에 처음 접근되는 시점에 자동으로 등록하는 방식으로 변경했습니다.(`ac255d9 (#149)`)
- SOPT-iOS에는 이전 방식의 호출부를 도입하여 빌드 시 에러가 발생하고 있었습니다.
- 앱 전역에서 SUIT 폰트는 항상 `Typography`를 거쳐서만 쓰이고 있어 직접 `UIFont(name: "SUIT...")`와 같이 명시적으로 쓰지 않는 한 문제는 발생하지 않습니다.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
생략

## 📸 스크린샷
생략

## 📮 관련 이슈
- Resolved: #958