### PR TITLE
[Chore] #977 - MakeFile 수정 및 Build Test CI 세팅

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: macos-15
     timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: SOPT-iOS
     env:
       SCHEME: SOPT-iOS-DEV
     steps:
@@ -35,7 +38,7 @@ jobs:
           path: |
             Tuist/.build
             ~/Library/Caches/tuist
-          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Package.resolved') }}
+          key: ${{ runner.os }}-tuist-${{ hashFiles('SOPT-iOS/Tuist/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-tuist-
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,6 +62,6 @@ jobs:
           xcodebuild build \
             -workspace SOPT-iOS.xcworkspace \
             -scheme "$SCHEME" \
-            -destination "genric/platform=iOS Simulator" \
+            -destination "generic/platform=iOS Simulator" \
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           install: true
           cache: true
+          working_directory: SOPT-iOS
 
       - name: Cache Tuist / SPM artifacts
         uses: actions/cache@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,6 +62,6 @@ jobs:
           xcodebuild build \
             -workspace SOPT-iOS.xcworkspace \
             -scheme "$SCHEME" \
-            -destination "platform=iOS Simulator" \
+            -destination "genric/platform=iOS Simulator" \
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO

--- a/SOPT-iOS/Makefile
+++ b/SOPT-iOS/Makefile
@@ -39,6 +39,7 @@ XCCONFIG_PATHS = \
     xcconfigs/Base/Targets Extension.xcconfig \
     xcconfigs/Base/Targets Framework.xcconfig \
     xcconfigs/Base/Targets StaticLibrary.xcconfig \
+    xcconfigs/targets iOS-Base.xcconfig \
     xcconfigs/targets iOS-Demo.xcconfig \
     xcconfigs/targets iOS-Framework.xcconfig \
     xcconfigs/targets iOS-StaticFramework.xcconfig \


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- chore/#977 

## 🌱 PR Point

#### MakeFile 수정
- Prviate 저장소에서 iOS Base config를 받아오는데, makefile에는 iOS Base config가 없어서 처음 빌드 때 에러가 납니다. 
- Private 저장소에서 config파일을 지우는 것보다는 makefile에 추가하는 것이 낫다고 판단하여 해당 라인을 추가하였습니다. 

#### Build Test yml 추가 
- 단순히 코드를 컴파일하여 빌드에 에러가 없는지 확인하는 workflow를 추가하였습니다. 
- 시뮬레이터를 부팅하여 테스트까지 하지 않는 이유는 CI 돌아가는 시간을 줄이기 위해 우선 빌드테스트만 걸었는데 후에 필요하다고 생각되면 적용할 생각입니다. 
- 기존에 있던 1명 approve ruleset을 제거..하고 ... 빌드를 통과해야 머지할 수 있도록 ruleset을 추가했습니다. 

## 📮 관련 이슈
- Resolved: #977 
