### PR TITLE
[Feat] #960 - 앱잼 기간 활성화 여부 서버 값 연동

### DIFF
--- a/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
+++ b/SOPT-iOS/Projects/Data/Sources/Repository/HomeRepository.swift
@@ -51,6 +51,12 @@ extension HomeRepository: HomeRepositoryInterface {
             .eraseToAnyPublisher()
     }
 
+    public func getIsAppjamMode() -> AnyPublisher<Bool, any Error> {
+        return homeService.getAppServiceAccessStatus()
+            .map { $0.isAppjamMode }
+            .eraseToAnyPublisher()
+    }
+
     public func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], any Error> {
         calendarService.getCalendarDetail()
             .map{ $0.map { $0.toDomain() } }

--- a/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/RepositoryInterface/HomeRepositoryInterface.swift
@@ -13,6 +13,7 @@ import Core
 public protocol HomeRepositoryInterface {
     func registerPushToken(with token: String) -> AnyPublisher<Bool, Error>
     func getAppServices() -> AnyPublisher<[HomeAppServicesModel], Error>
+    func getIsAppjamMode() -> AnyPublisher<Bool, Error>
     func getCalendarDetail() -> AnyPublisher<[HomeCalendarDetailModel], Error>
     func getReportUrl() -> AnyPublisher<SoptampReportUrlModel, Error>    
     func getFloatingButtonInfo() -> AnyPublisher<HomeFloatingButtonModel, Error>

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
@@ -105,6 +105,8 @@ extension DefaultMissionListUseCase: MissionListUseCase {
             .sink(receiveCompletion: { event in
                 if case Subscribers.Completion.failure = event {
                     self.errorOccurred.send()
+                    // 모드 조회 실패 시 일반 모드로 간주
+                    self.isAppjamModeFetched.send(false)
                 }
             }, receiveValue: { isAppjamMode in
                 self.isAppjamModeFetched.send(isAppjamMode)

--- a/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
+++ b/SOPT-iOS/Projects/Domain/Sources/UseCase/MissionListUseCase.swift
@@ -16,24 +16,29 @@ public protocol MissionListUseCase {
     func fetchIsActiveGenerationUser()
     func updateCurrentSoptampUserInfo()
     func fetchAppjamMissionList(teamNumber: String?, isCompleted: Bool?)
-    
+    func fetchIsAppjamMode()
+
     var missionListModelsFetched: PassthroughSubject<[MissionListModel], Error> { get set }
     var usersActiveGenerationInfo: PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error> { get set }
     var appjamMissionListModelFetched: PassthroughSubject<AppjamMissionListModel, Error> { get set }
+    var isAppjamModeFetched: PassthroughSubject<Bool, Error> { get set }
     var errorOccurred: PassthroughSubject<Void, Never> { get set }
 }
 
 public class DefaultMissionListUseCase {
-    
+
     private let repository: MissionListRepositoryInterface
+    private let homeRepository: HomeRepositoryInterface
     private var cancelBag = CancelBag()
     public var missionListModelsFetched = PassthroughSubject<[MissionListModel], Error>()
     public var usersActiveGenerationInfo = PassthroughSubject<UsersActiveGenerationStatusViewResponse, Error>()
     public var appjamMissionListModelFetched = PassthroughSubject<AppjamMissionListModel, Error>()
+    public var isAppjamModeFetched = PassthroughSubject<Bool, Error>()
     public var errorOccurred = PassthroughSubject<Void, Never>()
-    
-    public init(repository: MissionListRepositoryInterface) {
+
+    public init(repository: MissionListRepositoryInterface, homeRepository: HomeRepositoryInterface) {
         self.repository = repository
+        self.homeRepository = homeRepository
     }
 }
 
@@ -92,7 +97,19 @@ extension DefaultMissionListUseCase: MissionListUseCase {
                 self.appjamMissionListModelFetched.send(model)
             })
             .store(in: cancelBag)
-        
+
+    }
+
+    public func fetchIsAppjamMode() {
+        homeRepository.getIsAppjamMode()
+            .sink(receiveCompletion: { event in
+                if case Subscribers.Completion.failure = event {
+                    self.errorOccurred.send()
+                }
+            }, receiveValue: { isAppjamMode in
+                self.isAppjamModeFetched.send(isAppjamMode)
+            })
+            .store(in: cancelBag)
     }
 }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/LegacyStampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/LegacyStampBuilder.swift
@@ -16,13 +16,14 @@ final class LegacyStampBuilder {
     @Injected public var missionListRepository: MissionListRepositoryInterface
     @Injected public var rankingRepository: RankingRepositoryInterface
     @Injected public var listDetailRepository: ListDetailRepositoryInterface
-    
+    @Injected public var homeRepository: HomeRepositoryInterface
+
     public init() { }
 }
 
 extension LegacyStampBuilder: LegacyStampFeatureViewBuildable {
     public func makeMissionListVC(sceneType: MissionListSceneType, coordinator: Coordinator) -> LegacyMissionListViewControllable {
-        let useCase = DefaultMissionListUseCase(repository: missionListRepository)
+        let useCase = DefaultMissionListUseCase(repository: missionListRepository, homeRepository: homeRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType, coordinator: coordinator)
         let missionListVC = MissionListVC(viewModel: viewModel, isRouteFromTabBar: false)
         missionListVC.viewModel = viewModel

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/Coordinator/StampBuilder.swift
@@ -19,13 +19,14 @@ final class StampBuilder {
     @Injected public var rankingRepository: RankingRepositoryInterface
     @Injected public var listDetailRepository: ListDetailRepositoryInterface
     @Injected public var appjamRankingRepository: AppjamRankingRepositoryInterface
+    @Injected public var homeRepository: HomeRepositoryInterface
 
     public init() { }
 }
 
 extension StampBuilder: StampFeatureBuildable {
     public func makeMissionListVC(sceneType: MissionListSceneType, isRouteFromTabBar: Bool, coordinator: Coordinator) -> MissionListPresentable {
-        let useCase = DefaultMissionListUseCase(repository: missionListRepository)
+        let useCase = DefaultMissionListUseCase(repository: missionListRepository, homeRepository: homeRepository)
         let viewModel = MissionListViewModel(useCase: useCase, sceneType: sceneType, coordinator: coordinator)
         let missionListVC = MissionListVC(viewModel: viewModel, isRouteFromTabBar: isRouteFromTabBar)
    

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -384,7 +384,14 @@ extension MissionListVC {
             .sink { owner, _ in
                 owner.showNetworkAlert()
             }.store(in: self.cancelBag)
-        
+
+        output.$isLoading
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, isLoading in
+                isLoading ? owner.showLoading() : owner.stopLoading()
+            }.store(in: self.cancelBag)
+
         output.$appjamInfo
             .compactMap { $0 }
             .receive(on: DispatchQueue.main)
@@ -413,10 +420,6 @@ extension MissionListVC {
             .setTitleButtonMenu(menuItems: makeMenuItems())
 
         setFloatingButton(isAppJam: isAppJam)
-
-        if isAppJam {
-            missionTypeMenuSelected.send(.appjam)
-        }
     }
 
     private func updateAppjamUI(with appjamInfo: AppjamMissionListModel) {

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/VC/MissionListVC.swift
@@ -22,9 +22,8 @@ import BaseFeatureDependency
 
 public class MissionListVC: UIViewController, MissionListViewControllable, LegacyMissionListViewControllable {
     
-    // TODO: - 화면 전환 시에 수정
-    private var isAppJam: Bool = true
-    
+    private var isAppJam: Bool = false
+
     // MARK: - Properties
     
     public var viewModel: MissionListViewModel
@@ -52,15 +51,16 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
     public var onAppJamRankingButtonTap: (() -> Void)?
     
     private var usersActiveGenerationStatus: UsersActiveGenerationStatusViewResponse?
-    
+    private var appjamInfo: AppjamMissionListModel?
+
     // MARK: - UI Components
-    
+
     lazy var naviBar: STNavigationBar = {
         switch sceneType {
         case .default:
             return STNavigationBar(type: .title)
                 .setTitle(isAppJam ? I18N.MissionList.appjamMission : I18N.MissionList.allMission)
-                .setTitleButtonMenu(menuItems: self.menuItems)
+                .setTitleButtonMenu(menuItems: self.makeMenuItems())
                 .addLeftButtonToTitleMenu()
         case .ranking(let username, _):
             return STNavigationBar(type: .titleWithLeftButton)
@@ -73,14 +73,14 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         }
     }()
     
-    private lazy var menuItems: [UIAction] = {
+    private func makeMenuItems() -> [UIAction] {
         var menuItems: [UIAction] = []
         var menus: [(String, MissionListFetchType)] = []
-        
+
         menus = [
             (I18N.MissionList.allMission, MissionListFetchType.all),
             (I18N.MissionList.completeMission, MissionListFetchType.complete),
-             (I18N.MissionList.uncompleteMission, MissionListFetchType.incomplete)
+            (I18N.MissionList.uncompleteMission, MissionListFetchType.incomplete)
         ]
         if isAppJam {
             menus.append((I18N.MissionList.appjamMission, MissionListFetchType.appjam))
@@ -95,7 +95,7 @@ public class MissionListVC: UIViewController, MissionListViewControllable, Legac
         }
     
         return menuItems
-    }()
+    }
 
     private let sentenceContainerView = UIView().then {
         $0.layer.cornerRadius = 9
@@ -206,8 +206,6 @@ extension MissionListVC {
         self.navigationController?.isNavigationBarHidden = true
         self.view.backgroundColor = SemanticColor.Bg.Layer.basement
 
-        if isAppJam { missionTypeMenuSelected.send(.appjam) }
-
         switch sceneType {
         case .default:
             self.sentenceContainerView.backgroundColor = SemanticColor.Bg.Neutral.ghost
@@ -238,22 +236,8 @@ extension MissionListVC {
         
         switch sceneType {
         case .default:
-            if isAppJam {
-                self.view.addSubview(self.singleFloatingButton)
-                
-                self.singleFloatingButton.snp.makeConstraints { make in
-                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
-                    make.centerX.equalToSuperview()
-                }
-            } else {
-                self.view.addSubview(self.doubleFloatingButton)
-                
-                self.doubleFloatingButton.snp.makeConstraints { make in
-                    make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
-                    make.centerX.equalToSuperview()
-                }
-            }
-            
+            setFloatingButton(isAppJam: isAppJam)
+
         case .ranking:
             self.view.addSubview(sentenceContainerView)
             sentenceContainerView.addSubview(sentenceLabel)
@@ -294,6 +278,27 @@ extension MissionListVC {
                 make.top.equalTo(sentenceContainerView.snp.bottom).offset(16)
                 make.leading.trailing.equalToSuperview()
                 make.bottom.equalToSuperview()
+            }
+        }
+    }
+
+    private func setFloatingButton(isAppJam: Bool) {
+        doubleFloatingButton.removeFromSuperview()
+        singleFloatingButton.removeFromSuperview()
+
+        if isAppJam {
+            self.view.addSubview(self.singleFloatingButton)
+
+            self.singleFloatingButton.snp.makeConstraints { make in
+                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
+                make.centerX.equalToSuperview()
+            }
+        } else {
+            self.view.addSubview(self.doubleFloatingButton)
+
+            self.doubleFloatingButton.snp.makeConstraints { make in
+                make.bottom.equalTo(view.safeAreaLayoutGuide).offset(-18)
+                make.centerX.equalToSuperview()
             }
         }
     }
@@ -385,11 +390,35 @@ extension MissionListVC {
             .receive(on: DispatchQueue.main)
             .withUnretained(self)
             .sink { owner, appjamInfo in
+                owner.appjamInfo = appjamInfo
                 guard case .default = owner.sceneType else { return }
                 owner.updateAppjamUI(with: appjamInfo)
             }.store(in: self.cancelBag)
+
+        output.$isAppjamMode
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .withUnretained(self)
+            .sink { owner, isAppjamMode in
+                owner.updateAppJamMode(isAppjamMode)
+            }.store(in: self.cancelBag)
     }
-    
+
+    private func updateAppJamMode(_ isAppJam: Bool) {
+        guard case .default = sceneType, self.isAppJam != isAppJam else { return }
+        self.isAppJam = isAppJam
+
+        naviBar
+            .setTitle(isAppJam ? I18N.MissionList.appjamMission : I18N.MissionList.allMission)
+            .setTitleButtonMenu(menuItems: makeMenuItems())
+
+        setFloatingButton(isAppJam: isAppJam)
+
+        if isAppJam {
+            missionTypeMenuSelected.send(.appjam)
+        }
+    }
+
     private func updateAppjamUI(with appjamInfo: AppjamMissionListModel) {
         // 앱잼 참여자인 경우에만 팀명과 문구 표시
         guard appjamInfo.myTeamNumber != nil, let teamName = appjamInfo.teamName else { return }
@@ -573,9 +602,12 @@ extension MissionListVC: UICollectionViewDelegate {
             
             switch userType {
             case .active:
-                onCellTap?(model, username)
+                if case .default = self.sceneType, isAppJam, appjamInfo?.myTeamNumber == nil {
+                    showInactiveUserAlert()
+                } else {
+                    onCellTap?(model, username)
+                }
             case .inactive, .visitor:
-                //TODO: - 앱잼안하는 활동유저의 경우대한 분기도 추가
                 showInactiveUserAlert()
             }
 

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -33,6 +33,7 @@ public class MissionListViewModel: MissionListViewModelType {
     private let coordinator: AnyCoordinatorObject
     private var cancelBag = CancelBag()
     public var missionListsceneType: MissionListSceneType!
+    private var isAppjamMode: Bool = false
     
     // MARK: - Inputs
     
@@ -49,6 +50,7 @@ public class MissionListViewModel: MissionListViewModelType {
         @Published var usersActivateGenerationStatus: UsersActiveGenerationStatusViewResponse?
         @Published var reportUrl: SoptampReportUrlModel?
         @Published var appjamInfo: AppjamMissionListModel?
+        @Published var isAppjamMode: Bool?
         var needNetworkAlert = PassthroughSubject<Void, Never>()
     }
     
@@ -73,6 +75,9 @@ extension MissionListViewModel {
             .withUnretained(self)
             .sink { owner, _ in
                 owner.useCase.updateCurrentSoptampUserInfo()
+                if case .default = owner.missionListsceneType {
+                    owner.useCase.fetchIsAppjamMode()
+                }
             }.store(in: cancelBag)
         
         input.viewWillAppear
@@ -104,13 +109,16 @@ extension MissionListViewModel {
     }
     
     private func fetchMissionListByType(type: MissionListFetchType) {
-//        switch type {
-//        case .appjam:
-//            self.useCase.fetchAppjamMissionList(teamNumber: nil, isCompleted: nil)
-//        default:
-//            self.useCase.fetchMissionList(type: type)
-//        }
-        // TODO: - 앱잼 기간에는 앱잼 미션만 노출 필요 추후 상단 주석 활성화
+        guard isAppjamMode else {
+            switch type {
+            case .appjam:
+                self.useCase.fetchAppjamMissionList(teamNumber: nil, isCompleted: nil)
+            default:
+                self.useCase.fetchMissionList(type: type)
+            }
+            return
+        }
+
         switch type {
         case .all:
             self.useCase.fetchAppjamMissionList(teamNumber: nil, isCompleted: nil)
@@ -157,6 +165,14 @@ extension MissionListViewModel {
             .asDriver()
             .sink { _ in
                 output.needNetworkAlert.send()
+            }.store(in: cancelBag)
+
+        self.useCase.isAppjamModeFetched
+            .asDriver()
+            .withUnretained(self)
+            .sink { owner, isAppjamMode in
+                owner.isAppjamMode = isAppjamMode
+                output.isAppjamMode = isAppjamMode
             }.store(in: cancelBag)
     }
 }

--- a/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
+++ b/SOPT-iOS/Projects/Features/StampFeature/Sources/MissionListScene/ViewModel/MissionListViewModel.swift
@@ -33,7 +33,8 @@ public class MissionListViewModel: MissionListViewModelType {
     private let coordinator: AnyCoordinatorObject
     private var cancelBag = CancelBag()
     public var missionListsceneType: MissionListSceneType!
-    private var isAppjamMode: Bool = false
+    private var isAppjamMode: Bool?
+    private var missionTypeSelected: CurrentValueSubject<MissionListFetchType, Never>!
     
     // MARK: - Inputs
     
@@ -52,6 +53,7 @@ public class MissionListViewModel: MissionListViewModelType {
         @Published var appjamInfo: AppjamMissionListModel?
         @Published var isAppjamMode: Bool?
         var needNetworkAlert = PassthroughSubject<Void, Never>()
+        @Published var isLoading: Bool = false
     }
     
     // MARK: - init
@@ -68,6 +70,8 @@ public class MissionListViewModel: MissionListViewModelType {
 
 extension MissionListViewModel {
     public func transform(from input: Input, cancelBag: CancelBag) -> Output {
+        self.missionTypeSelected = input.missionTypeSelected
+
         let output = Output()
         self.bindOutput(output: output, cancelBag: cancelBag)
         
@@ -76,6 +80,7 @@ extension MissionListViewModel {
             .sink { owner, _ in
                 owner.useCase.updateCurrentSoptampUserInfo()
                 if case .default = owner.missionListsceneType {
+                    output.isLoading = true
                     owner.useCase.fetchIsAppjamMode()
                 }
             }.store(in: cancelBag)
@@ -109,6 +114,10 @@ extension MissionListViewModel {
     }
     
     private func fetchMissionListByType(type: MissionListFetchType) {
+        // 앱잼 모드 확인 전에는 일반/앱잼 여부를 판단할 수 없으므로 조회하지 않음.
+        // 모드 응답 도착 시 bindOutput에서 다시 호출됨.
+        guard let isAppjamMode else { return }
+
         guard isAppjamMode else {
             switch type {
             case .appjam:
@@ -173,6 +182,10 @@ extension MissionListViewModel {
             .sink { owner, isAppjamMode in
                 owner.isAppjamMode = isAppjamMode
                 output.isAppjamMode = isAppjamMode
+
+                guard case .default = owner.missionListsceneType else { return }
+                owner.fetchMissionListByType(type: owner.missionTypeSelected.value)
+                output.isLoading = false
             }.store(in: cancelBag)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약
서버가 내려주는 앱잼 기간 활성화 여부(`isAppjamMode`) 값을 미션 리스트 화면에 연동합니다. 기존에는 `MissionListVC`의 `isAppJam`이 하드코딩되어 있었는데, 이를 서버 값 기준으로 동적으로 반영하도록 변경했습니다.

🌱 작업한 브랜치
- feat/#960-appjam-status-sync

## 🌱 PR Point
### 앱잼여부 서버 응답값 사용
- `HomeRepositoryInterface`/`HomeRepository`에 `getIsAppjamMode()` 추가 (서버가 이미 내려주고 있었지만 Data→Domain 매핑 중 버려지고 있던 값 노출)
- `MissionListUseCase`에 `fetchIsAppjamMode`/`isAppjamModeFetched` 추가, `StampBuilder`/`LegacyStampBuilder`에서 `homeRepository` 주입
- `MissionListVC.isAppJam` 하드코딩(`= true`) 제거 → 서버 값 도착 시 naviBar 타이틀/메뉴/플로팅버튼을 반영하도록 리팩터링 (초기 레이아웃은 `false` 기준으로 구성 후 reactive하게 갱신)
- `MissionListViewModel.fetchMissionListByType`의 주석 처리돼있던 비앱잼 기간 분기 활성화
- 활동기수가 앱잼 미참여 상태로 미완료 미션을 열람할 때만 안내 얼럿이 뜨도록 분기 추가

### 로딩 인디케이터 추가
- 첫 진입 시 `isAppjamMode` 서버 응답 전에 일반 미션 목록을 먼저 조회하던 버그 수정
- 모드가 확인되기 전에는 조회하지 않도록 `MissionListViewModel.isAppjamMode`를 `Bool?`로 바꾸고, 모드 응답 도착 시점에 한 번만 올바른 타입으로 조회하도록 변경.
- 모드 조회 실패 시에는 일반 모드로 명시 폴백
- 모드가 확인되기 전까지는 로딩 인디케이터를 노출해 타이틀/메뉴/플로팅버튼이 확정되지 않은 상태로 잠깐 보였다가 바뀌는 깜빡임 제거

## 📌 참고 사항
- develop이 그 사이 MDS 디자인 토큰 마이그레이션(#953)으로 크게 변경되어 rebase를 진행했습니다. `MissionListVC.swift`에서 발생한 conflict는 마이그레이션 결과(SemanticColor 토큰, `sentenceContainerView` 구조 등)는 그대로 유지하고 이번 브랜치의 앱잼 연동 로직만 재적용하는 방식으로 해결했습니다.
- rebase 후, 그리고 레이스 컨디션 수정 후 각각 `StampFeature` 스킴 빌드 성공을 확인했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|앱잼 기간 미션 리스트|스크린샷 첨부|

## 📮 관련 이슈
- Resolved: #960

