### PR TITLE
[Chore] #977 - MakeFile 수정

### DIFF
--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -39,6 +39,7 @@ XCCONFIG_PATHS = \
     xcconfigs/Base/Targets Extension.xcconfig \
     xcconfigs/Base/Targets Framework.xcconfig \
     xcconfigs/Base/Targets StaticLibrary.xcconfig \
+    xcconfigs/targets iOS-Base.xcconfig \
     xcconfigs/targets iOS-Demo.xcconfig \
     xcconfigs/targets iOS-Framework.xcconfig \
     xcconfigs/targets iOS-StaticFramework.xcconfig \


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- chore/#977 

## 🌱 PR Point
- Prviate 저장소에서 iOS Base config를 받아오는데, makefile에는 iOS Base config가 없어서 처음 빌드 때 에러가 납니다. 
- Private 저장소에서 config파일을 지우는 것보다는 makefile에 추가하는 것이 낫다고 판단하여 해당 라인을 추가하였습니다. 

## 📮 관련 이슈
- Resolved: #977 
