### PR TITLE
[Feat] #976 - univeral link

### DIFF
--- a/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
+++ b/SOPT-iOS/Projects/Demo/SOPT-iOS-Demo.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:sopt-internal-dev.sopt.org</string>
+	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate+HandleURL.swift
@@ -63,4 +63,24 @@ extension SceneDelegate {
     func redirectSignInVC(url: String) {
         appCoordinator.start(with: .signInSuccess(url: url))
     }
+
+    /// 유니버설 링크로 진입한 UserActivity를 처리합니다.
+    /// 그 외 UserActivity(상태 복원 등)면 콜드 스타트일 때만 평소대로 앱을 시작합니다.
+    func handleUniversalLinkWithUserActivity(_ userActivity: NSUserActivity, isInitialLaunch: Bool = false) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            if isInitialLaunch {
+                appCoordinator.start()
+            }
+            return
+        }
+
+        let url = incomingURL.absoluteString
+        if isInitialLaunch {
+            appCoordinator.start(with: .universalWebLink(url: url))
+        } else {
+            // 이미 실행 중이면 코디네이터를 다시 시작하지 않고 링크만 흘려보냅니다.
+            notificationHandler.receive(webLink: url)
+        }
+    }
 }

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -38,7 +38,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        if let userActivity = connectionOptions.userActivities.first {
+        if let userActivity = connectionOptions.userActivities.first(where: {
+            $0.activityType == NSUserActivityTypeBrowsingWeb && $0.webpageURL != nil
+        }) {
             handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: true)
         } else {
             self.appCoordinator.start()

--- a/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/Demo/Sources/Application/SceneDelegate.swift
@@ -38,11 +38,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        self.appCoordinator.start()
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: true)
+        } else {
+            self.appCoordinator.start()
+        }
     }
-    
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         parseContexts(openURLContexts: URLContexts)
+    }
+
+    func scene(
+        _ scene: UIScene,
+        continue userActivity: NSUserActivity
+    ) {
+        handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: false)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
@@ -12,11 +12,4 @@ import Foundation
 public enum DeepLinkOption {
     case signInSuccess(url: String)
     case universalWebLink(url: String)
-    
-    public var url: String {
-        switch self {
-        case .signInSuccess(let url), .universalWebLink(let url):
-            return url
-        }
-    }
 }

--- a/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
+++ b/SOPT-iOS/Projects/Features/BaseFeatureDependency/Sources/Coordinator/Options/DeepLinkOptions.swift
@@ -11,10 +11,11 @@ import Foundation
 /// Coordinator에서 DeepLinkOption의 종류를 지정하는 enum입니다.
 public enum DeepLinkOption {
     case signInSuccess(url: String)
+    case universalWebLink(url: String)
     
     public var url: String {
         switch self {
-        case .signInSuccess(let url):
+        case .signInSuccess(let url), .universalWebLink(let url):
             return url
         }
     }

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -60,6 +60,11 @@ public final class ApplicationCoordinator: BaseCoordinator {
     // MARK: - Coordinator Life Cycle
     
     public override func start(with option: DeepLinkOption?) {
+        // AuthCoordinator의 url은 로그인 콜백 전용 - 유니버설 링크 X
+        let signInCallbackURL: String? = {
+            guard case .signInSuccess(let url) = option else { return nil }
+            return url
+        }()
         
         DIContainer.shared.register(
             interface: DefaultAuthCoordinator.self,
@@ -67,11 +72,11 @@ public final class ApplicationCoordinator: BaseCoordinator {
                 guard let self else { return }
                 switch FeatureFlag.auth {
                 case .legacy:
-                    return LegacyAuthCoordinator(router: self.router, factory: LegacyAuthBuilder(), url: option?.url)
+                    return LegacyAuthCoordinator(router: self.router, factory: LegacyAuthBuilder(), url: signInCallbackURL)
                 case .new:
                     return AuthCoordinator(navigationController: self.rootNavigationController,
                                            factory: AuthBuilder(),
-                                           url: option?.url)
+                                           url: signInCallbackURL)
                 }
             }
         )

--- a/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
+++ b/SOPT-iOS/Projects/Features/RootFeature/Sources/ApplicationCoordinator.swift
@@ -83,6 +83,11 @@ public final class ApplicationCoordinator: BaseCoordinator {
                     by: .rootWindow(animated: false, message: nil),
                     with: url
                 )
+            case .universalWebLink(let url):
+                // 링크는 webLink(CurrentValueSubject)에 담아두고 평소대로 부팅합니다.
+                // 탭바가 뜬 뒤 bindNotification()이 구독하는 시점에 현재값이 재생되어 웹뷰가 열립니다.
+                notificationHandler.receive(webLink: url)
+                runSplashFlow()
             }
         } else {
             runSplashFlow()

--- a/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
+++ b/SOPT-iOS/Projects/SOPT-iOS/SOPT-iOS.entitlements
@@ -8,5 +8,9 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:playground.sopt.org</string>
+	</array>
 </dict>
 </plist>

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate+HandleURL.swift
@@ -63,4 +63,24 @@ extension SceneDelegate {
     func redirectSignInVC(url: String) {
         appCoordinator.start(with: .signInSuccess(url: url))
     }
+    
+    /// 유니버설 링크로 진입한 UserActivity를 처리합니다.
+    /// 그 외 UserActivity(상태 복원 등)면 콜드 스타트일 때만 평소대로 앱을 시작합니다.
+    func handleUniversalLinkWithUserActivity(_ userActivity: NSUserActivity, isInitialLaunch: Bool = false) {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL else {
+            if isInitialLaunch {
+                appCoordinator.start()
+            }
+            return
+        }
+
+        let url = incomingURL.absoluteString
+        if isInitialLaunch {
+            appCoordinator.start(with: .universalWebLink(url: url))
+        } else {
+            // 이미 실행 중이면 코디네이터를 다시 시작하지 않고 링크만 흘려보냅니다.
+            notificationHandler.receive(webLink: url)
+        }
+    }
 }

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -37,11 +37,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        self.appCoordinator.start()
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: true)
+        } else {
+            self.appCoordinator.start()
+        }
     }
-    
+
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         parseContexts(openURLContexts: URLContexts)
+    }
+
+    func scene(
+        _ scene: UIScene,
+        continue userActivity: NSUserActivity
+    ) {
+        handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: false)
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
+++ b/SOPT-iOS/Projects/SOPT-iOS/Sources/Application/SceneDelegate.swift
@@ -37,7 +37,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = rootController
         window?.makeKeyAndVisible()
         
-        if let userActivity = connectionOptions.userActivities.first {
+        if let userActivity = connectionOptions.userActivities.first(where: {
+            $0.activityType == NSUserActivityTypeBrowsingWeb && $0.webpageURL != nil
+        }) {
             handleUniversalLinkWithUserActivity(userActivity, isInitialLaunch: true)
         } else {
             self.appCoordinator.start()


### PR DESCRIPTION
## 🌴 PR 요약

유니버설 링크로 앱에 진입하는 경로를 추가했습니다. `playground.sopt.org` / `sopt-internal-dev.sopt.org` 링크를 누르면 사파리가 아니라 앱이 열리고, 해당 URL이 웹뷰로 뜹니다.

## 🌿 유니버설 링크란

  일반 웹 URL(`https://playground.sopt.org/...`)을 눌렀을 때, 사파리 대신 앱이 열리게 하는 Apple의 기능입니다.

  기존에 앱이 쓰던 커스텀 URL 스킴(`sopt-stamp-ios://...`)과 비교하면 이렇습니다.

  | | 커스텀 URL 스킴 | 유니버설 링크 |
  |:--|:--|:--|
  | 주소 형태 | `sopt-stamp-ios://...` | `https://playground.sopt.org/...` |
  | 앱이 없으면 | 아무 일도 안 일어남 | 그냥 웹으로 열림 |
  | 확인 팝업 | "앱에서 열까요?" 뜸 | 없음, 바로 열림 |
  | 도메인 소유 검증 | 없음 (다른 앱이 같은 스킴 선점 가능) | 서버-앱 양쪽 검증 |

  즉 **슬랙이나 카톡에 공유된 평범한 링크 하나가, 앱 설치자에게는 앱으로 / 미설치자에게는 웹으로** 열립니다. 그래서 푸시 알림뿐 아니라 외부 공유 링크로도 앱 안의 특정 화면에 도달할 수 있게 됩니다.

  **동작 순서**

  ```
  1. 사용자가 https://playground.sopt.org/... 링크를 누름
  2. iOS가 앱의 엔타이틀먼트에서 applinks:playground.sopt.org 를 확인   ← 이번 PR (1)
  3. iOS가 그 도메인의 AASA 파일을 받아서 appID가 맞는지 확인          ← 서버 작업 필요
  4. 맞으면 앱을 열고 NSUserActivity 로 URL을 전달                     ← 이번 PR (3), (4)
  ```

  4번에서 앱이 URL을 받는 통로는 실행 상태에 따라 두 가지로 나뉩니다. 이번 PR에서 둘 다 처리했습니다.

  | 상태 | 진입점 |
  |:--|:--|
  | 앱이 꺼져 있음 (콜드 스타트) | `scene(_:willConnectTo:options:)`의 `connectionOptions.userActivities` |
  | 앱이 떠 있음 (웜 스타트) | `scene(_:continue:)` |

  전달되는 `NSUserActivity`는 `activityType`이 `NSUserActivityTypeBrowsingWeb`이고 `webpageURL`에 원본 URL이 담겨 있습니다. 상태 복원 등 다른 UserActivity도 같은 자리로 들어오기 때문에 타입 확인이 필요합니다.

🌱 작업한 브랜치
- feature/#976

## 🌱 PR Point
**1. 콜드 스타트에서도 스플래시를 태웁니다**

링크를 바로 열지 않고 `webLink`에 담아둔 뒤 평소대로 `runSplashFlow()`를 태웁니다.

```swift
case .universalWebLink(let url):
    notificationHandler.receive(webLink: url)
    runSplashFlow()
```

`bindNotification()`이 `runTabBarFlow`의 `defer`에서만 호출되기 때문에, 스플래시를 건너뛰면 탭바도 구독도 없어서 링크가 그대로 사라집니다. `webLink`가 `CurrentValueSubject`라 값을 먼저 넣어두면 탭바가 뜬 뒤 구독 시점에 현재값이 재생되어 웹뷰가 열립니다.

**2. 웜 스타트에서는 코디네이터를 다시 시작하지 않습니다**

```swift
if isInitialLaunch {
    appCoordinator.start(with: .universalWebLink(url: url))
} else {
    notificationHandler.receive(webLink: url)
}
```

앱이 이미 떠 있는데 `start(with:)`를 다시 타면 DI가 재등록되고 스플래시가 다시 돕니다. 브라우징이 아닌 UserActivity(상태 복원 등)는 콜드 스타트일 때만 평소대로 앱을 시작하고 무시합니다.


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
플그팀 웹에서 AASA 파일 배포를 도와줘서 현재 잘 동작하고 있는 상황입니다 !! 

## 👩‍🍳 리뷰 반영 사항

 **`option?.url` 분기 (@yungu0010)**
`.signInSuccess` 일 때만 URL 을 넘기도록 분기했습니다.

  ```swift
  let signInCallbackURL: String? = {
      guard case .signInSuccess(let url) = option else { return nil }
      return url
  }()
```

  이 수정으로 DeepLinkOption.url 을 쓰는 곳이 하나도 없어져서 프로퍼티도 제거했습니다.

-> `AuthCoordinator`에는 로그인 콜백 URL만 전달합니다



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-09-07 at 00 53 36" src="https://github.com/user-attachments/assets/36dc5d81-9045-416f-ab93-43b479cae113" />|

## 📮 관련 이슈
- Resolved: #976 
